### PR TITLE
[codex] Add containerized extension build

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@ body:
       label: Steps to reproduce
       description: Include the page type, extension action, and whether captions or recording were involved.
       placeholder: |
-        1. Run npm run build
+        1. Run make build
         2. Load dist/ in chrome://extensions
         3. Open a Google Meet...
     validations:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -19,4 +19,4 @@ body:
     id: verification
     attributes:
       label: Verification
-      description: Expected checks, for example npm run check or manual extension smoke test.
+      description: Expected checks, for example make check or manual extension smoke test.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,11 +9,11 @@ Briefly describe what changes and why.
 
 ## Verification
 
-1. `npm run check`
+1. `make check`
 2. Manual Chrome extension smoke test, if browser behavior changed:
-   - load `dist/` in `chrome://extensions`
-   - test transcript download on Google Meet
-   - test recording start/stop when capture or offscreen code changed
+   a) load `dist/` in `chrome://extensions`
+   b) test transcript download on Google Meet
+   c) test recording start/stop when capture or offscreen code changed
 
 ## Chrome Extension Impact
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,5 +26,5 @@ Follow these rules when generating code, comments, or review feedback in this re
 
 ## Validation
 
-- Use `npm run check` for code/config changes.
+- Use `make check` for code/config changes.
 - Ask for or describe manual Chrome extension testing when browser behavior changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Gdy czlowiek napisze `+PR`, uruchom lokalna procedure pracy z Pull Requestem.
    b) Pokaz czlowiekowi zakres zmian przed commitem.
    c) Jesli sa zmiany, zrob logiczny commit albo kilka malych commitow.
    d) Wypchnij branch.
-   e) Utworz Pull Request do glownej galezi projektu.
+   e) Utworz Pull Request do glownej galezi projektu jako gotowy do review, nie jako draft.
 
 2. Review Copilota
    a) Popros o review Copilota, jesli repozytorium to obsluguje.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,10 @@ Gdy czlowiek napisze `+PR`, uruchom lokalna procedure pracy z Pull Requestem.
    b) Poczekaj na wynik review.
    c) Jesli Copilot zglosi uwagi, nie wdrazaj ich automatycznie.
    d) Zbierz uwagi Copilota i przedstaw je czlowiekowi do decyzji, najlepiej pojedynczo.
-   e) Kazda uwage omow z czlowiekiem przed zmiana w kodzie.
-   f) Dopiero po zatwierdzeniu konkretnej uwagi przez czlowieka wprowadz zmiane.
+   e) Przy omawianiu uwagi podaj wystarczajacy kontekst techniczny, zeby czlowiek mogl podjac decyzje bez znajomosci detali implementacji.
+   f) Wyjasnij, czego uwaga dotyczy, jaki jest praktyczny skutek, jakie sa sensowne opcje i jaka opcje rekomendujesz.
+   g) Kazda uwage omow z czlowiekiem przed zmiana w kodzie.
+   h) Dopiero po zatwierdzeniu konkretnej uwagi przez czlowieka wprowadz zmiane.
 
 3. Odpowiedzi do review
    a) Na kazda uwage Copilota odpowiedz w watku:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,6 @@ Ten plik definiuje zasady dla agentow AI i automatyzacji pracujacych w tym repoz
 ## Weryfikacja
 
 - Po zmianach w kodzie lub konfiguracji uruchom `make check`.
-- Lokalny `npm run check` traktuj jako wariant alternatywny dla srodowisk z lokalnym Node.js.
 - Dla zmian dotykajacych przeplywow przegladarkowych wykonaj tez smoke test z `docs/runbooks/002-smoke-test-po-zmianach.md`.
 - Jesli nie da sie uruchomic walidacji, podaj konkretny powod i zakres ryzyka.
 
@@ -90,7 +89,6 @@ Gdy czlowiek napisze `+PR`, uruchom lokalna procedure pracy z Pull Requestem.
 ## Chrome Extension
 
 - Po `make build` testuj przez zaladowanie katalogu `dist/` w `chrome://extensions`.
-- Lokalny `npm run build` jest wariantem alternatywnym, nie domyslnym.
 - Po zmianach w `manifest.json`, `background.ts`, `offscreen.ts` albo plikach HTML przeladuj rozszerzenie w `chrome://extensions`.
 - Po zmianach w `scrapingScript.ts` odswiez aktywna karte Google Meet.
 - Nie dodawaj zewnetrznych uslug ani przesylania nagran/transkrypcji poza przegladarke bez jednoznacznej decyzji czlowieka.

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ deps-clean:
 	$(COMPOSE) down --volumes --remove-orphans
 
 prepare-deps:
-	$(COMPOSE) run --rm --user root builder sh -lc 'mkdir -p /workspace/node_modules /workspace/dist /home/node/.npm && npm ci && chown "$$HOST_UID:$$HOST_GID" /workspace /workspace/dist && chown -R "$$HOST_UID:$$HOST_GID" /workspace/node_modules /home/node/.npm'
+	$(COMPOSE) run --rm --user root builder sh -lc 'mkdir -p /workspace/node_modules /workspace/dist /home/node/.npm && chown "$$HOST_UID:$$HOST_GID" /workspace /workspace/dist && npm ci; status=$$?; chown "$$HOST_UID:$$HOST_GID" /workspace /workspace/dist; chown -R "$$HOST_UID:$$HOST_GID" /workspace/node_modules /home/node/.npm; exit $$status'

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+COMPOSE ?= docker compose
+HOST_UID ?= $(shell id -u)
+HOST_GID ?= $(shell id -g)
+export HOST_UID
+export HOST_GID
+
+.PHONY: build check shell clean deps-clean prepare-deps
+
+build: prepare-deps
+	$(COMPOSE) run --rm builder ./node_modules/.bin/webpack --mode=production
+
+check: prepare-deps
+	$(COMPOSE) run --rm builder sh -lc './node_modules/.bin/tsc --noEmit && ./node_modules/.bin/webpack --mode=production'
+
+shell: prepare-deps
+	$(COMPOSE) run --rm builder sh
+
+clean:
+	rm -rf dist
+
+deps-clean:
+	$(COMPOSE) down --volumes --remove-orphans
+
+prepare-deps:
+	$(COMPOSE) run --rm --user root builder sh -lc 'mkdir -p /workspace/node_modules /workspace/dist /home/node/.npm && npm ci && chown "$$HOST_UID:$$HOST_GID" /workspace /workspace/dist && chown -R "$$HOST_UID:$$HOST_GID" /workspace/node_modules /home/node/.npm'

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ If you'd rather use a bot or desktop recording form factor, check out [Recall.ai
 
 **Docker** with **Docker Compose v2** and **make** to build the extension without installing Node.js locally.
 
-Node.js 18+ and npm can still be used as an alternative local workflow.
-
 The extension uses the following Chrome permissions:
 `activeTab`, `downloads`, `tabCapture`, `offscreen`, `storage`, `tabs`, `desktopCapture`
 and is scoped to `https://meet.google.com/*`.
@@ -108,19 +106,7 @@ This runs `npm ci` and a production webpack build inside the `node:20-bookworm-s
   - Turn on `Developer mode`
   - Click `Load unpacked` → select the `dist` directory that was created inside your repo when you ran `make build`
 
-**Alternative: local Node.js/npm**
-
-If you intentionally want to build without Docker, install Node.js 18+ and npm, then run:
-
-```
-npm install
-npm run build
-```
-
-The containerized `make build` workflow is the default path for this project.
-
-> During development you can also run `npm run watch` if you are using local Node.js.
-> After each rebuild, click Reload on the extension in `chrome://extensions` to pick up changes. If you changed the service worker or manifest, you must reload the extension; for content script-only changes, a page refresh of the Google Meet tab may be enough.
+After each rebuild, click Reload on the extension in `chrome://extensions` to pick up changes. If you changed the service worker or manifest, you must reload the extension; for content script-only changes, a page refresh of the Google Meet tab may be enough.
 
 
 ## Using the extension
@@ -187,7 +173,7 @@ const WANT_MIC_MIX = true
 `make clean` – remove generated `dist/`
 `make deps-clean` – remove Docker Compose dependency/cache volumes
 
-## Local npm scripts
+## Internal npm scripts
 
 `npm run build` – single production build to `dist/`
 `npm run typecheck` – run TypeScript validation without emitting files
@@ -195,7 +181,7 @@ const WANT_MIC_MIX = true
 `npm run smoke` – run the smoke-test helper
 `npm run watch` – rebuild on change (remember to reload the extension in Chrome)
 
-The npm scripts are mostly used inside the build container. They are also available for the alternative local Node.js workflow.
+The npm scripts are implementation details used by the build container and CI. The supported local workflow is the Make/Docker Compose flow above.
 
 ## Dependencies & toolchain
 
@@ -261,8 +247,7 @@ Answer:
 
 ## Development tips
 
- - Use `make build` for the default containerized production build.
- - Use `npm run watch` during iteration only when using local Node.js.
+ - Use `make build` for the containerized production build.
  - Background logs appear in the `service worker` console:
     - `chrome://extensions` → your extension → `service worker` → `Inspect`
  - Offscreen logs: open `chrome://extensions` → your extension → `service worker` → look for messages from `[offscreen]`.

--- a/README.md
+++ b/README.md
@@ -33,37 +33,44 @@ If you'd rather use a bot or desktop recording form factor, check out [Recall.ai
 
 **Google Chrome** (or Chromium-based browser) with `Manifest V3` support and the `Offscreen API`.
 
-**Node.js 18+** and **npm** (or **pnpm/yarn**) to build the extension.
+**Docker** with **Docker Compose v2** and **make** to build the extension without installing Node.js locally.
+
+Node.js 18+ and npm can still be used as an alternative local workflow.
 
 The extension uses the following Chrome permissions:
 `activeTab`, `downloads`, `tabCapture`, `offscreen`, `storage`, `tabs`, `desktopCapture`
 and is scoped to `https://meet.google.com/*`.
 
 ## Quick start
-1) Clone and install
+
+1. Clone
+
 ```
 git clone https://github.com/recallai/chrome-recording-transcription-extension.git
 cd chrome-recording-transcription-extension
-npm install
 ```
 
-2) Build
+2. Build in a container
+
 ```
-npm run build   # outputs to `./dist`
+make build
 ```
 
-3) Load into Chrome
-- Open `chrome://extensions`
-- Toggle "Developer mode" (top right)
-- Click "Load unpacked"
-- Select the `./dist` folder
+This uses Docker Compose and writes the extension package to `./dist`.
+
+3. Load into Chrome
+
+   a) Open `chrome://extensions`.
+   b) Toggle `Developer mode`.
+   c) Click `Load unpacked`.
+   d) Select the `./dist` folder.
 
 ## Development workflow
 
 Before opening a PR or handing changes to another agent, run:
 
 ```
-npm run check
+make check
 ```
 
 For browser-facing changes, also follow the smoke test in [`docs/runbooks/002-smoke-test-po-zmianach.md`](docs/runbooks/002-smoke-test-po-zmianach.md): rebuild, reload `dist/` in `chrome://extensions`, then validate transcript download and recording on Google Meet when relevant.
@@ -76,37 +83,45 @@ Open a Google Meet, click the extension icon:
 
 ## Install & build (detailed)
 
-**1. Install Node**
-  - macOS: `brew install node`
+**1. Install Docker and make**
 
-  - Ubuntu/Debian: `sudo apt-get install -y nodejs npm`
+Docker must provide the `docker compose` command.
 
-  - Verify: `node -v && npm -v`
-
-**2. Install dependencies**
+Verify:
 
 ```
-npm install
+docker compose version
+make --version
 ```
 
-
-**3. Build once (production)**
+**2. Build once (production)**
 
 ```
-npm run build
+make build
 ```
 
-This compiles TypeScript via `ts-loader` and copies the HTML/manifest to `dist/`.
+This runs `npm ci` and a production webpack build inside the `node:20-bookworm-slim` container. Dependencies are kept in Docker volumes, not in a local `node_modules/` directory. The generated extension is written to `dist/`.
 
-**4. Load the extension**
+**3. Load the extension**
 
   - Visit `chrome://extensions`
   - Turn on `Developer mode`
-  - Click `Load unpacked` → select the `dist` directory that was created inside your repo when you ran `npm run build`
+  - Click `Load unpacked` → select the `dist` directory that was created inside your repo when you ran `make build`
 
-> During development you can also run:
-> `npm run watch` which will force a rebuild on file changes (when you save a file)
-> After each rebuild, click Reload on the extension (in `chrome://extensions`) to pick up changes. If you changed the service worker or manifest, you must reload the extension; for content script-only changes, a page refresh of the Google Meet tab may be enough.
+**Alternative: local Node.js/npm**
+
+If you intentionally want to build without Docker, install Node.js 18+ and npm, then run:
+
+```
+npm install
+npm run build
+```
+
+The containerized `make build` workflow is the default path for this project.
+
+> During development you can also run `npm run watch` if you are using local Node.js.
+> After each rebuild, click Reload on the extension in `chrome://extensions` to pick up changes. If you changed the service worker or manifest, you must reload the extension; for content script-only changes, a page refresh of the Google Meet tab may be enough.
+
 
 ## Using the extension
 
@@ -135,6 +150,8 @@ This compiles TypeScript via `ts-loader` and copies the HTML/manifest to `dist/`
 ├─ webpack.config.js
 ├─ tsconfig.json
 ├─ package.json
+├─ compose.yml
+├─ Makefile
 ├─ popup.html
 ├─ offscreen.html
 ├─ micsetup.html
@@ -162,13 +179,23 @@ const WANT_MIC_MIX = true
   - Recordings: `google-meet-recording-<meet-suffix>-<timestamp>.webm`
   - Transcripts: `google-meet-transcript-<meet-suffix>-<timestamp>.txt`
 
-## Scripts
+## Build commands
+
+`make build` – default production build to `dist/` using Docker Compose
+`make check` – default validation: typecheck and production build in a container
+`make shell` – open a shell in the build container
+`make clean` – remove generated `dist/`
+`make deps-clean` – remove Docker Compose dependency/cache volumes
+
+## Local npm scripts
 
 `npm run build` – single production build to `dist/`
 `npm run typecheck` – run TypeScript validation without emitting files
 `npm run check` – run typecheck and production build
-`npm run smoke` – run the local smoke-test helper
+`npm run smoke` – run the smoke-test helper
 `npm run watch` – rebuild on change (remember to reload the extension in Chrome)
+
+The npm scripts are mostly used inside the build container. They are also available for the alternative local Node.js workflow.
 
 ## Dependencies & toolchain
 
@@ -234,7 +261,8 @@ Answer:
 
 ## Development tips
 
- - Use `npm run watch` during iteration.
+ - Use `make build` for the default containerized production build.
+ - Use `npm run watch` during iteration only when using local Node.js.
  - Background logs appear in the `service worker` console:
     - `chrome://extensions` → your extension → `service worker` → `Inspect`
  - Offscreen logs: open `chrome://extensions` → your extension → `service worker` → look for messages from `[offscreen]`.

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,26 @@
+services:
+  builder:
+    image: node:20-bookworm-slim
+    working_dir: /workspace
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
+    environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
+      npm_config_cache: /home/node/.npm
+    volumes:
+      - ./package.json:/workspace/package.json:ro
+      - ./package-lock.json:/workspace/package-lock.json:ro
+      - ./tsconfig.json:/workspace/tsconfig.json:ro
+      - ./webpack.config.js:/workspace/webpack.config.js:ro
+      - ./manifest.json:/workspace/manifest.json:ro
+      - ./popup.html:/workspace/popup.html:ro
+      - ./offscreen.html:/workspace/offscreen.html:ro
+      - ./micsetup.html:/workspace/micsetup.html:ro
+      - ./src:/workspace/src:ro
+      - ./dist:/workspace/dist
+      - node_modules:/workspace/node_modules
+      - npm_cache:/home/node/.npm
+
+volumes:
+  node_modules:
+  npm_cache:

--- a/docs/runbooks/002-smoke-test-po-zmianach.md
+++ b/docs/runbooks/002-smoke-test-po-zmianach.md
@@ -6,13 +6,14 @@ Szybko potwierdzic, ze build oraz najwazniejsze sciezki rozszerzenia dzialaja po
 
 ## Wymagania
 
-- Zainstalowane zaleznosci Node.js (`npm install` albo `npm ci`).
+- Docker z obsluga `docker compose` v2.
+- `make`.
 - Google Chrome lub Chromium z obsluga Manifest V3 i Offscreen API.
 - Testowe spotkanie Google Meet albo mozliwosc otwarcia strony `https://meet.google.com/*`.
 
 ## Kroki
 
-1. Uruchom `npm run check`.
+1. Uruchom `make check`.
 2. Otworz `chrome://extensions`.
 3. Wlacz Developer mode.
 4. Kliknij Reload przy rozszerzeniu, jesli bylo juz zaladowane, albo Load unpacked i wybierz `dist/`.
@@ -23,7 +24,7 @@ Szybko potwierdzic, ze build oraz najwazniejsze sciezki rozszerzenia dzialaja po
 
 ## Kryteria zaliczenia
 
-- `npm run check` konczy sie sukcesem.
+- `make check` konczy sie sukcesem.
 - `dist/` laduje sie jako rozszerzenie bez bledow manifestu.
 - Transkrypt zapisuje plik `.txt`, gdy captions sa wlaczone.
 - Nagrywanie startuje, zatrzymuje sie i pobiera `.webm`, jesli dotknieto kodu recording/offscreen/permissions.

--- a/docs/runbooks/AGENTS.md
+++ b/docs/runbooks/AGENTS.md
@@ -4,4 +4,4 @@ Runbooki maja opisywac powtarzalne procedury, ktore agent albo czlowiek realnie 
 
 - Nie dodawaj ogolnych checklist bez zwiazku z rozszerzeniem Chrome.
 - Kazdy runbook powinien miec cel, wymagania, kroki i kryteria zaliczenia.
-- Jesli procedura dotyczy zmian w kodzie, uwzglednij `npm run check` oraz reczna walidacje rozszerzenia w Chrome, gdy jest potrzebna.
+- Jesli procedura dotyczy zmian w kodzie, uwzglednij `make check` oraz reczna walidacje rozszerzenia w Chrome, gdy jest potrzebna.

--- a/docs/specs/001-containerized-extension-build.md
+++ b/docs/specs/001-containerized-extension-build.md
@@ -1,0 +1,160 @@
+# Spec: containerized extension build
+
+## Podsumowanie
+
+Celem jest dodanie kontenerowego sposobu budowania rozszerzenia, tak aby lokalnie nie trzeba bylo instalowac Node.js ani uruchamiac `npm` na hoscie. Repo dostanie `compose.yml` z usluga buildowa oraz `Makefile`, ktory jednym poleceniem uruchomi build w kontenerze i zapisze wynik w lokalnym `dist/`.
+
+Realizacja specyfikacji ma tez przestawic instrukcje projektu tak, aby domyslnym sposobem lokalnego budowania i walidacji byl `make` uruchamiajacy kontener. Lokalny `npm` ma zostac opisany jako wariant alternatywny dla osob, ktore swiadomie chca uzywac lokalnego Node.js.
+
+Zakres jest narzedziowy: bez zmian w logice rozszerzenia, manifestu i uprawnien Chrome.
+
+## Cel
+
+Umozliwic zbudowanie rozszerzenia komenda typu:
+
+```bash
+make build
+```
+
+bez lokalnego `npm install`, lokalnego `node_modules/` i lokalnej instalacji Node.js.
+
+## Proponowany zakres zmian
+
+1. `compose.yml`
+   a) Dodac usluge `builder` oparta o oficjalny obraz `node:20-bookworm-slim`.
+   b) Zamontowac pliki i katalogi zrodlowe do `/workspace` jako precyzyjne mounty read-only.
+   c) Uzyc wolumenu Docker dla `/workspace/node_modules`, aby zaleznosci nie byly zapisywane na hoscie.
+   d) Uzyc wolumenu Docker dla cache npm, aby kolejne buildy byly szybsze.
+   e) Ustawic `working_dir` na `/workspace`.
+   f) Przekazac UID/GID z hosta przez zmienne `HOST_UID` i `HOST_GID`, zeby pliki wygenerowane w `dist/` nie byly tworzone jako `root`.
+   g) Zamontowac lokalny `./dist` do `/workspace/dist`, bo tylko artefakt builda ma trafic na hosta.
+
+2. `Makefile`
+   a) Dodac `make build`, ktore uruchamia w kontenerze `npm ci` i produkcyjny build webpacka.
+   b) Dodac `make check`, ktore uruchamia w kontenerze `npm ci`, `tsc --noEmit` i produkcyjny build webpacka.
+   c) Dodac `make shell` dla wejscia do srodowiska buildowego.
+   d) Dodac `make clean` do usuniecia wygenerowanego `dist/`.
+   e) Dodac `make deps-clean` do usuniecia wolumenow zaleznosci/cache.
+   f) Uzywac `docker compose`, nie starszego polecenia `docker-compose`.
+   g) Wyliczac `HOST_UID` i `HOST_GID` w Makefile przez `id -u` i `id -g`, z mozliwoscia nadpisania z zewnatrz.
+
+3. Dokumentacja i instrukcje projektowe
+   a) Zaktualizowac `README.md` tak, aby domyslny workflow lokalny byl oparty o kontener:
+      - `make build`
+      - zaladowanie `dist/` w `chrome://extensions`
+   b) Opisac lokalny `npm install` / `npm run build` jako wariant alternatywny, nie glowny.
+   c) Zaktualizowac `AGENTS.md`, aby dla agentow domyslna walidacja po zmianach byla `make check`, a nie `npm run check`.
+   d) Zaktualizowac `docs/system-map.md`, aby uwzglednic Docker Compose jako domyslne lokalne narzedzie buildowe.
+   e) Zaktualizowac `docs/runbooks/002-smoke-test-po-zmianach.md`, aby podstawowa sciezka smoke testu uzywala `make check`.
+   f) Zaktualizowac `scripts/README.md`, jesli dodany workflow zmieni opis helperow.
+   g) Zaktualizowac `.github/PULL_REQUEST_TEMPLATE.md`, jesli checklisty lub weryfikacja wskazuja obecnie lokalny `npm run check` jako glowna komende.
+
+## Zasady realizacji
+
+1. W trakcie implementacji rozstrzygaj niejednoznacznosci samodzielnie, jesli odpowiedz wynika z tej specyfikacji, architektury projektu albo oczywistych ograniczen technicznych.
+2. Nie zatrzymuj realizacji na decyzjach opisanych juz w sekcji `Decyzje projektowe`.
+3. Jesli pojawi sie niejednoznacznosc, ktorej nie da sie uczciwie rozstrzygnac z kontekstu, zadaj czlowiekowi jedno konkretne pytanie i czekaj na odpowiedz.
+4. Nie zadawaj serii pytan naraz.
+
+## Poza zakresem
+
+1. Zmiany w kodzie TypeScript rozszerzenia.
+2. Zmiany w `manifest.json` i uprawnieniach Chrome.
+3. Publikowanie rozszerzenia do Chrome Web Store.
+4. Zmiana GitHub Actions CI z `npm ci` na Docker Compose.
+5. Dodawanie wlasnego `Dockerfile`, jesli oficjalny obraz Node.js wystarczy.
+
+## Decyzje projektowe
+
+1. `node_modules` nie powinno trafic na hosta.
+   a) Implementacja ma uzyc nazwanego wolumenu Docker dla `/workspace/node_modules`.
+   b) Nie montuj calego repozytorium jako `/workspace`, bo Docker utworzy lokalny katalog `node_modules/` jako punkt montowania zagniezdzonego wolumenu.
+   c) Uzasadnienie: glowny cel to build bez lokalnego npm i bez lokalnego drzewa zaleznosci.
+
+2. `dist/` powinien zostac zapisany na hoscie.
+   a) Uzasadnienie: Chrome ma ladowac lokalny katalog `dist/` przez `Load unpacked`.
+
+3. Kontener powinien uruchamiac `npm ci`, nie `npm install`.
+   a) `make build` i `make check` maja uruchamiac `npm ci` przy kazdym wykonaniu jako krok przygotowania zaleznosci.
+   b) Krok `npm ci` ma dzialac jako `root`, bo npm usuwa i odtwarza `node_modules`, a katalog ten jest bezposrednim mountem nazwanego wolumenu.
+   c) Po `npm ci` Makefile ma przywrocic wlasciciela `/workspace`, `/workspace/dist`, `/workspace/node_modules` i cache npm na `HOST_UID:HOST_GID`.
+   d) Wlasciwy typecheck i build maja dzialac jako `HOST_UID:HOST_GID`, najlepiej przez bezposrednie binarki z `node_modules/.bin`, zeby nie pisac dodatkowych logow npm.
+   e) Uzasadnienie: build ma byc powtarzalny i zgodny z `package-lock.json`, a artefakty w `dist/` nie powinny byc tworzone jako `root`.
+
+4. `Makefile` powinien byc cienka nakladka na Docker Compose.
+   a) Uzasadnienie: uzytkownik ma pamietac `make build`, a szczegoly Compose zostaja w repo.
+
+5. Dokumentacja powinna promowac `make` jako sciezke domyslna.
+   a) Uzasadnienie: glowny cel zmiany to usuniecie wymogu lokalnego npm z typowego workflow.
+
+6. Cache npm powinien byc trwaly miedzy buildami.
+   a) Implementacja ma uzyc nazwanego wolumenu Docker dla cache npm.
+   b) Uzasadnienie: `npm ci` pozostaje deterministyczne, a cache zmniejsza koszt kolejnych instalacji.
+
+7. `make clean` powinien usuwac tylko wygenerowany katalog `dist/`.
+   a) Uzasadnienie: czyszczenie artefaktow builda nie powinno kasowac cache zaleznosci.
+
+8. `make deps-clean` powinien usuwac wolumeny zaleznosci i cache npm.
+   a) Uzasadnienie: reset zaleznosci ma byc jawna operacja diagnostyczna, uzywana przy problemach z wolumenami albo lockfile.
+
+9. Compose ma byc uruchamiany przez `docker compose` v2.
+   a) Uzasadnienie: to aktualny interfejs Docker Compose i taki wymog ma trafic do README.
+
+10. Obraz buildowy to `node:20-bookworm-slim`.
+   a) Uzasadnienie: CI uzywa Node.js 20, wiec lokalny kontener powinien trzymac te sama glowna wersje runtime'u.
+
+## Proponowany interfejs
+
+```bash
+make build
+make check
+make shell
+make clean
+make deps-clean
+```
+
+## Kryteria akceptacji
+
+1. `make build` dziala na maszynie z Dockerem i Docker Compose v2, bez lokalnego Node.js/npm.
+2. Po `make build` istnieje lokalny katalog `dist/` z plikami rozszerzenia.
+3. `make check` uruchamia typecheck i production build w kontenerze.
+4. Na hoscie nie powstaje lokalny `node_modules/`.
+5. Wygenerowane pliki w `dist/` sa zapisywalne/usuwalne przez uzytkownika hosta.
+6. README wskazuje `make build` jako domyslny sposob budowania rozszerzenia.
+7. README opisuje lokalny `npm` jako wariant alternatywny.
+8. AGENTS i runbook smoke testu wskazuja `make check` jako domyslna walidacje lokalna.
+
+## Plan weryfikacji
+
+1. Uruchomic:
+
+```bash
+make check
+```
+
+2. Potwierdzic, ze nie powstal lokalny katalog `node_modules/`.
+3. Potwierdzic, ze `dist/manifest.json`, `dist/background.js`, `dist/popup.js`, `dist/offscreen.js`, `dist/scrapingScript.js` i `dist/micsetup.js` istnieja.
+4. Uruchomic:
+
+```bash
+make clean
+make build
+```
+
+5. Zaladowac `dist/` w `chrome://extensions` jako `Load unpacked`.
+
+## Ryzyka
+
+1. Uprawnienia plikow w `dist/`
+   a) Mitigacja: uruchamiac wlasciwy build/check z UID/GID hosta przez zmienne przekazane z Makefile.
+
+2. Roznice Docker Compose miedzy systemami
+   a) Mitigacja: zakladac `docker compose` v2 i opisac to w README.
+
+3. Wolumen `node_modules` moze przechowywac stare zaleznosci
+   a) Mitigacja: dodac `make deps-clean` i dokumentowac uzycie przy problemach z zaleznosciami.
+
+## Rozstrzygniete decyzje
+
+1. `make check` ma byc rekomendowana podstawowa walidacja lokalna.
+2. `npm run check` pozostaje dostepne jako alternatywa dla osob z lokalnym Node.js.

--- a/docs/specs/001-containerized-extension-build.md
+++ b/docs/specs/001-containerized-extension-build.md
@@ -4,7 +4,7 @@
 
 Celem jest dodanie kontenerowego sposobu budowania rozszerzenia, tak aby lokalnie nie trzeba bylo instalowac Node.js ani uruchamiac `npm` na hoscie. Repo dostanie `compose.yml` z usluga buildowa oraz `Makefile`, ktory jednym poleceniem uruchomi build w kontenerze i zapisze wynik w lokalnym `dist/`.
 
-Realizacja specyfikacji ma tez przestawic instrukcje projektu tak, aby domyslnym sposobem lokalnego budowania i walidacji byl `make` uruchamiajacy kontener. Lokalny `npm` ma zostac opisany jako wariant alternatywny dla osob, ktore swiadomie chca uzywac lokalnego Node.js.
+Realizacja specyfikacji ma tez przestawic instrukcje projektu tak, aby wspieranym sposobem lokalnego budowania i walidacji byl `make` uruchamiajacy kontener. Lokalny `npm` pozostaje szczegolem implementacyjnym uzywanym przez kontener i CI, ale nie jest dokumentowany jako wspierany workflow lokalny.
 
 Zakres jest narzedziowy: bez zmian w logice rozszerzenia, manifestu i uprawnien Chrome.
 
@@ -42,7 +42,7 @@ bez lokalnego `npm install`, lokalnego `node_modules/` i lokalnej instalacji Nod
    a) Zaktualizowac `README.md` tak, aby domyslny workflow lokalny byl oparty o kontener:
       - `make build`
       - zaladowanie `dist/` w `chrome://extensions`
-   b) Opisac lokalny `npm install` / `npm run build` jako wariant alternatywny, nie glowny.
+   b) Nie opisywac lokalnego `npm install` / `npm run build` jako wspieranego workflow lokalnego.
    c) Zaktualizowac `AGENTS.md`, aby dla agentow domyslna walidacja po zmianach byla `make check`, a nie `npm run check`.
    d) Zaktualizowac `docs/system-map.md`, aby uwzglednic Docker Compose jako domyslne lokalne narzedzie buildowe.
    e) Zaktualizowac `docs/runbooks/002-smoke-test-po-zmianach.md`, aby podstawowa sciezka smoke testu uzywala `make check`.
@@ -121,7 +121,7 @@ make deps-clean
 4. Na hoscie nie powstaje lokalny `node_modules/`.
 5. Wygenerowane pliki w `dist/` sa zapisywalne/usuwalne przez uzytkownika hosta.
 6. README wskazuje `make build` jako domyslny sposob budowania rozszerzenia.
-7. README opisuje lokalny `npm` jako wariant alternatywny.
+7. README nie opisuje lokalnego `npm` jako wspieranego workflow lokalnego.
 8. AGENTS i runbook smoke testu wskazuja `make check` jako domyslna walidacje lokalna.
 
 ## Plan weryfikacji
@@ -157,4 +157,4 @@ make build
 ## Rozstrzygniete decyzje
 
 1. `make check` ma byc rekomendowana podstawowa walidacja lokalna.
-2. `npm run check` pozostaje dostepne jako alternatywa dla osob z lokalnym Node.js.
+2. `npm run check` pozostaje komenda techniczna dla kontenera i CI, ale nie jest wspieranym workflow lokalnym w dokumentacji projektu.

--- a/docs/specs/AGENTS.md
+++ b/docs/specs/AGENTS.md
@@ -3,6 +3,8 @@
 Specyfikacje sa potrzebne dla zmian, ktore maja nieoczywisty zakres, ryzyka lub kilka mozliwych rozwiazan.
 
 - Dla prostych poprawek nie tworz specyfikacji na sile.
-- Nazwa pliku powinna byc krotka i opisowa, np. `recording-error-state.md`.
+- Nazwa pliku powinna miec numer porzadkowy i krotki opis: `NNN-krotki-opis.md`, np. `001-recording-error-state.md`.
 - Specyfikacja powinna zawierac cel, zakres, decyzje, kryteria akceptacji i plan weryfikacji.
+- Przy pisaniu specyfikacji dookreslaj niejednoznacznosci samodzielnie, gdy odpowiedz wynika z architektury projektu, poprzednich ustalen albo oczywistych ograniczen technicznych.
+- Jesli niejednoznacznosci nie da sie uczciwie rozstrzygnac na podstawie kontekstu, zadaj czlowiekowi jedno konkretne pytanie i czekaj na odpowiedz; nie zadawaj serii pytan naraz.
 - Nie traktuj specyfikacji jako zgody na implementacje, jesli czlowiek poprosil tylko o analize.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -2,4 +2,6 @@
 
 Use this directory for short implementation specs when a change is larger than a direct bug fix.
 
+Use numbered filenames: `NNN-short-title.md`, for example `001-recording-error-state.md`.
+
 Start from [_template.md](_template.md), then keep only sections that help with the specific change.

--- a/docs/specs/_template.md
+++ b/docs/specs/_template.md
@@ -23,5 +23,5 @@ Describe the implementation approach.
 
 ## Verification
 
-- `npm run check`
+- `make check`
 - Manual Chrome extension smoke test, if browser behavior changes.

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -16,6 +16,7 @@ The extension saves Google Meet captions as a local `.txt` transcript and can re
 | Offscreen recorder | `offscreen.html`, `src/offscreen.ts` | Captures tab media, optionally mixes microphone audio, records via `MediaRecorder`, and returns a blob URL for download. |
 | Mic setup page | `micsetup.html`, `src/micsetup.ts` | Visible extension page used to request microphone permission when popup prompting is unreliable. |
 | Caption collector | `src/scrapingScript.ts` | Content script that observes Google Meet caption DOM and buffers transcript lines. |
+| Container build | `compose.yml`, `Makefile` | Default local build and validation entrypoint. Runs npm inside Docker Compose without local Node.js. |
 | Build | `webpack.config.js`, `tsconfig.json` | Compiles TypeScript entrypoints and copies static extension files into `dist/`. |
 
 ## Runtime Boundaries
@@ -27,8 +28,9 @@ The extension saves Google Meet captions as a local `.txt` transcript and can re
 
 ## Local Validation
 
-1. Install dependencies with `npm install` or `npm ci`.
-2. Run `npm run check`.
-3. Load `dist/` in `chrome://extensions`.
-4. Test on a Google Meet page with captions enabled for transcript behavior.
-5. Test recording start/stop and download behavior when touching capture, offscreen, or permission code.
+1. Run `make check`.
+2. Load `dist/` in `chrome://extensions`.
+3. Test on a Google Meet page with captions enabled for transcript behavior.
+4. Test recording start/stop and download behavior when touching capture, offscreen, or permission code.
+
+Local `npm run check` remains available as an alternative workflow for environments with Node.js installed.

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -33,4 +33,4 @@ The extension saves Google Meet captions as a local `.txt` transcript and can re
 3. Test on a Google Meet page with captions enabled for transcript behavior.
 4. Test recording start/stop and download behavior when touching capture, offscreen, or permission code.
 
-Local `npm run check` remains available as an alternative workflow for environments with Node.js installed.
+GitHub Actions may still call npm scripts directly, but the supported local workflow is `make`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,9 +1,11 @@
 # Scripts
 
-Helper scripts for local project workflows.
+Helper scripts for local project workflows. The default build and validation entrypoints are Make targets backed by Docker Compose.
 
 ## Available scripts
 
 - `smoke-test.sh` - runs the local validation command used before manual Chrome extension testing.
+
+Prefer `make check` for day-to-day validation. Use scripts directly only when a Make target points to them or when debugging the helper itself.
 
 Run scripts from the repository root.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 set -eu
 
-npm run check
+make check


### PR DESCRIPTION
## What changed

1. Added a Docker Compose based build container and Make targets:
   a) `make build`
   b) `make check`
   c) `make shell`
   d) `make clean`
   e) `make deps-clean`

2. Made the containerized Make workflow the default local build path.

3. Updated project documentation, runbooks, specs, GitHub templates, and helper docs to point to `make check` / `make build` first, with local npm kept as an alternative workflow.

## Why

The extension should be buildable without local Node.js or npm. Dependencies stay in Docker volumes, while the generated extension package is written to local `dist/` for Chrome `Load unpacked`.

## Verification

1. `make check`
2. `make clean && make build`
3. Confirmed no local `node_modules/` is created.
4. Confirmed `dist/` contains the extension files and is owned by the host user.

## Notes

1. CI still uses `npm run check`; changing GitHub Actions to Compose was intentionally out of scope for the spec.
2. `npm ci` still reports existing npm audit vulnerabilities; no automatic `npm audit fix` was run because that would change dependencies separately.
