### PR TITLE
[codex] Add recording upload backend flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,12 +7,14 @@ Stosuj te zasady przy generowaniu kodu, komentarzy i uwag review w tym repozytor
 1. To rozszerzenie Chrome Manifest V3 dla Google Meet.
 2. Kod źródłowy to TypeScript w `src/`.
 3. webpack buduje entrypointy JavaScript i kopiuje `manifest.json` oraz pliki HTML do `dist/`.
-4. Projekt nie ma backendu, bazy danych ani celu wdrożenia.
-5. Lokalne wzorce MV3, media, messagingu, storage i TypeScript są opisane w `docs/agent-guides/chrome-extension-ts.md`.
+4. Rozszerzenie wysyła nagrania do backendu uploadu i przetwarzania w repozytorium `pawel-walaszek/recording-backend`.
+5. Docelowy endpoint uploadu dla etapu dev/prod-like to `https://meet2note.com`.
+6. Ustalenia integracyjne z backendem są utrzymywane w specyfikacjach, issue cross-repo i realnym zachowaniu API.
+7. Lokalne wzorce MV3, media, messagingu, storage i TypeScript są opisane w `docs/agent-guides/chrome-extension-ts.md`.
 
 ## Priorytety review
 
-1. Regresje funkcjonalne w przechwytywaniu karty, nagrywaniu offscreen, pobieraniu plików i przepływie uprawnień mikrofonu.
+1. Regresje funkcjonalne w przechwytywaniu karty, nagrywaniu offscreen, uploadzie assetów i przepływie uprawnień mikrofonu.
 2. Ryzyka bezpieczeństwa i prywatności, szczególnie niepotrzebne uprawnienia Chrome albo dane opuszczające przeglądarkę.
 3. Brak walidacji dla zmienionego zachowania.
 4. Niespójność z istniejącą prostą strukturą TypeScript/webpack.
@@ -37,3 +39,9 @@ Stosuj te zasady przy generowaniu kodu, komentarzy i uwag review w tym repozytor
 
 1. Używaj `make check` dla zmian w kodzie albo konfiguracji.
 2. Poproś o ręczne testy rozszerzenia Chrome albo opisz je, gdy zmienia się zachowanie w przeglądarce.
+
+## Komunikacja cross-repo
+
+1. Jeśli review albo generowana zmiana wymaga pracy po stronie `recording-backend`, zgłoś to jako osobne issue w repozytorium backendu.
+2. Jeśli problem po stronie backendu wymaga zmiany wtyczki, oczekiwanym miejscem przekazania pracy jest issue w tym repozytorium.
+3. W issue podawaj kontekst, oczekiwany kontrakt, kryteria akceptacji i link do specyfikacji albo PR, jeśli istnieje.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,22 @@ Ten plik definiuje zasady dla agentow AI i automatyzacji pracujacych w tym repoz
 - Commit, push i tworzenie Pull Request wykonuj tylko po wyraznej zgodzie czlowieka.
 - PR powinien zawierac zakres, sposob weryfikacji, ryzyka oraz informacje o zmianach w uprawnieniach Chrome, jesli takie wystapily.
 
+## Powiazane repozytorium backendu
+
+1. Backend dla tej wtyczki znajduje sie w repozytorium `recording-backend`.
+   a) Lokalna sciezka: `/Users/pawel.walaszek/playground/recording-backend`.
+   b) GitHub: `pawel-walaszek/recording-backend`.
+
+2. Backend jest docelowym server-side dla uploadu, przetwarzania, transkrypcji i udostepniania nagran z tej wtyczki.
+
+3. Przy zmianach dotyczacych uploadu, formatu plikow, metadanych nagrania, autoryzacji, API albo przyszlego MCP:
+   a) sprawdz repo backendu,
+   b) sprawdz kontrakt API backend-wtyczka,
+   c) zaktualizuj dokumentacje po obu stronach,
+   d) uruchom dostepne walidacje albo opisz, czego nie dalo sie sprawdzic.
+
+4. Zrodlem prawdy kontraktu integracyjnego ma byc `docs/contracts/recording-upload.openapi.yml` w repo backendu, gdy plik zostanie utworzony.
+
 ## Skrot `+PR`
 
 Gdy czlowiek napisze `+PR`, uruchom lokalna procedure pracy z Pull Requestem.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Gdy czlowiek napisze `+PR`, uruchom lokalna procedure pracy z Pull Requestem.
    c) Po ponowieniu review czekaj do 10 minut na kolejna porcje uwag Copilota.
    d) Ponow review Copilota tylko wtedy, gdy nie przekracza to ustalonego limitu rund.
    e) Domyslny limit to 3 rundy CR - poprawki - CR.
-   f) Jesli limit zostal osiagniety, nie pros o kolejne review automatycznie; zapytaj czlowieka, co dalej.
+   f) Po trzeciej rundzie poprawek wyslanych do PR nie pros Copilota o kolejne review automatycznie; uznaj proces Copilot CR za zakonczony.
 
 5. Wazne zasady
    a) Nigdy nie wdrazaj sugestii Copilota w ciemno.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Ten plik definiuje zasady dla agentow AI i automatyzacji pracujacych w tym repoz
 - Uprawnienia Chrome i `host_permissions` zmieniaj tylko wtedy, gdy wymaga tego funkcjonalnosc, i opisz powod w podsumowaniu.
 - Przy kazdym generowaniu nowej wtyczki podbijaj `version` w `manifest.json`.
 - Przy poprawkach bugow podbijaj ostatnia liczbe wersji, np. `1.1.0` -> `1.1.1`.
+- Zmiany UX, drobne funkcje pomocnicze i male usprawnienia podbijaja patch, nie minor. Minor podbijaj tylko dla znaczacych funkcji albo zmian zachowania o wiekszym zakresie.
 
 ## Weryfikacja
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,9 +82,11 @@ Gdy czlowiek napisze `+PR`, uruchom lokalna procedure pracy z Pull Requestem.
 
 4. Kolejne rundy
    a) Po wdrozeniu zatwierdzonych przez czlowieka poprawek zrob commit i push.
-   b) Ponow review Copilota tylko wtedy, gdy nie przekracza to ustalonego limitu rund.
-   c) Domyslny limit to 3 rundy CR - poprawki - CR.
-   d) Jesli limit zostal osiagniety, nie pros o kolejne review automatycznie; zapytaj czlowieka, co dalej.
+   b) Po odpowiedzeniu na wszystkie uwagi z danej rundy popros Copilota o ponowne review poprawek w tym samym PR.
+   c) Po ponowieniu review czekaj do 10 minut na kolejna porcje uwag Copilota.
+   d) Ponow review Copilota tylko wtedy, gdy nie przekracza to ustalonego limitu rund.
+   e) Domyslny limit to 3 rundy CR - poprawki - CR.
+   f) Jesli limit zostal osiagniety, nie pros o kolejne review automatycznie; zapytaj czlowieka, co dalej.
 
 5. Wazne zasady
    a) Nigdy nie wdrazaj sugestii Copilota w ciemno.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,14 @@ Ten plik definiuje zasady dla agentow AI i automatyzacji pracujacych w tym repoz
 - Runbooki trzymaj w `docs/runbooks/` tylko dla powtarzalnych procedur.
 - Unikaj semantycznych duplikatow miedzy `AGENTS.md`, `README.md` i dokumentacja.
 
+## Doprecyzowywanie specyfikacji
+
+1. Przy pracy nad specyfikacja end-to-end najpierw samodzielnie rozstrzygaj niejednoznacznosci, ktore wynikaja z architektury, historii ustalen albo istniejacego kodu.
+2. Pytaj czlowieka tylko o decyzje, ktorych nie da sie bezpiecznie wywnioskowac z kontekstu.
+3. Pytania zadawaj pojedynczo, nigdy seria.
+4. Przy kazdym pytaniu podawaj licznik w formacie `Pytanie X z Y`, zeby bylo jasne, ile decyzji zostalo.
+5. Po odpowiedzi czlowieka zapisz decyzje w specyfikacji i powiazanych issue, jesli istnieja.
+
 ## GitHub i proces pracy
 
 - Glowne repozytorium ustalaj z `git remote -v`.
@@ -60,6 +68,9 @@ Ten plik definiuje zasady dla agentow AI i automatyzacji pracujacych w tym repoz
    b) GitHub: `pawel-walaszek/recording-backend`.
 
 2. Backend jest docelowym server-side dla uploadu, przetwarzania, transkrypcji i udostepniania nagran z tej wtyczki.
+   a) Aktualny backend jest aplikacja Node.js/TypeScript oparta o NestJS + Fastify.
+   b) Webowe GUI backendu jest aplikacja React + Vite + Ant Design.
+   c) Repo backendu uzywa pnpm workspaces oraz `docker compose up -d` jako podstawowego sposobu uruchamiania.
 
 3. Przy zmianach dotyczacych uploadu, formatu plikow, metadanych nagrania, autoryzacji, API albo przyszlego MCP:
    a) sprawdz repo backendu,
@@ -67,7 +78,27 @@ Ten plik definiuje zasady dla agentow AI i automatyzacji pracujacych w tym repoz
    c) zaktualizuj dokumentacje po obu stronach,
    d) uruchom dostepne walidacje albo opisz, czego nie dalo sie sprawdzic.
 
-4. Zrodlem prawdy kontraktu integracyjnego ma byc `docs/contracts/recording-upload.openapi.yml` w repo backendu, gdy plik zostanie utworzony.
+4. Zrodlem ustalen integracyjnych sa specyfikacje i issue cross-repo oraz realne zachowanie API backendu.
+   a) Jesli backend wybierze konkretna forme dokumentowania API, dopiero wtedy linkuj ja jako referencje.
+
+5. Docelowy endpoint dla uploadu z rozszerzenia to `https://meet2note.com`.
+   a) Na obecnym etapie traktuj `https://meet2note.com` jako srodowisko deweloperskie/prod-like, mimo ze domena wyglada produkcyjnie.
+   b) Lokalny backend nadal moze dzialac pod `http://localhost:3000`.
+   c) Nie hardcoduj sekretow ani tokenow; upload uzywa tokenu zwracanego przez backend po inicjalizacji uploadu.
+   d) Po wdrozeniu uploadu nie pobieraj automatycznie lokalnego pliku `.webm`; upload ma zastapic lokalny zapis.
+
+6. Obecny kontrakt uploadu:
+   a) `POST /api/upload/init` tworzy sesje uploadu i zwraca `recordingId`, `uploadToken` oraz `expiresAt`.
+   b) `PUT /api/upload/{recordingId}/video` wysyla asset `video_audio` jako `application/octet-stream` z naglowkiem `X-Upload-Token`.
+   c) `PUT /api/upload/{recordingId}/microphone` wysyla opcjonalny asset mikrofonu jako `application/octet-stream` z naglowkiem `X-Upload-Token`.
+   d) `POST /api/upload/{recordingId}/complete` konczy upload z naglowkiem `X-Upload-Token`.
+
+## Komunikacja cross-repo
+
+1. Jesli zmiana w tym repozytorium wymaga pracy po stronie `recording-backend`, utworz issue w repozytorium backendu z konkretnym zakresem, kontekstem i kryteriami akceptacji.
+2. Jesli zmiana w `recording-backend` wymaga pracy po stronie tej wtyczki, oczekiwanym miejscem przekazania pracy jest issue w tym repozytorium.
+3. W issue linkuj odpowiednia specyfikacje, kontrakt albo PR, jesli istnieje.
+4. Nie zakladaj, ze ustalenia z rozmowy sa wystarczajaca dokumentacja zaleznosci miedzy projektami.
 
 ## Skrot `+PR`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Ten plik definiuje zasady dla agentow AI i automatyzacji pracujacych w tym repoz
 - Po zmianach w kodzie lub konfiguracji uruchom `make check`.
 - Dla zmian dotykajacych przeplywow przegladarkowych wykonaj tez smoke test z `docs/runbooks/002-smoke-test-po-zmianach.md`.
 - Jesli nie da sie uruchomic walidacji, podaj konkretny powod i zakres ryzyka.
+- Jesli poprawiasz blad zgloszony w Sentry, po wdrozeniu poprawki zamknij odpowiednie issue w Sentry jako rozwiazane.
 
 ## Dokumentacja
 

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,12 @@ HOST_UID ?= $(shell id -u)
 HOST_GID ?= $(shell id -g)
 SENTRY_DSN ?= $(shell scripts/sentry-public-dsn.sh || true)
 SENTRY_ENVIRONMENT ?= chrome-extension-dev
+UPLOAD_API_BASE_URL ?= https://meet2note.com
 export HOST_UID
 export HOST_GID
 export SENTRY_DSN
 export SENTRY_ENVIRONMENT
+export UPLOAD_API_BASE_URL
 
 .PHONY: build check shell clean deps-clean prepare-deps
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 COMPOSE ?= docker compose
 HOST_UID ?= $(shell id -u)
 HOST_GID ?= $(shell id -g)
-SENTRY_DSN ?= $(shell scripts/sentry-public-dsn.sh 2>/dev/null || true)
+SENTRY_DSN ?= $(shell scripts/sentry-public-dsn.sh || true)
 SENTRY_ENVIRONMENT ?= chrome-extension-dev
 export HOST_UID
 export HOST_GID

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 COMPOSE ?= docker compose
 HOST_UID ?= $(shell id -u)
 HOST_GID ?= $(shell id -g)
+SENTRY_DSN ?= $(shell scripts/sentry-public-dsn.sh 2>/dev/null || true)
+SENTRY_ENVIRONMENT ?= chrome-extension-dev
 export HOST_UID
 export HOST_GID
+export SENTRY_DSN
+export SENTRY_ENVIRONMENT
 
 .PHONY: build check shell clean deps-clean prepare-deps
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
 │  ├─ background.ts     # service worker MV3: tworzy offscreen i koordynuje strumienie
 │  ├─ offscreen.ts      # uruchamia nagrywarkę, miksuje mikrofon z kartą i zapisuje blob
 │  ├─ popup.ts          # obsługa popupu: mikrofon, start/stop
+│  ├─ micPreferences.ts # wspólne helpery zapisu wyboru mikrofonu
 │  └─ micsetup.ts       # widoczna strona do nadania uprawnienia i wyboru mikrofonu
 └─ dist/                # wygenerowany wynik builda
 ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Przy zmianach widocznych w przeglądarce wykonaj też test dymny z [`docs/runboo
 
 
 Otwórz Google Meet i kliknij ikonę rozszerzenia:
-1. **Enable Microphone** - nadaje uprawnienie mikrofonu, żeby Twój głos mógł zostać domiksowany do nagrania.
+1. **Enable Microphone / Microphone Settings** - otwiera konfigurację mikrofonu i pozwala wybrać urządzenie wejściowe.
 2. **Start Recording / Stop & Download** - tworzy plik `.webm` przez Downloads API.
 
 ## Instalacja i budowanie
@@ -111,10 +111,10 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
 
 3. W popupie:
  
-   a) **Enable Microphone** - włącz przed kliknięciem `Start Recording`, żeby poza dźwiękiem innych uczestników nagrać też swój głos.
-   b) Prośba o dostęp do mikrofonu może nie pojawiać się niezawodnie w popupie. W takim przypadku przycisk otwiera dedykowaną stronę `Enable Microphone` (`micsetup.html`), gdzie można kliknąć `Enable` i udzielić dostępu do mikrofonu.
-   c) Po udzieleniu dostępu etykieta zmienia się na `Microphone Enabled`.
-   d) **Start Recording**: rozpoczyna nagrywanie bieżącej karty (wideo + audio systemowe). Jeśli mikrofon jest włączony i miksowanie jest aktywne (domyślnie), mikrofon zostanie domiksowany.
+   a) **Enable Microphone** - przy pierwszym użyciu otwiera stronę konfiguracji i prosi o dostęp do mikrofonu.
+   b) **Microphone Settings** - po nadaniu uprawnienia pozostaje aktywne i pozwala zmienić mikrofon.
+   c) Na stronie konfiguracji wybierz `Default microphone` albo konkretne urządzenie wejściowe i kliknij `Save Microphone`.
+   d) **Start Recording**: rozpoczyna nagrywanie bieżącej karty (wideo + audio systemowe). Jeśli mikrofon jest dostępny i miksowanie jest aktywne (domyślnie), mikrofon zostanie domiksowany.
    e) **Stop & Download**: finalizuje i pobiera `google-meet-recording-<meeting-id>-<timestamp>.webm`.
 
 > Podczas nagrywania rozszerzenie pokazuje znacznik `REC`. Wszystkie pliki są zapisywane lokalnie przez Chrome Downloads API.
@@ -138,7 +138,7 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
 │  ├─ background.ts     # service worker MV3: tworzy offscreen i koordynuje strumienie
 │  ├─ offscreen.ts      # uruchamia nagrywarkę, miksuje mikrofon z kartą i zapisuje blob
 │  ├─ popup.ts          # obsługa popupu: mikrofon, start/stop
-│  └─ micsetup.ts       # widoczna strona do nadania uprawnienia mikrofonu
+│  └─ micsetup.ts       # widoczna strona do nadania uprawnienia i wyboru mikrofonu
 └─ dist/                # wygenerowany wynik builda
 ```
 
@@ -208,8 +208,15 @@ Odpowiedź:
 
 Pytanie: W nagraniu nie ma audio z mikrofonu.
 Odpowiedź:
-1. Kliknij `Enable Microphone` w popupie. Jeśli prośba inline nie zadziała, otworzy się karta konfiguracji mikrofonu; kliknij tam `Enable` i zezwól na dostęp.
+1. Kliknij `Enable Microphone` albo `Microphone Settings` w popupie, wybierz mikrofon i kliknij `Save Microphone`.
 2. Sprawdź też uprawnienia mikrofonu dla Chrome w systemie: `System Settings` -> `Privacy` -> `Microphone`.
+
+Pytanie: Jak zmienić mikrofon, jeśli Chrome używa złego urządzenia?
+Odpowiedź:
+1. Kliknij `Microphone Settings` w popupie.
+2. Wybierz `Default microphone` albo konkretne urządzenie z listy.
+3. Kliknij `Save Microphone`.
+4. Przy następnym nagraniu rozszerzenie użyje zapisanego wyboru; jeśli urządzenie zniknie, wróci do mikrofonu domyślnego albo nagrywania bez mikrofonu.
 
 Pytanie: Dlaczego nagranie jest ciche albo bez dźwięku?
 Odpowiedź:

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Są już zadeklarowane w `package.json`:
 4. `offscreen` - tworzenie dokumentu offscreen dla logiki nagrywania działającej w tle.
 5. `storage` - zapis tymczasowych wskazówek o stanie nagrywania dla synchronizacji UI.
 6. `host_permissions` dla `https://sentry.eengine.pl/*` - wysyłka zdarzeń diagnostycznych do Sentry, gdy build zawiera DSN.
-7. `host_permissions` dla `https://meet.google.com/*` - content script wykrywa wejście i wyjście ze spotkania, żeby pokazać stan `RDY` i automatycznie zatrzymać nagrywanie po opuszczeniu spotkania.
+7. `content_scripts` dla `https://meet.google.com/*` - content script wykrywa wejście i wyjście ze spotkania, żeby pokazać stan `RDY` i automatycznie zatrzymać nagrywanie po opuszczeniu spotkania.
 
 ## Rozwiązywanie problemów / FAQ
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
    a) Jest jeden przycisk konfiguracji mikrofonu: przy pierwszym użyciu ma etykietę **Enable Microphone**, otwiera stronę konfiguracji i prosi o dostęp do mikrofonu.
    b) Po nadaniu uprawnienia ten sam przycisk zmienia etykietę na **Microphone Settings** i pozwala później zmienić mikrofon.
    c) Na stronie konfiguracji wybierz `Default microphone` albo konkretne urządzenie wejściowe i kliknij `Save Microphone`.
-   d) **Start Recording**: rozpoczyna nagrywanie bieżącej karty (wideo + audio systemowe). Jeśli mikrofon jest dostępny i miksowanie jest aktywne (domyślnie), mikrofon zostanie domiksowany.
-   e) **Stop & Download**: finalizuje i pobiera `google-meet-recording-<meeting-id>-<timestamp>.webm`.
+   d) **Start Recording** rozpoczyna nagrywanie bieżącej karty (wideo + audio systemowe). Jeśli mikrofon jest dostępny i miksowanie jest aktywne (domyślnie), mikrofon zostanie domiksowany.
+   e) Podczas nagrywania ten sam przycisk zmienia się na **Stop & Download**, finalizuje i pobiera `google-meet-recording-<meeting-id>-<timestamp>.webm`.
+   f) Status pod przyciskami pokazuje, czy nagrywanie trwa i ile czasu już nagrano.
 
 > Na aktywnym spotkaniu Google Meet rozszerzenie pokazuje znacznik `RDY`, a podczas nagrywania `REC`. Jeśli nagranie zostało rozpoczęte na karcie Meet, wyjście ze spotkania automatycznie zatrzymuje nagrywanie i pobiera plik. Wszystkie pliki są zapisywane lokalnie przez Chrome Downloads API.
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
    d) **Start Recording**: rozpoczyna nagrywanie bieżącej karty (wideo + audio systemowe). Jeśli mikrofon jest dostępny i miksowanie jest aktywne (domyślnie), mikrofon zostanie domiksowany.
    e) **Stop & Download**: finalizuje i pobiera `google-meet-recording-<meeting-id>-<timestamp>.webm`.
 
-> Podczas nagrywania rozszerzenie pokazuje znacznik `REC`. Wszystkie pliki są zapisywane lokalnie przez Chrome Downloads API.
+> Na aktywnym spotkaniu Google Meet rozszerzenie pokazuje znacznik `RDY`, a podczas nagrywania `REC`. Jeśli nagranie zostało rozpoczęte na karcie Meet, wyjście ze spotkania automatycznie zatrzymuje nagrywanie i pobiera plik. Wszystkie pliki są zapisywane lokalnie przez Chrome Downloads API.
 
 ## Struktura projektu
 ```
@@ -212,6 +212,7 @@ Są już zadeklarowane w `package.json`:
 4. `offscreen` - tworzenie dokumentu offscreen dla logiki nagrywania działającej w tle.
 5. `storage` - zapis tymczasowych wskazówek o stanie nagrywania dla synchronizacji UI.
 6. `host_permissions` dla `https://sentry.eengine.pl/*` - wysyłka zdarzeń diagnostycznych do Sentry, gdy build zawiera DSN.
+7. `host_permissions` dla `https://meet.google.com/*` - content script wykrywa wejście i wyjście ze spotkania, żeby pokazać stan `RDY` i automatycznie zatrzymać nagrywanie po opuszczeniu spotkania.
 
 ## Rozwiązywanie problemów / FAQ
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ const WANT_MIC_MIX = true
 `make clean` - usuwa wygenerowany `dist/`
 `make deps-clean` - usuwa wolumeny zależności/cache Docker Compose
 
+### Sentry
+
+Build przez `make` próbuje odczytać publiczny DSN Sentry z `SENTRY_DSN` albo pobrać go przez API na podstawie `SENTRY_AUTH_TOKEN`, `SENTRY_ORG_SLUG`, `SENTRY_PROJECT_SLUG` i `SENTRY_BASE_URL` z `~/.codex/.secrets`. Jeśli DSN nie jest dostępny, integracja Sentry pozostaje wyłączona.
+
+Domyślne środowisko Sentry dla tej wtyczki to `chrome-extension-dev`. Można je zmienić przed buildem:
+
+```
+SENTRY_ENVIRONMENT=chrome-extension-local make build
+```
+
+Do Sentry trafiają błędy techniczne z popupu, service workera, offscreen documentu i strony ustawień mikrofonu. Nie wysyłamy nagrań, danych audio ani treści spotkań.
+
 ## Wewnętrzne skrypty npm
 
 `npm run build` - pojedynczy build produkcyjny do `dist/`
@@ -178,6 +190,7 @@ Skrypty npm są szczegółem implementacyjnym używanym przez kontener buildowy 
 2. webpack 5 + ts-loader
 3. copy-webpack-plugin, clean-webpack-plugin
 4. @types/chrome, @types/node
+5. @sentry/browser dla opcjonalnej diagnostyki błędów
 
 Są już zadeklarowane w `package.json`:
 ```
@@ -198,6 +211,7 @@ Są już zadeklarowane w `package.json`:
 3. `tabCapture` / `desktopCapture` - przechwytywanie wideo i audio z bieżącej karty.
 4. `offscreen` - tworzenie dokumentu offscreen dla logiki nagrywania działającej w tle.
 5. `storage` - zapis tymczasowych wskazówek o stanie nagrywania dla synchronizacji UI.
+6. `host_permissions` dla `https://sentry.eengine.pl/*` - wysyłka zdarzeń diagnostycznych do Sentry, gdy build zawiera DSN.
 
 ## Rozwiązywanie problemów / FAQ
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
 
 3. W popupie:
  
-   a) **Enable Microphone** - przy pierwszym użyciu otwiera stronę konfiguracji i prosi o dostęp do mikrofonu.
-   b) **Microphone Settings** - po nadaniu uprawnienia pozostaje aktywne i pozwala zmienić mikrofon.
+   a) Jest jeden przycisk konfiguracji mikrofonu: przy pierwszym użyciu ma etykietę **Enable Microphone**, otwiera stronę konfiguracji i prosi o dostęp do mikrofonu.
+   b) Po nadaniu uprawnienia ten sam przycisk zmienia etykietę na **Microphone Settings** i pozwala później zmienić mikrofon.
    c) Na stronie konfiguracji wybierz `Default microphone` albo konkretne urządzenie wejściowe i kliknij `Save Microphone`.
    d) **Start Recording**: rozpoczyna nagrywanie bieżącej karty (wideo + audio systemowe). Jeśli mikrofon jest dostępny i miksowanie jest aktywne (domyślnie), mikrofon zostanie domiksowany.
    e) **Stop & Download**: finalizuje i pobiera `google-meet-recording-<meeting-id>-<timestamp>.webm`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Rozszerzenie Chrome do nagrywania spotkań
 
-Nagrywa bieżącą kartę Google Meet (wideo + audio) do pliku `.webm`. Opcjonalnie może domiksować mikrofon, żeby w nagraniu był też Twój głos.
+Nagrywa bieżącą kartę Google Meet i wysyła nagranie bezpośrednio do backendu `https://meet2note.com`.
 
-Wszystko dzieje się lokalnie w przeglądarce.
+Audio karty i mikrofon są wysyłane jako osobne assety, żeby backend mógł później normalizować poziomy, połączyć ścieżki i udostępnić gotowe nagranie. Rozszerzenie nie pobiera lokalnego pliku `.webm`.
 
 Jeśli interesuje Cię proces, decyzje projektowe, demo i dodatkowe materiały, zobacz [wpis na blogu](https://www.recall.ai/blog/how-to-build-a-chrome-recording-extension).
 
@@ -11,9 +11,13 @@ Jeśli wolisz wariant z botem albo aplikacją desktopową do nagrywania, zobacz 
 
 ## Funkcje
 
-**Nagrywanie karty** - przechwytuje wideo i audio z karty Google Meet do pliku `.webm` przez `MediaRecorder`.
+**Nagrywanie karty** - przechwytuje wideo i audio z karty Google Meet przez `MediaRecorder`.
 
-**Opcjonalne domiksowanie mikrofonu** - dodaje mikrofon do nagrania po udzieleniu uprawnienia.
+**Osobny asset mikrofonu** - nagrywa mikrofon jako oddzielny asset, jeśli użytkownik udzielił uprawnienia.
+
+**Upload do backendu** - wysyła `video_audio` i opcjonalny `microphone` do `https://meet2note.com`.
+
+**Retry uploadu** - jeśli upload się nie powiedzie, ponawia próbę co 15 sekund aż do sukcesu, bez lokalnego pobierania pliku.
 
 **Architektura MV3/Offscreen** - nagrywanie działa w ukrytym dokumencie offscreen.
 
@@ -23,7 +27,7 @@ Jeśli wolisz wariant z botem albo aplikacją desktopową do nagrywania, zobacz 
 
 2. Service worker w tle tworzy i koordynuje dokument offscreen oraz pobiera właściwy `streamId` przechwytywania dla aktywnej karty.
 
-3. Strona offscreen przechwytuje kartę, opcjonalnie miksuje audio z mikrofonu, nagrywa i przekazuje blob do pobrania.
+3. Strona offscreen przechwytuje kartę, nagrywa osobny asset mikrofonu, finalizuje bloby i wysyła je do backendu.
 
 ## Wymagania
 
@@ -32,7 +36,11 @@ Jeśli wolisz wariant z botem albo aplikacją desktopową do nagrywania, zobacz 
 **Docker** z **Docker Compose v2** oraz **make**, żeby budować rozszerzenie bez lokalnej instalacji Node.js.
 
 Rozszerzenie używa następujących uprawnień Chrome:
-`activeTab`, `downloads`, `tabCapture`, `offscreen`, `storage`, `tabs`, `desktopCapture`.
+`activeTab`, `tabCapture`, `offscreen`, `storage`, `tabs`, `desktopCapture`.
+
+Rozszerzenie ma też wąskie `host_permissions` dla:
+1. `https://meet2note.com/*` - upload nagrań do backendu.
+2. `https://sentry.eengine.pl/*` - opcjonalna diagnostyka błędów, jeśli build zawiera DSN Sentry.
 
 ## Szybki start
 
@@ -71,7 +79,7 @@ Przy zmianach widocznych w przeglądarce wykonaj też test dymny z [`docs/runboo
 
 Otwórz Google Meet i kliknij ikonę rozszerzenia:
 1. **Enable Microphone / Microphone Settings** - otwiera konfigurację mikrofonu i pozwala wybrać urządzenie wejściowe.
-2. **Start Recording / Stop & Download** - tworzy plik `.webm` przez Downloads API.
+2. **Start Recording / Stop & Upload** - nagrywa kartę i wysyła wynik do `https://meet2note.com`.
 
 ## Instalacja i budowanie
 
@@ -114,11 +122,11 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
    a) Jest jeden przycisk konfiguracji mikrofonu: przy pierwszym użyciu ma etykietę **Enable Microphone**, otwiera stronę konfiguracji i prosi o dostęp do mikrofonu.
    b) Po nadaniu uprawnienia ten sam przycisk zmienia etykietę na **Microphone Settings** i pozwala później zmienić mikrofon.
    c) Na stronie konfiguracji wybierz `Default microphone` albo konkretne urządzenie wejściowe i kliknij `Save Microphone`.
-   d) **Start Recording** rozpoczyna nagrywanie bieżącej karty (wideo + audio systemowe). Jeśli mikrofon jest dostępny i miksowanie jest aktywne (domyślnie), mikrofon zostanie domiksowany.
-   e) Podczas nagrywania ten sam przycisk zmienia się na **Stop & Download**, finalizuje i pobiera `google-meet-recording-<meeting-id>-<timestamp>.webm`.
-   f) Status pod przyciskami pokazuje, czy nagrywanie trwa i ile czasu już nagrano.
+   d) **Start Recording** rozpoczyna nagrywanie bieżącej karty (wideo + audio systemowe). Jeśli mikrofon jest dostępny, zostanie nagrany jako osobny asset.
+   e) Podczas nagrywania ten sam przycisk zmienia się na **Stop & Upload**, finalizuje nagranie i wysyła assety do `https://meet2note.com`.
+   f) Status pod przyciskami pokazuje, czy nagrywanie trwa, czy trwa upload oraz kiedy nastąpi kolejna próba retry.
 
-> Na aktywnym spotkaniu Google Meet rozszerzenie pokazuje znacznik `RDY`, a podczas nagrywania `REC`. Jeśli nagranie zostało rozpoczęte na karcie Meet, wyjście ze spotkania automatycznie zatrzymuje nagrywanie i pobiera plik. Wszystkie pliki są zapisywane lokalnie przez Chrome Downloads API.
+> Na aktywnym spotkaniu Google Meet rozszerzenie pokazuje znacznik `RDY`, a podczas nagrywania `REC`. Jeśli nagranie zostało rozpoczęte na karcie Meet, wyjście ze spotkania automatycznie zatrzymuje nagrywanie i uruchamia upload do backendu. Rozszerzenie nie zapisuje nagrań lokalnie przez Chrome Downloads API.
 
 ## Struktura projektu
 ```
@@ -137,23 +145,29 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
 ├─ scripts/             # lokalne skrypty pomocnicze
 ├─ src/
 │  ├─ background.ts     # service worker MV3: tworzy offscreen i koordynuje strumienie
-│  ├─ offscreen.ts      # uruchamia nagrywarkę, miksuje mikrofon z kartą i zapisuje blob
+│  ├─ offscreen.ts      # uruchamia nagrywarkę i wysyła assety do backendu
 │  ├─ popup.ts          # obsługa popupu: mikrofon, start/stop
 │  ├─ micPreferences.ts # wspólne helpery zapisu wyboru mikrofonu
+│  ├─ uploadClient.ts   # klient kontraktu uploadu backendu
 │  └─ micsetup.ts       # widoczna strona do nadania uprawnienia i wyboru mikrofonu
 └─ dist/                # wygenerowany wynik builda
 ```
 
 ## Konfiguracja
-1. Domiksowanie mikrofonu do nagrania
+1. Asset mikrofonu
   a) W `src/offscreen.ts`:
 ```
-const WANT_MIC_MIX = true
+const WANT_MIC_ASSET = true
 ```
-  b) Ustaw `false`, żeby całkowicie wyłączyć miksowanie mikrofonu i nagrywać tylko audio z karty.
+  b) Ustaw `false`, żeby całkowicie wyłączyć nagrywanie assetu mikrofonu i wysyłać tylko `video_audio`.
 
-2. Nazwy plików wynikowych
-  a) Nagrania: `google-meet-recording-<meet-suffix>-<timestamp>.webm`
+2. Backend uploadu
+  a) Domyślny URL: `https://meet2note.com`.
+  b) Możesz go zmienić przy buildzie:
+
+```
+UPLOAD_API_BASE_URL=http://localhost:3000 make build
+```
 
 ## Komendy builda
 
@@ -208,10 +222,10 @@ Są już zadeklarowane w `package.json`:
 ```
 ## Wyjaśnienie uprawnień
 1. `activeTab`, `tabs` - odczyt aktywnej karty, potrzebny do wskazania i opisania nagrania.
-2. `downloads` - lokalny zapis nagrań.
-3. `tabCapture` / `desktopCapture` - przechwytywanie wideo i audio z bieżącej karty.
-4. `offscreen` - tworzenie dokumentu offscreen dla logiki nagrywania działającej w tle.
-5. `storage` - zapis tymczasowych wskazówek o stanie nagrywania dla synchronizacji UI.
+2. `tabCapture` / `desktopCapture` - przechwytywanie wideo i audio z bieżącej karty.
+3. `offscreen` - tworzenie dokumentu offscreen dla logiki nagrywania i uploadu działającej w tle.
+4. `storage` - zapis tymczasowych wskazówek o stanie nagrywania/uploadu dla synchronizacji UI.
+5. `host_permissions` dla `https://meet2note.com/*` - upload nagrań do backendu.
 6. `host_permissions` dla `https://sentry.eengine.pl/*` - wysyłka zdarzeń diagnostycznych do Sentry, gdy build zawiera DSN.
 7. `content_scripts` dla `https://meet.google.com/*` - content script wykrywa wejście i wyjście ze spotkania, żeby pokazać stan `RDY` i automatycznie zatrzymać nagrywanie po opuszczeniu spotkania.
 
@@ -239,13 +253,13 @@ Pytanie: Dlaczego nagranie jest ciche albo bez dźwięku?
 Odpowiedź:
 1. Upewnij się, że karta Google Meet odtwarza audio i nie jest wyciszona.
 2. Jeśli wyciszysz stronę, kartę albo Google Meet, audio z karty nie zostanie przechwycone.
-3. Jeśli miksowanie mikrofonu jest włączone, sprawdź urządzenie wejściowe i poziomy w systemie.
+3. Jeśli asset mikrofonu jest włączony, sprawdź urządzenie wejściowe i poziomy w systemie.
 
-Pytanie: `Stop & Download` kończy działanie, ale plik się nie pojawia. Co zrobić?
+Pytanie: `Stop & Upload` kończy nagrywanie, ale upload się ponawia. Co zrobić?
 Odpowiedź:
-1. Sprawdź panel pobranych plików w przeglądarce.
-2. Jeśli masz włączone pytanie o miejsce zapisu każdego pliku, powinno pojawić się okno zapisu.
-3. Niektóre menedżery pobierania albo rozszerzenia mogą przeszkadzać; wyłącz je i spróbuj ponownie.
+1. Sprawdź, czy `https://meet2note.com` działa i czy przeglądarka ma połączenie z siecią.
+2. Rozszerzenie ponawia pełną próbę uploadu co 15 sekund aż do sukcesu.
+3. Nie zamykaj przeglądarki ani nie przeładowuj rozszerzenia, bo gotowe bloby są trzymane w pamięci i mogą zostać utracone.
 
 Pytanie: Dlaczego przyciski w popupie nie włączają się albo nie wyłączają poprawnie?
 Odpowiedź:

--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,7 @@ services:
       HOST_GID: "${HOST_GID:-1000}"
       SENTRY_DSN: "${SENTRY_DSN:-}"
       SENTRY_ENVIRONMENT: "${SENTRY_ENVIRONMENT:-chrome-extension-dev}"
+      UPLOAD_API_BASE_URL: "${UPLOAD_API_BASE_URL:-https://meet2note.com}"
       npm_config_cache: /home/node/.npm
     volumes:
       - ./package.json:/workspace/package.json:ro

--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       HOST_UID: "${HOST_UID:-1000}"
       HOST_GID: "${HOST_GID:-1000}"
+      SENTRY_DSN: "${SENTRY_DSN:-}"
+      SENTRY_ENVIRONMENT: "${SENTRY_ENVIRONMENT:-chrome-extension-dev}"
       npm_config_cache: /home/node/.npm
     volumes:
       - ./package.json:/workspace/package.json:ro

--- a/docs/runbooks/002-smoke-test-po-zmianach.md
+++ b/docs/runbooks/002-smoke-test-po-zmianach.md
@@ -30,3 +30,4 @@ Szybko potwierdzic, ze build oraz najwazniejsze sciezki rozszerzenia dzialaja po
 - `dist/` laduje sie jako rozszerzenie bez bledow manifestu.
 - Strona konfiguracji mikrofonu pokazuje `Default microphone` i pozwala zapisac wybor.
 - Nagrywanie startuje, zatrzymuje sie i pobiera `.webm`, jesli dotknieto kodu recording/offscreen/permissions.
+- Na aktywnym spotkaniu Meet znacznik rozszerzenia pokazuje `RDY`, po starcie `REC`, a wyjscie ze spotkania zatrzymuje nagrywanie i pobiera `.webm`.

--- a/docs/runbooks/002-smoke-test-po-zmianach.md
+++ b/docs/runbooks/002-smoke-test-po-zmianach.md
@@ -21,13 +21,18 @@ Szybko potwierdzic, ze build oraz najwazniejsze sciezki rozszerzenia dzialaja po
 6. Kliknij `Enable Microphone` albo `Microphone Settings`.
 7. Na stronie konfiguracji wybierz `Default microphone`, zapisz wybór i wroc do testowanej karty.
 8. Jesli dostepne sa co najmniej dwa mikrofony, wybierz konkretny mikrofon, zapisz wybor i potwierdz, ze popup pokazuje zapisany mikrofon.
-9. Uruchom `Start Recording`, zatrzymaj nagranie i potwierdz pobranie pliku `.webm`.
-10. Sprawdz konsole service workera, offscreen document i karty testowej pod katem nowych bledow.
+9. Uruchom `Start Recording`, zatrzymaj nagranie przez `Stop & Upload` i potwierdz upload do `https://meet2note.com`.
+10. Potwierdz, ze Chrome nie pobiera lokalnego pliku `.webm`.
+11. Jesli testujesz retry, czasowo odetnij backend albo siec, zatrzymaj nagranie i potwierdz, ze popup pokazuje ponawianie uploadu co okolo 15 sekund.
+12. Przywroc backend albo siec i potwierdz, ze kolejna proba uploadu konczy sie sukcesem.
+13. Sprawdz konsole service workera, offscreen document i karty testowej pod katem nowych bledow.
 
 ## Kryteria zaliczenia
 
 - `make check` konczy sie sukcesem.
 - `dist/` laduje sie jako rozszerzenie bez bledow manifestu.
 - Strona konfiguracji mikrofonu pokazuje `Default microphone` i pozwala zapisac wybor.
-- Nagrywanie startuje, zatrzymuje sie i pobiera `.webm`, jesli dotknieto kodu recording/offscreen/permissions.
-- Na aktywnym spotkaniu Meet znacznik rozszerzenia pokazuje `RDY`, po starcie `REC`, a wyjscie ze spotkania zatrzymuje nagrywanie i pobiera `.webm`.
+- Nagrywanie startuje, zatrzymuje sie i wysyla assety do backendu, jesli dotknieto kodu recording/offscreen/upload/permissions.
+- Po sukcesie Chrome nie pobiera lokalnego `.webm`.
+- Na aktywnym spotkaniu Meet znacznik rozszerzenia pokazuje `RDY`, po starcie `REC`, a wyjscie ze spotkania zatrzymuje nagrywanie i uruchamia upload.
+- Przy bledzie uploadu popup pokazuje retry, a kolejna proba nastepuje co okolo 15 sekund.

--- a/docs/runbooks/002-smoke-test-po-zmianach.md
+++ b/docs/runbooks/002-smoke-test-po-zmianach.md
@@ -18,11 +18,15 @@ Szybko potwierdzic, ze build oraz najwazniejsze sciezki rozszerzenia dzialaja po
 3. Wlacz Developer mode.
 4. Kliknij Reload przy rozszerzeniu, jesli bylo juz zaladowane, albo Load unpacked i wybierz `dist/`.
 5. Otworz Google Meet albo inna karte testowa z odtwarzanym audio/wideo.
-6. Kliknij `Enable Microphone` w razie potrzeby, uruchom `Start Recording`, zatrzymaj nagranie i potwierdz pobranie pliku `.webm`.
-7. Sprawdz konsole service workera, offscreen document i karty testowej pod katem nowych bledow.
+6. Kliknij `Enable Microphone` albo `Microphone Settings`.
+7. Na stronie konfiguracji wybierz `Default microphone`, zapisz wybór i wroc do testowanej karty.
+8. Jesli dostepne sa co najmniej dwa mikrofony, wybierz konkretny mikrofon, zapisz wybor i potwierdz, ze popup pokazuje zapisany mikrofon.
+9. Uruchom `Start Recording`, zatrzymaj nagranie i potwierdz pobranie pliku `.webm`.
+10. Sprawdz konsole service workera, offscreen document i karty testowej pod katem nowych bledow.
 
 ## Kryteria zaliczenia
 
 - `make check` konczy sie sukcesem.
 - `dist/` laduje sie jako rozszerzenie bez bledow manifestu.
+- Strona konfiguracji mikrofonu pokazuje `Default microphone` i pozwala zapisac wybor.
 - Nagrywanie startuje, zatrzymuje sie i pobiera `.webm`, jesli dotknieto kodu recording/offscreen/permissions.

--- a/docs/specs/002-konfiguracja-mikrofonu.md
+++ b/docs/specs/002-konfiguracja-mikrofonu.md
@@ -72,7 +72,6 @@ Zmiana dotyczy tylko konfiguracji i użycia mikrofonu. Nie przywraca transkrypcj
 3. Format danych w `chrome.storage.local`
    a) `preferredMicDeviceId`: `string | null`
    b) `preferredMicLabel`: `string | null`
-   c) `preferredMicUpdatedAt`: `number`
 
 4. Użycie mikrofonu w offscreen
    a) `maybeGetMicStream()` odczytuje `preferredMicDeviceId` z `chrome.storage.local`.

--- a/docs/specs/003-upload-do-backendu-meet2note.md
+++ b/docs/specs/003-upload-do-backendu-meet2note.md
@@ -50,7 +50,7 @@ Zakres tej specyfikacji przygotowuje implementację po stronie wtyczki. Backend 
 ## Backend
 
 1. Repozytorium backendu:
-   a) lokalnie: `/Users/pawel.walaszek/playground/recording-backend`,
+   a) lokalnie: `$HOME/playground/recording-backend`,
    b) GitHub: `pawel-walaszek/recording-backend`.
 
 2. Stos technologiczny backendu:

--- a/docs/specs/003-upload-do-backendu-meet2note.md
+++ b/docs/specs/003-upload-do-backendu-meet2note.md
@@ -1,0 +1,264 @@
+# Specyfikacja: upload do backendu meet2note.com
+
+## Podsumowanie
+
+Celem zmiany jest przejście z pobierania lokalnego pliku `.webm` na bezpośredni upload nagrania do backendu działającego pod `https://meet2note.com`. Tę domenę traktujemy na razie jako środowisko deweloperskie/prod-like, bo system nie jest jeszcze faktycznie uruchomiony produkcyjnie. Wtyczka ma użyć uzgodnionego API backendu, a nie własnego, równoległego formatu komunikacji.
+
+Zakres tej specyfikacji przygotowuje implementację po stronie wtyczki. Backend pozostaje osobnym repozytorium i źródłem prawdy dla realnego zachowania API.
+
+## Cel
+
+1. Wysyłać nagrania z rozszerzenia bezpośrednio do `https://meet2note.com`.
+2. Użyć kontraktu uploadu z backendu:
+   a) `POST /api/upload/init`,
+   b) `PUT /api/upload/{recordingId}/video`,
+   c) opcjonalnie `PUT /api/upload/{recordingId}/microphone`,
+   d) `POST /api/upload/{recordingId}/complete`.
+3. Przekazywać `X-Upload-Token` zwrócony przez backend po inicjalizacji uploadu.
+4. Zachować diagnostykę błędów w Sentry dla problemów z uploadem.
+
+## Zakres
+
+1. W zakresie:
+   a) Dodanie konfiguracji bazowego URL backendu z domyślną wartością `https://meet2note.com`.
+   b) Dodanie klienta uploadu po stronie rozszerzenia.
+   c) Zmiana przepływu po zatrzymaniu nagrywania tak, aby nagranie było wysyłane do backendu zamiast pobierane lokalnie.
+   d) Usunięcie lokalnego pobierania nagrania jako domyślnego efektu zatrzymania nagrywania.
+   e) Zmiana nagrywania tak, aby domyślnie powstawały dwa assety: `video_audio` oraz `microphone`, jeśli mikrofon jest dostępny.
+   f) Dodanie wymaganej zgody Chrome na komunikację z `https://meet2note.com/*`.
+   g) Przekazywanie metadanych nagrania do `/api/upload/init`.
+   h) Obsługa błędów sieciowych, błędów HTTP i timeoutów.
+   i) Aktualizacja README, mapy systemu i runbooków.
+   j) Podbicie wersji rozszerzenia zgodnie z zasadami z `AGENTS.md`.
+
+2. Poza zakresem:
+   a) Implementacja backendu.
+   b) Autoryzacja użytkowników po stronie wtyczki, jeśli backend jeszcze jej nie wymaga.
+   c) Finalna normalizacja audio, transkodowanie i transkrypcja.
+   d) Integracje backendu z zewnętrznymi API lub usługami firm trzecich.
+   e) Publikacja wtyczki do Chrome Web Store.
+
+## Obecne zachowanie
+
+1. `src/offscreen.ts` nagrywa media przez `MediaRecorder` i zwraca blob URL.
+2. `src/background.ts` po zatrzymaniu nagrywania uruchamia pobranie pliku przez Chrome Downloads API.
+3. Popup pokazuje przycisk `Start Recording` / `Stop & Download`.
+4. Nagranie nie opuszcza przeglądarki poza lokalnym pobraniem pliku.
+5. Backend jest opisany w dokumentacji, ale wtyczka nie wykonuje do niego żadnych requestów.
+6. `src/offscreen.ts` obecnie miksuje mikrofon do jednego finalnego strumienia, więc surowy plik nie rozdziela audio karty i mikrofonu na osobne assety.
+
+## Backend
+
+1. Repozytorium backendu:
+   a) lokalnie: `/Users/pawel.walaszek/playground/recording-backend`,
+   b) GitHub: `pawel-walaszek/recording-backend`.
+
+2. Stos technologiczny backendu:
+   a) API: Node.js + TypeScript + NestJS + Fastify,
+   b) GUI: React + Vite + Ant Design,
+   c) workspace: pnpm workspaces,
+   d) lokalny start: `docker compose up -d`.
+
+3. Źródło ustaleń integracyjnych:
+   a) issue cross-repo po stronie wtyczki i backendu,
+   b) dokumentacja backendu, jeśli backend utrzymuje ją jako aktualną,
+   c) realne zachowanie endpointów `https://meet2note.com`.
+
+4. Środowiska:
+   a) lokalny backend: `http://localhost:3000`,
+   b) docelowy dev/prod-like backend wtyczki: `https://meet2note.com`.
+
+## Proponowana zmiana
+
+1. Konfiguracja backendu
+   a) Dodać jedno miejsce konfiguracji bazowego URL uploadu, np. `UPLOAD_API_BASE_URL`.
+   b) Domyślna wartość w buildzie deweloperskim wtyczki: `https://meet2note.com`.
+   c) Nie zapisywać sekretów, prywatnych tokenów ani danych Sentry w kodzie.
+   d) Dodać `https://meet2note.com/*` do `host_permissions`, bo wtyczka będzie wykonywać requesty do tego hosta z kontekstu rozszerzenia.
+   e) Nie dodawać szerszych uprawnień typu `https://*/*`.
+
+2. Inicjalizacja uploadu
+   a) Po zatrzymaniu nagrywania wtyczka wywołuje `POST /api/upload/init`.
+   b) Minimalne metadane:
+      - `title`,
+      - `meetingId`, jeśli da się go ustalić z Google Meet,
+      - `meetingTitle`, jeśli da się go ustalić bez kruchego parsowania UI,
+      - `startedAt`,
+      - `durationMs`.
+   c) Backend zwraca `recordingId`, `uploadToken` i `expiresAt`.
+   d) `title` budować deterministycznie z `meetingTitle`, a jeśli go nie ma, z hosta/ścieżki aktywnej karty i daty rozpoczęcia.
+   e) `meetingId` dla Google Meet brać z ostatniego segmentu ścieżki URL, jeśli pasuje do kodu spotkania.
+   f) Nie parsować agresywnie DOM Google Meet tylko po to, aby wydobyć nazwę spotkania.
+
+3. Upload assetów
+   a) Główny blob `video_audio` wysyłać do `PUT /api/upload/{recordingId}/video`.
+   b) Request ma używać `Content-Type: application/octet-stream`.
+   c) Request ma używać nagłówka `X-Upload-Token: <uploadToken>`.
+   d) Mikrofon nagrywać jako osobny asset `microphone`, jeśli strumień mikrofonu jest dostępny.
+   e) Asset `video_audio` ma zawierać obraz karty oraz audio karty, bez domiksowanego mikrofonu.
+   f) Asset `microphone` wysyłać do `PUT /api/upload/{recordingId}/microphone`.
+   g) Jeśli mikrofon jest niedostępny, wysłać tylko `video_audio`, a w `/complete` podać tylko faktycznie wysłane assety.
+   h) Surowy asset mikrofonu może mieć format `audio/webm` / Opus, ale request nadal używa `Content-Type: application/octet-stream`, zgodnie z kontraktem.
+   i) Po udanym uploadzie nie wywoływać Chrome Downloads API i nie pobierać lokalnego pliku `.webm`.
+
+4. Miejsce wykonania uploadu
+   a) Upload wykonywać w `offscreen.ts`, po zatrzymaniu `MediaRecorder` i zbudowaniu blobów.
+   b) `background.ts` ma koordynować lifecycle, badge, stan runtime i komunikaty do popupu, ale nie powinien przejmować dużych blobów tylko po to, żeby wykonać upload.
+   c) Uzasadnienie: offscreen już obsługuje media i pozostaje naturalnym miejscem dla finalizacji nagrania, a service worker MV3 może zostać uśpiony przy dłuższych operacjach.
+
+5. Zakończenie uploadu
+   a) Po pomyślnym uploadzie assetów wywołać `POST /api/upload/{recordingId}/complete`.
+   b) W body przekazać listę wysłanych assetów zgodną z kontraktem backendu.
+   c) Po sukcesie pokazać w popupie stan zakończonego uploadu.
+
+6. Obsługa błędów
+   a) Jeśli `/init` nie powiedzie się, nie rozpoczynać uploadu assetu.
+   b) Jeśli upload assetu nie powiedzie się, nie wywoływać `/complete`.
+   c) Błędy HTTP i błędy sieciowe logować przez istniejącą diagnostykę.
+   d) Komunikat w popupie ma być krótki, ale ma odróżniać błąd nagrywania od błędu uploadu.
+   e) Błąd uploadu nie powinien automatycznie uruchamiać lokalnego pobierania pliku jako fallbacku.
+   f) Nie logować `uploadToken`, pełnego URL z tokenem ani zawartości blobów.
+   g) Jeśli upload się nie powiedzie, zachować gotowe bloby w pamięci i ponawiać pełną próbę uploadu co 15 sekund aż do sukcesu.
+   h) Retry ma działać bez trwałego zapisu lokalnego; jeśli Chrome zamknie kontekst rozszerzenia albo przeglądarka zostanie zamknięta, nagranie może zostać utracone.
+   i) Każda próba po błędzie powinna zaczynać od nowego `/api/upload/init`, żeby nie polegać na częściowo zużytej sesji uploadu.
+
+7. Stan runtime i popup
+   a) Wprowadzić stany: `idle`, `recording`, `stopping`, `uploading`, `upload_retrying`, `uploaded`.
+   b) Stan krótkotrwały zapisywać w `chrome.storage.session`, tak jak obecny stan nagrywania.
+   c) Popup po otwarciu ma odczytać aktualny stan i pokazać właściwą etykietę oraz status.
+   d) Podczas `uploading` przycisk start/stop ma być zablokowany albo ma jasno pokazywać, że trwa finalizacja.
+   e) Podczas retry status powinien jasno informować, że upload jest ponawiany i że kolejna próba nastąpi za około 15 sekund.
+
+8. UI
+   a) Przycisk nie powinien sugerować pobrania, jeśli domyślną akcją jest upload.
+   b) Etykietę `Stop & Download` zmienić na `Stop & Upload`.
+   c) Timer nagrywania pozostaje bez zmian w trakcie nagrywania.
+   d) Po zatrzymaniu timer może zostać zastąpiony statusem uploadu, np. `Uploading...`, `Retrying upload...`, `Uploaded`.
+   e) Nie dodawać lokalnego przycisku download w ramach tej zmiany.
+
+## Decyzje projektowe
+
+1. `https://meet2note.com` traktujemy jako dev/prod-like.
+   a) Uzasadnienie: domena już odpowiada, ale projekt nie jest jeszcze live produkcyjnie.
+
+2. API backendu jest nadrzędne wobec lokalnych pomysłów wtyczki.
+   a) Uzasadnienie: backend będzie obsługiwał dalszą normalizację, transkodowanie, transkrypcję i udostępnianie.
+
+3. Na start nie dokładamy autoryzacji użytkownika w rozszerzeniu, jeśli backend jej jeszcze nie egzekwuje.
+   a) Uzasadnienie: aktualny kontrakt uploadu opiera się na `uploadToken` zwracanym przez `/init`.
+
+4. Nie kodujemy integracji z zewnętrznymi usługami po stronie wtyczki.
+   a) Uzasadnienie: integracje typu storage, AI/transkrypcja i przetwarzanie mają należeć do backendu.
+
+5. Upload zastępuje lokalny zapis nagrania.
+   a) Uzasadnienie: docelowo użytkownik nie ma pracować na surowym pliku `.webm`; nagranie ma trafić do backendu, gdzie będzie dalej przetwarzane, normalizowane i udostępniane.
+   b) Lokalny download nie jest fallbackiem dla błędów uploadu.
+   c) Ewentualny ręczny eksport lokalnego pliku może wrócić tylko jako osobna funkcja po jawnej decyzji.
+   d) Przy błędzie uploadu wtyczka nie pobiera pliku lokalnie, tylko ponawia upload co 15 sekund aż do sukcesu.
+
+6. Mikrofon wysyłamy jako osobny asset, nie jako miks w `video_audio`.
+   a) Uzasadnienie: backend ma docelowo normalizować poziomy audio i dopiero potem łączyć ścieżki.
+   b) `video_audio` oznacza obraz karty oraz audio karty.
+   c) `microphone` oznacza surowe audio z wybranego mikrofonu.
+   d) Jeśli mikrofon jest niedostępny, upload bez mikrofonu nadal jest poprawnym, zdegradowanym przepływem.
+
+7. Upload wykonywany jest w offscreen.
+   a) Uzasadnienie: offscreen posiada blob po finalizacji `MediaRecorder` i lepiej pasuje do długich operacji media niż service worker.
+   b) `background.ts` pozostaje koordynatorem stanu i komunikacji z popupem.
+
+8. Zmiana wersji rozszerzenia powinna być podbiciem minor.
+   a) Uzasadnienie: zastąpienie lokalnego downloadu uploadem do backendu to istotna zmiana zachowania.
+   b) Dla obecnej linii `1.5.x` oczekiwany kolejny numer to `1.6.0`, chyba że przed implementacją wersja w `manifest.json` będzie już wyższa.
+
+9. Retry uploadu trwa do skutku.
+   a) Po błędzie wtyczka ponawia pełną próbę uploadu co 15 sekund.
+   b) Retry nie ma limitu liczby prób po stronie wtyczki.
+   c) Wtyczka nie zapisuje nagrania lokalnie na dysku jako mechanizmu retry.
+   d) Retry działa tak długo, jak długo Chrome utrzymuje kontekst rozszerzenia z blobami w pamięci.
+
+## Niejednoznaczności rozstrzygnięte w specyfikacji
+
+1. Czy produkcyjnie wyglądająca domena `https://meet2note.com` ma być traktowana ostrożnie jak produkcja?
+   a) Nie na tym etapie. Dla tej zmiany traktujemy ją jako środowisko dev/prod-like.
+
+2. Czy wtyczka ma wymyślać własny endpoint uploadu?
+   a) Nie. Używa API uzgodnionego z `recording-backend`.
+
+3. Czy upload ma zawierać osobny asset mikrofonu?
+   a) Tak, jeśli mikrofon jest dostępny.
+   b) Implementacja ma przestać traktować miks mikrofonu do `video_audio` jako domyślny format docelowy dla uploadu.
+
+4. Czy po udanym uploadzie wtyczka ma nadal pobierać lokalny plik `.webm`?
+   a) Nie. Upload do `https://meet2note.com` zastępuje pobieranie.
+   b) Nie dodajemy też automatycznego lokalnego pobierania jako fallbacku przy błędzie uploadu.
+
+5. Czy `https://meet2note.com/*` trzeba dodać do `host_permissions`?
+   a) Tak. Wtyczka będzie wykonywać requesty do tego hosta, więc uprawnienie ma być jawne i wąskie.
+
+6. Czy upload ma być w `background.ts` czy w `offscreen.ts`?
+   a) W `offscreen.ts`, bo tam powstają bloby po nagrywaniu.
+   b) `background.ts` tylko przekazuje stan i koordynuje lifecycle.
+
+7. Jaką etykietę ma mieć przycisk zatrzymania?
+   a) `Stop & Upload`.
+
+8. Co zrobić z gotowym nagraniem, jeśli upload do backendu się nie powiedzie?
+   a) Zachować gotowe bloby w pamięci i ponawiać upload co 15 sekund aż do sukcesu.
+   b) Nie pobierać lokalnego pliku i nie zapisywać trwałej kopii nagrania na dysku.
+   c) Jeśli kontekst rozszerzenia zostanie zamknięty przez Chrome albo użytkownik zamknie przeglądarkę, retry może zostać przerwany, a nagranie utracone.
+
+## Kryteria akceptacji
+
+1. Wtyczka po zatrzymaniu nagrywania inicjuje upload przez `POST /api/upload/init`.
+2. Wtyczka wysyła główny blob do `PUT /api/upload/{recordingId}/video`.
+3. Wtyczka wysyła osobny blob mikrofonu do `PUT /api/upload/{recordingId}/microphone`, jeśli mikrofon jest dostępny.
+4. Wtyczka przekazuje `X-Upload-Token` przy uploadzie assetów i przy `/complete`.
+5. Wtyczka kończy upload przez `POST /api/upload/{recordingId}/complete`.
+6. Body `/complete` zawiera tylko faktycznie wysłane assety.
+7. Po udanym uploadzie wtyczka nie pobiera lokalnego pliku `.webm`.
+8. Przy błędzie uploadu wtyczka nie uruchamia automatycznego lokalnego pobierania.
+9. Przy błędzie uploadu wtyczka ponawia pełny upload co 15 sekund aż do sukcesu.
+10. Popup pokazuje stan uploadu i informację o retry.
+11. Błędy uploadu trafiają do istniejącej diagnostyki bez tokenów i bez zawartości nagrań.
+12. README i mapa systemu opisują nowy przepływ bez lokalnego zapisu jako domyślnej ścieżki.
+13. `manifest.json` ma `host_permissions` ograniczone do niezbędnych domen, w tym `https://meet2note.com/*`.
+14. `manifest.json` ma podbitą wersję zgodnie z zasadą minor dla tej zmiany.
+15. `make check` przechodzi.
+
+## Weryfikacja
+
+1. Uruchomić:
+
+```bash
+make check
+```
+
+2. Załadować świeże `dist/` w `chrome://extensions`.
+3. Wykonać krótkie nagranie na stronie testowej albo w Google Meet.
+4. Zatrzymać nagrywanie i potwierdzić requesty:
+   a) `POST /api/upload/init`,
+   b) `PUT /api/upload/{recordingId}/video`,
+   c) `PUT /api/upload/{recordingId}/microphone`, jeśli mikrofon jest dostępny,
+   d) `POST /api/upload/{recordingId}/complete`.
+5. Potwierdzić po stronie backendu, że nagranie jest widoczne jako rekord uploadu.
+6. Potwierdzić, że po sukcesie Chrome nie pobiera lokalnego `.webm`.
+7. Wymusić błąd backendu albo sieci i potwierdzić, że popup pokazuje retry uploadu.
+8. Przywrócić backend albo sieć i potwierdzić, że kolejna próba po maksymalnie około 15 sekundach kończy upload sukcesem.
+9. Potwierdzić, że Sentry dostaje diagnostykę błędów bez tokenów i bez zawartości nagrania.
+
+## Ryzyka
+
+1. CORS albo konfiguracja proxy na `https://meet2note.com` może blokować requesty z rozszerzenia.
+   a) Mitigacja: sprawdzić requesty z `chrome-extension://...` i w razie potrzeby poprawić backend/proxy.
+
+2. Duże pliki `.webm` mogą powodować timeout albo wysokie zużycie pamięci.
+   a) Mitigacja: w pierwszym kroku wysyłać cały blob, ale zostawić w dokumentacji miejsce na późniejszy upload chunkowany.
+
+3. Service worker MV3 może zostać uśpiony podczas długiego uploadu.
+   a) Mitigacja: wykonać upload w offscreen document i utrzymywać kontrolowany przepływ finalizacji.
+
+4. Backend może mieć jeszcze placeholderową obsługę storage.
+   a) Mitigacja: przed implementacją sprawdzić aktualny stan `recording-backend`, powiązane issue i realne zachowanie API.
+
+5. Zmiana z pobierania na upload zmienia oczekiwania użytkownika.
+   a) Mitigacja: jednoznacznie zmienić etykiety UI i README.

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -6,6 +6,12 @@ To repozytorium buduje rozszerzenie Chrome Manifest V3 do nagrywania spotkań w 
 
 Rozszerzenie nagrywa bieżącą kartę do lokalnego pliku `.webm`. Nagrywanie odbywa się w przeglądarce, bez backendu.
 
+Docelowy backend dla uploadu i przetwarzania nagrań będzie rozwijany w powiązanym repozytorium `recording-backend`:
+
+1. Lokalnie: `/Users/pawel.walaszek/playground/recording-backend`.
+2. GitHub: `pawel-walaszek/recording-backend`.
+3. Kontrakt integracyjny będzie utrzymywany w `docs/contracts/recording-upload.openapi.yml` po stronie backendu, gdy zostanie utworzony.
+
 ## Komponenty
 
 | Komponent | Ścieżka | Rola |

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -4,13 +4,15 @@
 
 To repozytorium buduje rozszerzenie Chrome Manifest V3 do nagrywania spotkań w przeglądarce.
 
-Rozszerzenie nagrywa bieżącą kartę do lokalnego pliku `.webm`. Nagrywanie odbywa się w przeglądarce, bez backendu.
+Rozszerzenie nagrywa bieżącą kartę i wysyła assety bezpośrednio do backendu działającego pod `https://meet2note.com`. Na obecnym etapie ta domena jest traktowana jako środowisko deweloperskie/prod-like, bo aplikacja nie jest jeszcze faktycznie uruchomiona produkcyjnie.
 
 Docelowy backend dla uploadu i przetwarzania nagrań będzie rozwijany w powiązanym repozytorium `recording-backend`:
 
 1. Lokalnie: `/Users/pawel.walaszek/playground/recording-backend`.
 2. GitHub: `pawel-walaszek/recording-backend`.
-3. Kontrakt integracyjny będzie utrzymywany w `docs/contracts/recording-upload.openapi.yml` po stronie backendu, gdy zostanie utworzony.
+3. Lokalny API base URL: `http://localhost:3000`.
+4. Dev/prod-like API base URL dla wtyczki: `https://meet2note.com`.
+5. Ustalenia integracyjne są utrzymywane w issue cross-repo, specyfikacjach i dokumentacji projektu.
 
 ## Komponenty
 
@@ -19,18 +21,32 @@ Docelowy backend dla uploadu i przetwarzania nagrań będzie rozwijany w powiąz
 | Manifest | `manifest.json` | Deklaruje metadane MV3, uprawnienia, worker tła i dostępne zasoby. |
 | Popup | `popup.html`, `src/popup.ts` | Kontrolki użytkownika do otwierania ustawień mikrofonu oraz startu/stopu nagrywania. |
 | Watcher Google Meet | `src/meetWatcher.ts`, `manifest.json` | Content script na `meet.google.com`, który wykrywa aktywne spotkanie i opuszczenie spotkania. |
-| Service worker tła | `src/background.ts` | Koordynuje przechwytywanie karty, cykl życia dokumentu offscreen, stan nagrywania, znacznik i pobieranie plików. |
-| Nagrywarka offscreen | `offscreen.html`, `src/offscreen.ts` | Przechwytuje media z karty, opcjonalnie miksuje audio mikrofonu, nagrywa przez `MediaRecorder` i zwraca URL blobu do pobrania. |
+| Service worker tła | `src/background.ts` | Koordynuje przechwytywanie karty, cykl życia dokumentu offscreen, stan nagrywania/uploadu i znaczniki. |
+| Nagrywarka offscreen | `offscreen.html`, `src/offscreen.ts` | Przechwytuje media z karty, nagrywa osobny asset mikrofonu, finalizuje bloby i wysyła je do backendu. |
+| Klient uploadu | `src/uploadClient.ts` | Wykonuje kontrakt uploadu backendu: `/init`, upload assetów, `/complete`. |
 | Strona konfiguracji mikrofonu | `micsetup.html`, `src/micsetup.ts` | Widoczna strona rozszerzenia używana do nadania uprawnienia mikrofonu, wyboru urządzenia i zapisu konfiguracji w `chrome.storage.local`. |
 | Preferencje mikrofonu | `src/micPreferences.ts` | Wspólne klucze i helpery `chrome.storage.local` dla zapisanego wyboru mikrofonu. |
 | Diagnostyka Sentry | `src/diagnostics.ts`, `scripts/sentry-public-dsn.sh`, `Makefile` | Opcjonalnie inicjalizuje Sentry, jeśli build ma dostęp do publicznego DSN albo sekretów pozwalających pobrać DSN przez API. |
 | Build kontenerowy | `compose.yml`, `Makefile` | Domyślny lokalny punkt wejścia do builda i walidacji. Uruchamia npm w Docker Compose bez lokalnego Node.js. |
 | Build webpacka | `webpack.config.js`, `tsconfig.json` | Kompiluje entrypointy TypeScript i kopiuje statyczne pliki rozszerzenia do `dist/`. |
+| Backend uploadu | `/Users/pawel.walaszek/playground/recording-backend` | NestJS + Fastify API oraz React + Vite + Ant Design GUI dla uploadu, przetwarzania i udostępniania nagrań. |
+
+## API Uploadu
+
+Ten opis dokumentuje aktualne ustalenia integracyjne między wtyczką i backendem.
+
+1. Rozszerzenie inicjuje upload przez `POST /api/upload/init`.
+2. Backend zwraca `recordingId`, `uploadToken` oraz `expiresAt`.
+3. Rozszerzenie wysyła główny asset `video_audio` przez `PUT /api/upload/{recordingId}/video`.
+4. Jeśli mikrofon jest dostępny, rozszerzenie wysyła osobny asset `microphone` przez `PUT /api/upload/{recordingId}/microphone`.
+5. Każdy upload assetu używa nagłówka `X-Upload-Token`.
+6. Rozszerzenie kończy upload przez `POST /api/upload/{recordingId}/complete`.
+7. Jeśli upload się nie powiedzie, offscreen ponawia pełny upload co 15 sekund aż do sukcesu, bez lokalnego zapisu pliku.
 
 ## Granice uruchomieniowe
 
-1. Pliki wynikowe są zapisywane lokalnie przez Chrome Downloads API.
-2. Rozszerzenie nie wymaga backendu, bazy danych ani przechowywania w chmurze.
+1. Pliki wynikowe trafiają bezpośrednio do `https://meet2note.com`, bez automatycznego pobierania lokalnego `.webm`.
+2. Gotowe bloby są trzymane tylko w pamięci na czas uploadu i retry.
 3. Wybór mikrofonu jest zapisywany lokalnie w `chrome.storage.local`.
 4. Content script na Google Meet nie czyta ani nie wysyła treści spotkania; wykrywa tylko stan obecności w spotkaniu.
 5. `dist/` jest wygenerowanym wynikiem builda i nie powinien być edytowany ręcznie.
@@ -39,6 +55,6 @@ Docelowy backend dla uploadu i przetwarzania nagrań będzie rozwijany w powiąz
 
 1. Uruchom `make check`.
 2. Załaduj `dist/` w `chrome://extensions`.
-3. Sprawdź start/stop nagrywania i pobieranie pliku, jeśli zmieniasz kod przechwytywania, offscreen albo uprawnień.
+3. Sprawdź start/stop nagrywania, upload do backendu i retry, jeśli zmieniasz kod przechwytywania, offscreen, uploadu albo uprawnień.
 
 GitHub Actions może nadal wywoływać skrypty npm bezpośrednio, ale wspierany lokalny przepływ pracy to `make`.

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -8,7 +8,7 @@ Rozszerzenie nagrywa bieżącą kartę i wysyła assety bezpośrednio do backend
 
 Docelowy backend dla uploadu i przetwarzania nagrań będzie rozwijany w powiązanym repozytorium `recording-backend`:
 
-1. Lokalnie: `/Users/pawel.walaszek/playground/recording-backend`.
+1. Lokalnie: `$HOME/playground/recording-backend`.
 2. GitHub: `pawel-walaszek/recording-backend`.
 3. Lokalny API base URL: `http://localhost:3000`.
 4. Dev/prod-like API base URL dla wtyczki: `https://meet2note.com`.
@@ -29,7 +29,7 @@ Docelowy backend dla uploadu i przetwarzania nagrań będzie rozwijany w powiąz
 | Diagnostyka Sentry | `src/diagnostics.ts`, `scripts/sentry-public-dsn.sh`, `Makefile` | Opcjonalnie inicjalizuje Sentry, jeśli build ma dostęp do publicznego DSN albo sekretów pozwalających pobrać DSN przez API. |
 | Build kontenerowy | `compose.yml`, `Makefile` | Domyślny lokalny punkt wejścia do builda i walidacji. Uruchamia npm w Docker Compose bez lokalnego Node.js. |
 | Build webpacka | `webpack.config.js`, `tsconfig.json` | Kompiluje entrypointy TypeScript i kopiuje statyczne pliki rozszerzenia do `dist/`. |
-| Backend uploadu | `/Users/pawel.walaszek/playground/recording-backend` | NestJS + Fastify API oraz React + Vite + Ant Design GUI dla uploadu, przetwarzania i udostępniania nagrań. |
+| Backend uploadu | `$HOME/playground/recording-backend` | NestJS + Fastify API oraz React + Vite + Ant Design GUI dla uploadu, przetwarzania i udostępniania nagrań. |
 
 ## API Uploadu
 

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -12,6 +12,7 @@ Rozszerzenie nagrywa bieżącą kartę do lokalnego pliku `.webm`. Nagrywanie od
 | --- | --- | --- |
 | Manifest | `manifest.json` | Deklaruje metadane MV3, uprawnienia, worker tła i dostępne zasoby. |
 | Popup | `popup.html`, `src/popup.ts` | Kontrolki użytkownika do otwierania ustawień mikrofonu oraz startu/stopu nagrywania. |
+| Watcher Google Meet | `src/meetWatcher.ts`, `manifest.json` | Content script na `meet.google.com`, który wykrywa aktywne spotkanie i opuszczenie spotkania. |
 | Service worker tła | `src/background.ts` | Koordynuje przechwytywanie karty, cykl życia dokumentu offscreen, stan nagrywania, znacznik i pobieranie plików. |
 | Nagrywarka offscreen | `offscreen.html`, `src/offscreen.ts` | Przechwytuje media z karty, opcjonalnie miksuje audio mikrofonu, nagrywa przez `MediaRecorder` i zwraca URL blobu do pobrania. |
 | Strona konfiguracji mikrofonu | `micsetup.html`, `src/micsetup.ts` | Widoczna strona rozszerzenia używana do nadania uprawnienia mikrofonu, wyboru urządzenia i zapisu konfiguracji w `chrome.storage.local`. |
@@ -25,7 +26,8 @@ Rozszerzenie nagrywa bieżącą kartę do lokalnego pliku `.webm`. Nagrywanie od
 1. Pliki wynikowe są zapisywane lokalnie przez Chrome Downloads API.
 2. Rozszerzenie nie wymaga backendu, bazy danych ani przechowywania w chmurze.
 3. Wybór mikrofonu jest zapisywany lokalnie w `chrome.storage.local`.
-4. `dist/` jest wygenerowanym wynikiem builda i nie powinien być edytowany ręcznie.
+4. Content script na Google Meet nie czyta ani nie wysyła treści spotkania; wykrywa tylko stan obecności w spotkaniu.
+5. `dist/` jest wygenerowanym wynikiem builda i nie powinien być edytowany ręcznie.
 
 ## Lokalna walidacja
 

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -16,6 +16,7 @@ Rozszerzenie nagrywa bieżącą kartę do lokalnego pliku `.webm`. Nagrywanie od
 | Nagrywarka offscreen | `offscreen.html`, `src/offscreen.ts` | Przechwytuje media z karty, opcjonalnie miksuje audio mikrofonu, nagrywa przez `MediaRecorder` i zwraca URL blobu do pobrania. |
 | Strona konfiguracji mikrofonu | `micsetup.html`, `src/micsetup.ts` | Widoczna strona rozszerzenia używana do nadania uprawnienia mikrofonu, wyboru urządzenia i zapisu konfiguracji w `chrome.storage.local`. |
 | Preferencje mikrofonu | `src/micPreferences.ts` | Wspólne klucze i helpery `chrome.storage.local` dla zapisanego wyboru mikrofonu. |
+| Diagnostyka Sentry | `src/diagnostics.ts`, `scripts/sentry-public-dsn.sh`, `Makefile` | Opcjonalnie inicjalizuje Sentry, jeśli build ma dostęp do publicznego DSN albo sekretów pozwalających pobrać DSN przez API. |
 | Build kontenerowy | `compose.yml`, `Makefile` | Domyślny lokalny punkt wejścia do builda i walidacji. Uruchamia npm w Docker Compose bez lokalnego Node.js. |
 | Build webpacka | `webpack.config.js`, `tsconfig.json` | Kompiluje entrypointy TypeScript i kopiuje statyczne pliki rozszerzenia do `dist/`. |
 

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -15,6 +15,7 @@ Rozszerzenie nagrywa bieżącą kartę do lokalnego pliku `.webm`. Nagrywanie od
 | Service worker tła | `src/background.ts` | Koordynuje przechwytywanie karty, cykl życia dokumentu offscreen, stan nagrywania, znacznik i pobieranie plików. |
 | Nagrywarka offscreen | `offscreen.html`, `src/offscreen.ts` | Przechwytuje media z karty, opcjonalnie miksuje audio mikrofonu, nagrywa przez `MediaRecorder` i zwraca URL blobu do pobrania. |
 | Strona konfiguracji mikrofonu | `micsetup.html`, `src/micsetup.ts` | Widoczna strona rozszerzenia używana do nadania uprawnienia mikrofonu, wyboru urządzenia i zapisu konfiguracji w `chrome.storage.local`. |
+| Preferencje mikrofonu | `src/micPreferences.ts` | Wspólne klucze i helpery `chrome.storage.local` dla zapisanego wyboru mikrofonu. |
 | Build kontenerowy | `compose.yml`, `Makefile` | Domyślny lokalny punkt wejścia do builda i walidacji. Uruchamia npm w Docker Compose bez lokalnego Node.js. |
 | Build webpacka | `webpack.config.js`, `tsconfig.json` | Kompiluje entrypointy TypeScript i kopiuje statyczne pliki rozszerzenia do `dist/`. |
 

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -11,10 +11,10 @@ Rozszerzenie nagrywa bieżącą kartę do lokalnego pliku `.webm`. Nagrywanie od
 | Komponent | Ścieżka | Rola |
 | --- | --- | --- |
 | Manifest | `manifest.json` | Deklaruje metadane MV3, uprawnienia, worker tła i dostępne zasoby. |
-| Popup | `popup.html`, `src/popup.ts` | Kontrolki użytkownika do nadawania uprawnień mikrofonu oraz startu/stopu nagrywania. |
+| Popup | `popup.html`, `src/popup.ts` | Kontrolki użytkownika do otwierania ustawień mikrofonu oraz startu/stopu nagrywania. |
 | Service worker tła | `src/background.ts` | Koordynuje przechwytywanie karty, cykl życia dokumentu offscreen, stan nagrywania, znacznik i pobieranie plików. |
 | Nagrywarka offscreen | `offscreen.html`, `src/offscreen.ts` | Przechwytuje media z karty, opcjonalnie miksuje audio mikrofonu, nagrywa przez `MediaRecorder` i zwraca URL blobu do pobrania. |
-| Strona konfiguracji mikrofonu | `micsetup.html`, `src/micsetup.ts` | Widoczna strona rozszerzenia używana do nadania uprawnienia mikrofonu, gdy prośba o dostęp w popupie jest zawodna. |
+| Strona konfiguracji mikrofonu | `micsetup.html`, `src/micsetup.ts` | Widoczna strona rozszerzenia używana do nadania uprawnienia mikrofonu, wyboru urządzenia i zapisu konfiguracji w `chrome.storage.local`. |
 | Build kontenerowy | `compose.yml`, `Makefile` | Domyślny lokalny punkt wejścia do builda i walidacji. Uruchamia npm w Docker Compose bez lokalnego Node.js. |
 | Build webpacka | `webpack.config.js`, `tsconfig.json` | Kompiluje entrypointy TypeScript i kopiuje statyczne pliki rozszerzenia do `dist/`. |
 
@@ -22,7 +22,8 @@ Rozszerzenie nagrywa bieżącą kartę do lokalnego pliku `.webm`. Nagrywanie od
 
 1. Pliki wynikowe są zapisywane lokalnie przez Chrome Downloads API.
 2. Rozszerzenie nie wymaga backendu, bazy danych ani przechowywania w chmurze.
-3. `dist/` jest wygenerowanym wynikiem builda i nie powinien być edytowany ręcznie.
+3. Wybór mikrofonu jest zapisywany lokalnie w `chrome.storage.local`.
+4. `dist/` jest wygenerowanym wynikiem builda i nie powinien być edytowany ręcznie.
 
 ## Lokalna walidacja
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "permissions": ["activeTab", "downloads", "tabCapture", "offscreen", "storage", "tabs", "desktopCapture"],
     "host_permissions": ["https://sentry.eengine.pl/*"],
     "action": { "default_popup": "popup.html" },

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,9 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.3.0",
+    "version": "1.4.1",
     "permissions": ["activeTab", "downloads", "tabCapture", "offscreen", "storage", "tabs", "desktopCapture"],
+    "host_permissions": ["https://sentry.eengine.pl/*"],
     "action": { "default_popup": "popup.html" },
     "background": { "service_worker": "background.js", "type": "module" },
     "web_accessible_resources": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "permissions": ["activeTab", "downloads", "tabCapture", "offscreen", "storage", "tabs", "desktopCapture"],
     "host_permissions": ["https://sentry.eengine.pl/*"],
     "action": { "default_popup": "popup.html" },

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.6.5",
+    "version": "1.6.6",
     "permissions": ["activeTab", "tabCapture", "offscreen", "storage", "tabs", "desktopCapture"],
     "host_permissions": ["https://sentry.eengine.pl/*", "https://meet2note.com/*"],
     "action": { "default_popup": "popup.html" },

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "Google Meet Recorder",
     "version": "1.5.0",
     "permissions": ["activeTab", "downloads", "tabCapture", "offscreen", "storage", "tabs", "desktopCapture"],
-    "host_permissions": ["https://meet.google.com/*", "https://sentry.eengine.pl/*"],
+    "host_permissions": ["https://sentry.eengine.pl/*"],
     "action": { "default_popup": "popup.html" },
     "background": { "service_worker": "background.js", "type": "module" },
     "content_scripts": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.6.4",
+    "version": "1.6.5",
     "permissions": ["activeTab", "tabCapture", "offscreen", "storage", "tabs", "desktopCapture"],
     "host_permissions": ["https://sentry.eengine.pl/*", "https://meet2note.com/*"],
     "action": { "default_popup": "popup.html" },

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,18 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.4.1",
+    "version": "1.5.0",
     "permissions": ["activeTab", "downloads", "tabCapture", "offscreen", "storage", "tabs", "desktopCapture"],
-    "host_permissions": ["https://sentry.eengine.pl/*"],
+    "host_permissions": ["https://meet.google.com/*", "https://sentry.eengine.pl/*"],
     "action": { "default_popup": "popup.html" },
     "background": { "service_worker": "background.js", "type": "module" },
+    "content_scripts": [
+      {
+        "matches": ["https://meet.google.com/*"],
+        "js": ["meetWatcher.js"],
+        "run_at": "document_idle"
+      }
+    ],
     "web_accessible_resources": [
       { "resources": ["offscreen.html"], "matches": ["<all_urls>"] }
     ]

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "permissions": ["activeTab", "downloads", "tabCapture", "offscreen", "storage", "tabs", "desktopCapture"],
     "action": { "default_popup": "popup.html" },
     "background": { "service_worker": "background.js", "type": "module" },

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.5.2",
-    "permissions": ["activeTab", "downloads", "tabCapture", "offscreen", "storage", "tabs", "desktopCapture"],
-    "host_permissions": ["https://sentry.eengine.pl/*"],
+    "version": "1.6.4",
+    "permissions": ["activeTab", "tabCapture", "offscreen", "storage", "tabs", "desktopCapture"],
+    "host_permissions": ["https://sentry.eengine.pl/*", "https://meet2note.com/*"],
     "action": { "default_popup": "popup.html" },
     "background": { "service_worker": "background.js", "type": "module" },
     "content_scripts": [

--- a/micsetup.html
+++ b/micsetup.html
@@ -6,7 +6,7 @@
 </head>
 <body>
   <h3>Microphone Settings</h3>
-  <p>Choose which microphone should be mixed into recordings.</p>
+  <p>Choose which microphone should be recorded.</p>
   <button id="enable">Enable / Refresh Microphones</button>
   <p>
     <label for="mic-select">Microphone</label><br>

--- a/micsetup.html
+++ b/micsetup.html
@@ -2,12 +2,17 @@
 <html>
 <head>
   <meta charset="utf-8" />
-  <title>Enable Microphone</title>
+  <title>Microphone Settings</title>
 </head>
 <body>
-  <h3>Enable microphone for the extension</h3>
-  <p>Click the button below and Allow the microphone when prompted.</p>
-  <button id="enable">Enable Microphone</button>
+  <h3>Microphone Settings</h3>
+  <p>Choose which microphone should be mixed into recordings.</p>
+  <button id="enable">Enable / Refresh Microphones</button>
+  <p>
+    <label for="mic-select">Microphone</label><br>
+    <select id="mic-select" disabled></select>
+  </p>
+  <button id="save-mic" disabled>Save Microphone</button>
   <p id="status"></p>
   <script src="micsetup.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
             "name": "google-meet-recorder-extension",
             "version": "1.0.0",
             "license": "ISC",
+            "dependencies": {
+                "@sentry/browser": "^10.50.0"
+            },
             "devDependencies": {
                 "@types/chrome": "^0.0.326",
                 "@types/node": "^24.0.4",
@@ -91,6 +94,81 @@
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
+        "node_modules/@sentry-internal/browser-utils": {
+            "version": "10.50.0",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.50.0.tgz",
+            "integrity": "sha512-42bxyRTxnCmYlWnvz4CxikuQNanw8UNma2WJrtxJ0f1MAJV2GhQGSHDLnA+lvFlmiz6qct3pfen/NXGyOTegTA==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/core": "10.50.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry-internal/feedback": {
+            "version": "10.50.0",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.50.0.tgz",
+            "integrity": "sha512-0k9XZF0wn86f77mIO2U3gNNyDZooy139CnEanRzHinrN106vVzvBZ6TUEQoHtoO1fqQxr+nWWVrqV/PXUqk47w==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/core": "10.50.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry-internal/replay": {
+            "version": "10.50.0",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.50.0.tgz",
+            "integrity": "sha512-51FYNfnvVLAWw1rrEWPFfwHuMRb9mkVCFGA4J9/un7SpeGBsQDziGB0Di4fsCxI7+EdSBpfLHPF0csKtCCw0oQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry-internal/browser-utils": "10.50.0",
+                "@sentry/core": "10.50.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry-internal/replay-canvas": {
+            "version": "10.50.0",
+            "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.50.0.tgz",
+            "integrity": "sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry-internal/replay": "10.50.0",
+                "@sentry/core": "10.50.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/browser": {
+            "version": "10.50.0",
+            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.50.0.tgz",
+            "integrity": "sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry-internal/browser-utils": "10.50.0",
+                "@sentry-internal/feedback": "10.50.0",
+                "@sentry-internal/replay": "10.50.0",
+                "@sentry-internal/replay-canvas": "10.50.0",
+                "@sentry/core": "10.50.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/core": {
+            "version": "10.50.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.50.0.tgz",
+            "integrity": "sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@types/chrome": {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "keywords": [],
     "author": "",
     "license": "ISC",
-    "description": ""
+    "description": "",
+    "dependencies": {
+        "@sentry/browser": "^10.50.0"
+    }
 }

--- a/popup.html
+++ b/popup.html
@@ -5,8 +5,8 @@
     <button id="enable-mic">Enable Microphone</button>
     <div id="mic-status" style="font-size: 12px; margin-top: 4px;"></div>
     <hr/>
-    <button id="start-rec">Start Recording</button>
-    <button id="stop-rec" disabled>Stop & Download</button>
+    <button id="recording-toggle">Start Recording</button>
+    <div id="recording-status" style="font-size: 12px; margin-top: 4px;">Not recording</div>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -3,6 +3,7 @@
   <head><title>Google Meet Helper</title></head>
   <body>
     <button id="enable-mic">Enable Microphone</button>
+    <div id="mic-status" style="font-size: 12px; margin-top: 4px;"></div>
     <hr/>
     <button id="start-rec">Start Recording</button>
     <button id="stop-rec" disabled>Stop & Download</button>

--- a/scripts/sentry-public-dsn.sh
+++ b/scripts/sentry-public-dsn.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+secrets_file="${CODEX_SECRETS:-$HOME/.codex/.secrets}"
+
+if [ -f "$secrets_file" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$secrets_file"
+  set +a
+fi
+
+if [ -n "${SENTRY_DSN:-}" ]; then
+  printf '%s\n' "$SENTRY_DSN"
+  exit 0
+fi
+
+if [ -z "${SENTRY_AUTH_TOKEN:-}" ] ||
+   [ -z "${SENTRY_ORG_SLUG:-}" ] ||
+   [ -z "${SENTRY_PROJECT_SLUG:-}" ] ||
+   [ -z "${SENTRY_BASE_URL:-}" ]; then
+  exit 0
+fi
+
+api_base="${SENTRY_BASE_URL%/}"
+case "$api_base" in
+  */api/0) ;;
+  *) api_base="$api_base/api/0" ;;
+esac
+
+curl -fsS \
+  -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+  "$api_base/projects/$SENTRY_ORG_SLUG/$SENTRY_PROJECT_SLUG/keys/" |
+  python3 -c 'import json, sys
+keys = json.load(sys.stdin)
+if not keys:
+    sys.exit(0)
+dsn = keys[0].get("dsn", {})
+print(dsn.get("public") or dsn.get("publicDsn") or "")'

--- a/scripts/sentry-public-dsn.sh
+++ b/scripts/sentry-public-dsn.sh
@@ -22,16 +22,32 @@ if [ -z "${SENTRY_AUTH_TOKEN:-}" ] ||
   exit 0
 fi
 
+if ! command -v curl >/dev/null 2>&1; then
+  printf '%s\n' 'sentry-public-dsn.sh: missing required dependency: curl' >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  printf '%s\n' 'sentry-public-dsn.sh: missing required dependency: python3' >&2
+  exit 1
+fi
+
 api_base="${SENTRY_BASE_URL%/}"
 case "$api_base" in
   */api/0) ;;
   *) api_base="$api_base/api/0" ;;
 esac
 
-curl -fsS \
-  -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
-  "$api_base/projects/$SENTRY_ORG_SLUG/$SENTRY_PROJECT_SLUG/keys/" |
-  python3 -c 'import json, sys
+response="$(
+  curl -fsS \
+    -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+    "$api_base/projects/$SENTRY_ORG_SLUG/$SENTRY_PROJECT_SLUG/keys/"
+)" || {
+  printf '%s\n' "sentry-public-dsn.sh: failed to fetch Sentry project keys from $api_base" >&2
+  exit 1
+}
+
+printf '%s' "$response" | python3 -c 'import json, sys
 keys = json.load(sys.stdin)
 if not keys:
     sys.exit(0)

--- a/src/background.ts
+++ b/src/background.ts
@@ -10,6 +10,7 @@ let offscreenReady = false
 let lastKnownRecording = false
 let currentRecordingTabId: number | null = null
 let autoStopMeetTabId: number | null = null
+let recordingStartedAt: number | null = null
 
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
 function bglog(...a: any[]) { console.log('[background]', ...a) }
@@ -22,6 +23,15 @@ function setBadge(recording: boolean, tabId?: number | null) {
 function setMeetReadyBadge(tabId: number, ready: boolean) {
   if (lastKnownRecording && currentRecordingTabId === tabId) return
   chrome.action.setBadgeText({ tabId, text: ready ? 'RDY' : '' }).catch?.(() => {})
+}
+
+function persistRecordingState(recording: boolean, startedAt: number | null): void {
+  try {
+    void (chrome.storage as any)?.session?.set?.({
+      recording,
+      recordingStartedAt: startedAt
+    })?.catch?.(() => {})
+  } catch {}
 }
 
 async function getMicPreferencesForOffscreen(): Promise<MicPreferences> {
@@ -87,6 +97,8 @@ async function resetOffscreen(): Promise<void> {
   lastKnownRecording = false
   currentRecordingTabId = null
   autoStopMeetTabId = null
+  recordingStartedAt = null
+  persistRecordingState(false, null)
   setBadge(false)
 
   try {
@@ -114,8 +126,15 @@ chrome.runtime.onConnect.addListener((port) => {
 
     if (msg?.type === 'RECORDING_STATE') {
       lastKnownRecording = !!msg.recording
+      if (lastKnownRecording && !recordingStartedAt) recordingStartedAt = Date.now()
+      if (!lastKnownRecording) recordingStartedAt = null
+      persistRecordingState(lastKnownRecording, recordingStartedAt)
       setBadge(lastKnownRecording, currentRecordingTabId)
-      chrome.runtime.sendMessage({ type: 'RECORDING_STATE', recording: lastKnownRecording }).catch(() => {})
+      chrome.runtime.sendMessage({
+        type: 'RECORDING_STATE',
+        recording: lastKnownRecording,
+        recordingStartedAt
+      }).catch(() => {})
       if (!lastKnownRecording) {
         currentRecordingTabId = null
         autoStopMeetTabId = null
@@ -156,6 +175,8 @@ chrome.runtime.onConnect.addListener((port) => {
     lastKnownRecording = false
     currentRecordingTabId = null
     autoStopMeetTabId = null
+    recordingStartedAt = null
+    persistRecordingState(false, null)
     setBadge(false)
   })
 })
@@ -221,6 +242,8 @@ async function stopRecording(reason: string): Promise<any> {
   setBadge(false, currentRecordingTabId)
   currentRecordingTabId = null
   autoStopMeetTabId = null
+  recordingStartedAt = null
+  persistRecordingState(false, null)
   return response
 }
 
@@ -292,9 +315,16 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           lastKnownRecording = true
           currentRecordingTabId = tabId
           autoStopMeetTabId = typeof msg.autoStopMeetTabId === 'number' ? msg.autoStopMeetTabId : tabId
+          if (!recordingStartedAt) recordingStartedAt = Date.now()
+          persistRecordingState(true, recordingStartedAt)
           setBadge(true, tabId)
-          chrome.runtime.sendMessage({ type: 'RECORDING_STATE', recording: true, warning: r.warning }).catch(() => {})
-          sendResponse({ ok: true, micIncluded: r.micIncluded, warning: r.warning })
+          chrome.runtime.sendMessage({
+            type: 'RECORDING_STATE',
+            recording: true,
+            recordingStartedAt,
+            warning: r.warning
+          }).catch(() => {})
+          sendResponse({ ok: true, micIncluded: r.micIncluded, warning: r.warning, recordingStartedAt })
         } else {
           sendResponse({ ok: false, error: r?.error || 'Failed to start' })
         }
@@ -319,7 +349,16 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     }
 
     if (msg?.type === 'GET_RECORDING_STATUS') {
-      sendResponse({ recording: lastKnownRecording })
+      if (!lastKnownRecording) {
+        try {
+          const sessionState = await (chrome.storage as any)?.session?.get?.(['recording', 'recordingStartedAt'])
+          lastKnownRecording = !!sessionState?.recording
+          recordingStartedAt = typeof sessionState?.recordingStartedAt === 'number'
+            ? sessionState.recordingStartedAt
+            : null
+        } catch {}
+      }
+      sendResponse({ recording: lastKnownRecording, recordingStartedAt })
       return
     }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -8,11 +8,20 @@ initDiagnostics('background')
 let offscreenPort: chrome.runtime.Port | null = null
 let offscreenReady = false
 let lastKnownRecording = false
+let currentRecordingTabId: number | null = null
+let autoStopMeetTabId: number | null = null
 
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
 function bglog(...a: any[]) { console.log('[background]', ...a) }
-function setBadge(recording: boolean) {
-  chrome.action.setBadgeText({ text: recording ? 'REC' : '' }).catch?.(() => {})
+function setBadge(recording: boolean, tabId?: number | null) {
+  const details: chrome.action.BadgeTextDetails = { text: recording ? 'REC' : '' }
+  if (typeof tabId === 'number') details.tabId = tabId
+  chrome.action.setBadgeText(details).catch?.(() => {})
+}
+
+function setMeetReadyBadge(tabId: number, ready: boolean) {
+  if (lastKnownRecording && currentRecordingTabId === tabId) return
+  chrome.action.setBadgeText({ tabId, text: ready ? 'RDY' : '' }).catch?.(() => {})
 }
 
 async function getMicPreferencesForOffscreen(): Promise<MicPreferences> {
@@ -76,6 +85,8 @@ async function resetOffscreen(): Promise<void> {
   offscreenPort = null
   offscreenReady = false
   lastKnownRecording = false
+  currentRecordingTabId = null
+  autoStopMeetTabId = null
   setBadge(false)
 
   try {
@@ -103,8 +114,12 @@ chrome.runtime.onConnect.addListener((port) => {
 
     if (msg?.type === 'RECORDING_STATE') {
       lastKnownRecording = !!msg.recording
-      setBadge(lastKnownRecording)
+      setBadge(lastKnownRecording, currentRecordingTabId)
       chrome.runtime.sendMessage({ type: 'RECORDING_STATE', recording: lastKnownRecording }).catch(() => {})
+      if (!lastKnownRecording) {
+        currentRecordingTabId = null
+        autoStopMeetTabId = null
+      }
     }
 
     if (msg?.type === 'OFFSCREEN_SAVE') {
@@ -139,6 +154,8 @@ chrome.runtime.onConnect.addListener((port) => {
     offscreenPort = null
     offscreenReady = false
     lastKnownRecording = false
+    currentRecordingTabId = null
+    autoStopMeetTabId = null
     setBadge(false)
   })
 })
@@ -192,8 +209,49 @@ function getStreamIdForTab(tabId: number): Promise<string> {
   })
 }
 
+async function stopRecording(reason: string): Promise<any> {
+  bglog('Stopping recording:', reason)
+  await ensureOffscreen()
+  let response: any = { ok: true }
+  if (offscreenPort) {
+    response = await postToOffscreen({ type: 'OFFSCREEN_STOP', reason })
+    bglog('postToOffscreen(OFFSCREEN_STOP) response', response)
+  }
+  lastKnownRecording = false
+  setBadge(false, currentRecordingTabId)
+  currentRecordingTabId = null
+  autoStopMeetTabId = null
+  return response
+}
+
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   (async () => {
+    if (msg?.type === 'MEET_MEETING_STATE') {
+      const tabId = _sender.tab?.id
+      if (typeof tabId !== 'number') { sendResponse({ ok: false, error: 'Missing sender tab' }); return }
+
+      if (msg.inMeeting) {
+        bglog('Meet meeting detected on tab', tabId)
+        setMeetReadyBadge(tabId, true)
+      } else {
+        bglog('Meet meeting left on tab', tabId)
+        setMeetReadyBadge(tabId, false)
+        if (lastKnownRecording && autoStopMeetTabId === tabId) {
+          try {
+            await stopRecording('MEET_LEFT')
+            sendResponse({ ok: true, stopped: true })
+          } catch (e: any) {
+            captureException(e, { operation: 'MEET_AUTO_STOP' })
+            sendResponse({ ok: false, error: `AUTO_STOP failed: ${e?.message || e}` })
+          }
+          return
+        }
+      }
+
+      sendResponse({ ok: true })
+      return
+    }
+
     if (msg?.type === 'START_RECORDING') {
       const tabId: number | undefined = msg.tabId
       if (typeof tabId !== 'number') { sendResponse({ ok: false, error: 'Missing tabId' }); return }
@@ -232,9 +290,11 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
         if (r?.ok) {
           lastKnownRecording = true
-          setBadge(true)
-          chrome.runtime.sendMessage({ type: 'RECORDING_STATE', recording: true }).catch(() => {})
-          sendResponse({ ok: true })
+          currentRecordingTabId = tabId
+          autoStopMeetTabId = typeof msg.autoStopMeetTabId === 'number' ? msg.autoStopMeetTabId : tabId
+          setBadge(true, tabId)
+          chrome.runtime.sendMessage({ type: 'RECORDING_STATE', recording: true, warning: r.warning }).catch(() => {})
+          sendResponse({ ok: true, micIncluded: r.micIncluded, warning: r.warning })
         } else {
           sendResponse({ ok: false, error: r?.error || 'Failed to start' })
         }
@@ -249,11 +309,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
     if (msg?.type === 'STOP_RECORDING') {
       try {
-        await ensureOffscreen()
-        if (offscreenPort) {
-          const r = await postToOffscreen({ type: 'OFFSCREEN_STOP' })
-          bglog('postToOffscreen(OFFSCREEN_STOP) response', r)
-        }
+        await stopRecording('USER_STOP')
         sendResponse({ ok: true })
       } catch (e: any) {
         captureException(e, { operation: 'STOP_RECORDING' })

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,6 @@
 // src/background.ts
 
-import { captureException, captureMessage, initDiagnostics } from './diagnostics'
+import { captureException, initDiagnostics } from './diagnostics'
 import { clearMicPreferences, getMicPreferences, type MicPreferences } from './micPreferences'
 
 initDiagnostics('background')
@@ -8,10 +8,21 @@ initDiagnostics('background')
 let offscreenPort: chrome.runtime.Port | null = null
 let offscreenReady = false
 let lastKnownRecording = false
+let recordingStarting = false
+let recordingStartingTabId: number | null = null
+let recordingStartRequestedAt: number | null = null
+let recordingStopping = false
 let currentRecordingTabId: number | null = null
 let autoStopMeetTabId: number | null = null
 let recordingStartedAt: number | null = null
 const meetTabsInMeeting = new Set<number>()
+
+type UploadStatus = 'idle' | 'uploading' | 'upload_retrying' | 'uploaded'
+
+let currentUploadStatus: UploadStatus = 'idle'
+let currentUploadError: string | null = null
+let currentUploadNextRetryAt: number | null = null
+let currentUploadedRecordingId: string | null = null
 
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
 function bglog(...a: any[]) { console.log('[background]', ...a) }
@@ -26,13 +37,95 @@ function setMeetReadyBadge(tabId: number, ready: boolean) {
   chrome.action.setBadgeText({ tabId, text: ready ? 'RDY' : '' }).catch?.(() => {})
 }
 
+function clearRecordingAfterConfirmedStop(stoppedTabId: number | null): void {
+  lastKnownRecording = false
+  recordingStopping = false
+  setBadge(false, stoppedTabId)
+  currentRecordingTabId = null
+  autoStopMeetTabId = null
+  recordingStartedAt = null
+  persistRecordingState(false, null)
+
+  if (typeof stoppedTabId === 'number' && meetTabsInMeeting.has(stoppedTabId)) {
+    setMeetReadyBadge(stoppedTabId, true)
+  }
+}
+
 function persistRecordingState(recording: boolean, startedAt: number | null): void {
   try {
     void (chrome.storage as any)?.session?.set?.({
       recording,
-      recordingStartedAt: startedAt
+      recordingStartedAt: startedAt,
+      recordingStarting,
+      recordingStartingTabId,
+      recordingStartRequestedAt,
+      recordingStopping
     })?.catch?.(() => {})
   } catch {}
+}
+
+function broadcastRecordingState(extra?: Record<string, unknown>): void {
+  chrome.runtime.sendMessage({
+    type: 'RECORDING_STATE',
+    recording: lastKnownRecording,
+    recordingStartedAt,
+    starting: recordingStarting,
+    startingTabId: recordingStartingTabId,
+    startRequestedAt: recordingStartRequestedAt,
+    stopping: recordingStopping,
+    ...extra
+  }).catch(() => {})
+}
+
+function setRecordingStarting(starting: boolean, tabId: number | null = null): void {
+  recordingStarting = starting
+  recordingStartingTabId = starting ? tabId : null
+  recordingStartRequestedAt = starting ? Date.now() : null
+  persistRecordingState(lastKnownRecording, recordingStartedAt)
+  broadcastRecordingState()
+}
+
+function setRecordingStopping(stopping: boolean): void {
+  recordingStopping = stopping
+  persistRecordingState(lastKnownRecording, recordingStartedAt)
+  broadcastRecordingState()
+}
+
+function persistUploadState(): void {
+  try {
+    void (chrome.storage as any)?.session?.set?.({
+      uploadStatus: currentUploadStatus,
+      uploadError: currentUploadError,
+      uploadNextRetryAt: currentUploadNextRetryAt,
+      uploadedRecordingId: currentUploadedRecordingId
+    })?.catch?.(() => {})
+  } catch {}
+}
+
+function setUploadState(
+  status: UploadStatus,
+  extra?: {
+    error?: string | null
+    nextRetryAt?: number | null
+    recordingId?: string | null
+  }
+): void {
+  currentUploadStatus = status
+  currentUploadError = extra?.error ?? null
+  currentUploadNextRetryAt = extra?.nextRetryAt ?? null
+  currentUploadedRecordingId = extra?.recordingId ?? (status === 'uploaded' ? currentUploadedRecordingId : null)
+  persistUploadState()
+  chrome.runtime.sendMessage({
+    type: 'UPLOAD_STATE',
+    status: currentUploadStatus,
+    error: currentUploadError,
+    nextRetryAt: currentUploadNextRetryAt,
+    recordingId: currentUploadedRecordingId
+  }).catch(() => {})
+}
+
+function isUploadBlockingNewRecording(): boolean {
+  return currentUploadStatus === 'uploading' || currentUploadStatus === 'upload_retrying'
 }
 
 async function getMicPreferencesForOffscreen(): Promise<MicPreferences> {
@@ -96,10 +189,15 @@ async function resetOffscreen(): Promise<void> {
   offscreenPort = null
   offscreenReady = false
   lastKnownRecording = false
+  recordingStarting = false
+  recordingStartingTabId = null
+  recordingStartRequestedAt = null
+  recordingStopping = false
   currentRecordingTabId = null
   autoStopMeetTabId = null
   recordingStartedAt = null
   persistRecordingState(false, null)
+  setUploadState('idle')
   setBadge(false)
 
   try {
@@ -126,45 +224,40 @@ chrome.runtime.onConnect.addListener((port) => {
     }
 
     if (msg?.type === 'RECORDING_STATE') {
+      const stateTabId = currentRecordingTabId
       lastKnownRecording = !!msg.recording
+      const incomingStartedAt = typeof msg.recordingStartedAt === 'number' ? msg.recordingStartedAt : null
+      if (lastKnownRecording) {
+        recordingStarting = false
+        recordingStartingTabId = null
+        recordingStartRequestedAt = null
+      }
+      if (lastKnownRecording && incomingStartedAt) recordingStartedAt = incomingStartedAt
       if (lastKnownRecording && !recordingStartedAt) recordingStartedAt = Date.now()
-      if (!lastKnownRecording) recordingStartedAt = null
+      if (!lastKnownRecording) {
+        recordingStartedAt = null
+        recordingStopping = false
+      }
       persistRecordingState(lastKnownRecording, recordingStartedAt)
       setBadge(lastKnownRecording, currentRecordingTabId)
-      chrome.runtime.sendMessage({
-        type: 'RECORDING_STATE',
-        recording: lastKnownRecording,
-        recordingStartedAt
-      }).catch(() => {})
+      if (!lastKnownRecording && typeof stateTabId === 'number' && meetTabsInMeeting.has(stateTabId)) {
+        setMeetReadyBadge(stateTabId, true)
+      }
+      broadcastRecordingState()
       if (!lastKnownRecording) {
         currentRecordingTabId = null
         autoStopMeetTabId = null
       }
     }
 
-    if (msg?.type === 'OFFSCREEN_SAVE') {
-      const filename =
-        (typeof msg.filename === 'string' && msg.filename.trim())
-          ? msg.filename
-          : `google-meet-recording-${Date.now()}.webm`
-
-      if (msg.blobUrl) {
-        bglog('Saving OFFSCREEN_SAVE via blobUrl', filename)
-        chrome.downloads.download({ url: msg.blobUrl, filename, saveAs: true }, () => {
-          if (chrome.runtime.lastError) {
-            bglog('downloads.download error:', chrome.runtime.lastError.message)
-            captureMessage('downloads.download error', 'error', {
-              operation: 'OFFSCREEN_SAVE',
-              error: chrome.runtime.lastError.message
-            })
-          } else {
-            chrome.runtime.sendMessage({ type: 'RECORDING_SAVED', filename }).catch(() => {})
-          }
-          setTimeout(() => {
-            try { offscreenPort?.postMessage({ type: 'REVOKE_BLOB_URL', blobUrl: msg.blobUrl }) } catch {}
-          }, 10_000)
+    if (msg?.type === 'UPLOAD_STATE') {
+      const status = typeof msg.status === 'string' ? msg.status as UploadStatus : 'idle'
+      if (status === 'uploading' || status === 'upload_retrying' || status === 'uploaded' || status === 'idle') {
+        setUploadState(status, {
+          error: typeof msg.error === 'string' ? msg.error : null,
+          nextRetryAt: typeof msg.nextRetryAt === 'number' ? msg.nextRetryAt : null,
+          recordingId: typeof msg.recordingId === 'string' ? msg.recordingId : null
         })
-        return
       }
     }
   })
@@ -174,10 +267,17 @@ chrome.runtime.onConnect.addListener((port) => {
     offscreenPort = null
     offscreenReady = false
     lastKnownRecording = false
+    recordingStarting = false
+    recordingStartingTabId = null
+    recordingStartRequestedAt = null
+    recordingStopping = false
     currentRecordingTabId = null
     autoStopMeetTabId = null
     recordingStartedAt = null
     persistRecordingState(false, null)
+    if (currentUploadStatus !== 'uploading' && currentUploadStatus !== 'upload_retrying') {
+      setUploadState('idle')
+    }
     setBadge(false)
   })
 })
@@ -233,18 +333,34 @@ function getStreamIdForTab(tabId: number): Promise<string> {
 
 async function stopRecording(reason: string): Promise<any> {
   bglog('Stopping recording:', reason)
+  const stoppedTabId = currentRecordingTabId
+  recordingStarting = false
+  recordingStartingTabId = null
+  recordingStartRequestedAt = null
+  setRecordingStopping(true)
   await ensureOffscreen()
   let response: any = { ok: true }
   if (offscreenPort) {
-    response = await postToOffscreen({ type: 'OFFSCREEN_STOP', reason })
-    bglog('postToOffscreen(OFFSCREEN_STOP) response', response)
+    try {
+      response = await postToOffscreen({ type: 'OFFSCREEN_STOP', reason })
+      bglog('postToOffscreen(OFFSCREEN_STOP) response', response)
+    } catch (e: any) {
+      if (`${e?.message || e}`.includes('Offscreen response timeout')) {
+        bglog('OFFSCREEN_STOP timed out; waiting for async state update', e)
+        captureException(e, { operation: 'STOP_RECORDING.timeout' })
+        return { ok: true, warning: 'STOP_TIMEOUT_WAITING_FOR_STATE' }
+      }
+      setRecordingStopping(false)
+      throw e
+    }
   }
-  lastKnownRecording = false
-  setBadge(false, currentRecordingTabId)
-  currentRecordingTabId = null
-  autoStopMeetTabId = null
-  recordingStartedAt = null
-  persistRecordingState(false, null)
+
+  if (response?.ok === false) {
+    setRecordingStopping(false)
+    throw new Error(response.error || 'OFFSCREEN_STOP failed')
+  }
+
+  clearRecordingAfterConfirmedStop(stoppedTabId)
   return response
 }
 
@@ -285,7 +401,25 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     if (msg?.type === 'START_RECORDING') {
       const tabId: number | undefined = msg.tabId
       if (typeof tabId !== 'number') { sendResponse({ ok: false, error: 'Missing tabId' }); return }
+      if (recordingStarting || recordingStopping) {
+        sendResponse({
+          ok: true,
+          starting: recordingStarting,
+          stopping: recordingStopping,
+          startRequestedAt: recordingStartRequestedAt
+        })
+        return
+      }
+      if (lastKnownRecording) {
+        sendResponse({ ok: true, recording: true, recordingStartedAt })
+        return
+      }
+      if (isUploadBlockingNewRecording()) {
+        sendResponse({ ok: false, error: 'Upload is still in progress' })
+        return
+      }
       bglog('Popup requested START_RECORDING for tabId', tabId)
+      setRecordingStarting(true, tabId)
 
       try {
         const start = async () => {
@@ -294,7 +428,17 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
           const streamId = await getStreamIdForTab(tabId)
           const micPreferences = await getMicPreferencesForOffscreen()
-          const r = await postToOffscreen({ type: 'OFFSCREEN_START', streamId, micPreferences })
+          const tab = await chrome.tabs.get(tabId).catch(() => null)
+          setUploadState('idle')
+          const r = await postToOffscreen({
+            type: 'OFFSCREEN_START',
+            streamId,
+            micPreferences,
+            recordingContext: {
+              tabUrl: tab?.url || null,
+              tabTitle: tab?.title || null
+            }
+          })
           bglog('postToOffscreen(OFFSCREEN_START) response', r)
           return r
         }
@@ -320,6 +464,9 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
         if (r?.ok) {
           lastKnownRecording = true
+          recordingStarting = false
+          recordingStartingTabId = null
+          recordingStartRequestedAt = null
           currentRecordingTabId = tabId
           autoStopMeetTabId = meetTabsInMeeting.has(tabId)
             ? (typeof msg.autoStopMeetTabId === 'number' ? msg.autoStopMeetTabId : tabId)
@@ -327,20 +474,17 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           if (!recordingStartedAt) recordingStartedAt = Date.now()
           persistRecordingState(true, recordingStartedAt)
           setBadge(true, tabId)
-          chrome.runtime.sendMessage({
-            type: 'RECORDING_STATE',
-            recording: true,
-            recordingStartedAt,
-            warning: r.warning
-          }).catch(() => {})
+          broadcastRecordingState({ warning: r.warning })
           sendResponse({ ok: true, micIncluded: r.micIncluded, warning: r.warning, recordingStartedAt })
         } else {
+          setRecordingStarting(false)
           sendResponse({ ok: false, error: r?.error || 'Failed to start' })
         }
       } catch (e: any) {
         bglog('OFFSCREEN_START failed', e)
         captureException(e, { operation: 'START_RECORDING' })
         await resetOffscreen()
+        setRecordingStarting(false)
         sendResponse({ ok: false, error: `OFFSCREEN_START failed: ${e?.message || e}` })
       }
       return
@@ -348,8 +492,15 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
     if (msg?.type === 'STOP_RECORDING') {
       try {
-        await stopRecording('USER_STOP')
-        sendResponse({ ok: true })
+        const response = await stopRecording('USER_STOP')
+        if (response?.ok === false) {
+          sendResponse({ ok: false, error: response.error || 'Failed to stop' })
+          return
+        }
+        sendResponse({
+          ok: true,
+          warning: typeof response?.warning === 'string' ? response.warning : undefined
+        })
       } catch (e: any) {
         captureException(e, { operation: 'STOP_RECORDING' })
         sendResponse({ ok: false, error: `STOP failed: ${e?.message || e}` })
@@ -358,16 +509,53 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     }
 
     if (msg?.type === 'GET_RECORDING_STATUS') {
-      if (!lastKnownRecording) {
-        try {
-          const sessionState = await (chrome.storage as any)?.session?.get?.(['recording', 'recordingStartedAt'])
-          lastKnownRecording = !!sessionState?.recording
-          recordingStartedAt = typeof sessionState?.recordingStartedAt === 'number'
-            ? sessionState.recordingStartedAt
-            : null
-        } catch {}
-      }
-      sendResponse({ recording: lastKnownRecording, recordingStartedAt })
+      try {
+        const sessionState = await (chrome.storage as any)?.session?.get?.([
+          'recording',
+          'recordingStartedAt',
+          'recordingStarting',
+          'recordingStartingTabId',
+          'recordingStartRequestedAt',
+          'recordingStopping',
+          'uploadStatus',
+          'uploadError',
+          'uploadNextRetryAt',
+          'uploadedRecordingId'
+        ])
+        lastKnownRecording = !!sessionState?.recording
+        recordingStartedAt = typeof sessionState?.recordingStartedAt === 'number'
+          ? sessionState.recordingStartedAt
+          : null
+        recordingStarting = !!sessionState?.recordingStarting
+        recordingStartingTabId = typeof sessionState?.recordingStartingTabId === 'number'
+          ? sessionState.recordingStartingTabId
+          : null
+        recordingStartRequestedAt = typeof sessionState?.recordingStartRequestedAt === 'number'
+          ? sessionState.recordingStartRequestedAt
+          : null
+        recordingStopping = !!sessionState?.recordingStopping
+        if (sessionState?.uploadStatus === 'uploading' ||
+            sessionState?.uploadStatus === 'upload_retrying' ||
+            sessionState?.uploadStatus === 'uploaded' ||
+            sessionState?.uploadStatus === 'idle') {
+          currentUploadStatus = sessionState.uploadStatus
+        }
+        currentUploadError = typeof sessionState?.uploadError === 'string' ? sessionState.uploadError : null
+        currentUploadNextRetryAt = typeof sessionState?.uploadNextRetryAt === 'number' ? sessionState.uploadNextRetryAt : null
+        currentUploadedRecordingId = typeof sessionState?.uploadedRecordingId === 'string' ? sessionState.uploadedRecordingId : null
+      } catch {}
+      sendResponse({
+        recording: lastKnownRecording,
+        recordingStartedAt,
+        starting: recordingStarting,
+        startingTabId: recordingStartingTabId,
+        startRequestedAt: recordingStartRequestedAt,
+        stopping: recordingStopping,
+        uploadStatus: currentUploadStatus,
+        uploadError: currentUploadError,
+        uploadNextRetryAt: currentUploadNextRetryAt,
+        uploadedRecordingId: currentUploadedRecordingId
+      })
       return
     }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,5 +1,10 @@
 // src/background.ts
 
+import { captureException, captureMessage, initDiagnostics } from './diagnostics'
+import { clearMicPreferences, getMicPreferences, type MicPreferences } from './micPreferences'
+
+initDiagnostics('background')
+
 let offscreenPort: chrome.runtime.Port | null = null
 let offscreenReady = false
 let lastKnownRecording = false
@@ -8,6 +13,19 @@ const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
 function bglog(...a: any[]) { console.log('[background]', ...a) }
 function setBadge(recording: boolean) {
   chrome.action.setBadgeText({ text: recording ? 'REC' : '' }).catch?.(() => {})
+}
+
+async function getMicPreferencesForOffscreen(): Promise<MicPreferences> {
+  try {
+    return await getMicPreferences()
+  } catch (e) {
+    bglog('getMicPreferences failed; continuing without saved microphone preference', e)
+    captureException(e, { operation: 'getMicPreferencesForOffscreen' })
+    return {
+      preferredMicDeviceId: null,
+      preferredMicLabel: null
+    }
+  }
 }
 
 async function hasOffscreenContext(): Promise<boolean> {
@@ -67,6 +85,7 @@ async function resetOffscreen(): Promise<void> {
     }
   } catch (e) {
     bglog('Offscreen reset failed', e)
+    captureException(e, { operation: 'resetOffscreen' })
   }
 }
 
@@ -99,6 +118,10 @@ chrome.runtime.onConnect.addListener((port) => {
         chrome.downloads.download({ url: msg.blobUrl, filename, saveAs: true }, () => {
           if (chrome.runtime.lastError) {
             bglog('downloads.download error:', chrome.runtime.lastError.message)
+            captureMessage('downloads.download error', 'error', {
+              operation: 'OFFSCREEN_SAVE',
+              error: chrome.runtime.lastError.message
+            })
           } else {
             chrome.runtime.sendMessage({ type: 'RECORDING_SAVED', filename }).catch(() => {})
           }
@@ -182,7 +205,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           bglog('ensureOffscreen() completed')
 
           const streamId = await getStreamIdForTab(tabId)
-          const r = await postToOffscreen({ type: 'OFFSCREEN_START', streamId })
+          const micPreferences = await getMicPreferencesForOffscreen()
+          const r = await postToOffscreen({ type: 'OFFSCREEN_START', streamId, micPreferences })
           bglog('postToOffscreen(OFFSCREEN_START) response', r)
           return r
         }
@@ -216,6 +240,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         }
       } catch (e: any) {
         bglog('OFFSCREEN_START failed', e)
+        captureException(e, { operation: 'START_RECORDING' })
         await resetOffscreen()
         sendResponse({ ok: false, error: `OFFSCREEN_START failed: ${e?.message || e}` })
       }
@@ -231,6 +256,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         }
         sendResponse({ ok: true })
       } catch (e: any) {
+        captureException(e, { operation: 'STOP_RECORDING' })
         sendResponse({ ok: false, error: `STOP failed: ${e?.message || e}` })
       }
       return
@@ -240,8 +266,20 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       sendResponse({ recording: lastKnownRecording })
       return
     }
+
+    if (msg?.type === 'CLEAR_MIC_PREFERENCES') {
+      try {
+        await clearMicPreferences()
+        sendResponse({ ok: true })
+      } catch (e: any) {
+        captureException(e, { operation: 'CLEAR_MIC_PREFERENCES' })
+        sendResponse({ ok: false, error: e?.message || String(e) })
+      }
+      return
+    }
   })().catch((err) => {
     console.error('[background] top-level error', err)
+    captureException(err, { operation: 'runtime.onMessage' })
     sendResponse({ ok: false, error: String(err) })
   })
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -11,6 +11,7 @@ let lastKnownRecording = false
 let currentRecordingTabId: number | null = null
 let autoStopMeetTabId: number | null = null
 let recordingStartedAt: number | null = null
+const meetTabsInMeeting = new Set<number>()
 
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
 function bglog(...a: any[]) { console.log('[background]', ...a) }
@@ -255,11 +256,17 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
       if (msg.inMeeting) {
         bglog('Meet meeting detected on tab', tabId)
+        meetTabsInMeeting.add(tabId)
+        if (lastKnownRecording && currentRecordingTabId === tabId && autoStopMeetTabId === null) {
+          autoStopMeetTabId = tabId
+        }
         setMeetReadyBadge(tabId, true)
       } else {
         bglog('Meet meeting left on tab', tabId)
+        const wasConfirmedInMeeting = meetTabsInMeeting.has(tabId)
+        meetTabsInMeeting.delete(tabId)
         setMeetReadyBadge(tabId, false)
-        if (lastKnownRecording && autoStopMeetTabId === tabId) {
+        if (wasConfirmedInMeeting && lastKnownRecording && autoStopMeetTabId === tabId) {
           try {
             await stopRecording('MEET_LEFT')
             sendResponse({ ok: true, stopped: true })
@@ -314,7 +321,9 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         if (r?.ok) {
           lastKnownRecording = true
           currentRecordingTabId = tabId
-          autoStopMeetTabId = typeof msg.autoStopMeetTabId === 'number' ? msg.autoStopMeetTabId : tabId
+          autoStopMeetTabId = meetTabsInMeeting.has(tabId)
+            ? (typeof msg.autoStopMeetTabId === 'number' ? msg.autoStopMeetTabId : tabId)
+            : null
           if (!recordingStartedAt) recordingStartedAt = Date.now()
           persistRecordingState(true, recordingStartedAt)
           setBadge(true, tabId)

--- a/src/background.ts
+++ b/src/background.ts
@@ -128,6 +128,27 @@ function isUploadBlockingNewRecording(): boolean {
   return currentUploadStatus === 'uploading' || currentUploadStatus === 'upload_retrying'
 }
 
+function isUploadStatus(value: unknown): value is UploadStatus {
+  return value === 'idle' || value === 'uploading' || value === 'upload_retrying' || value === 'uploaded'
+}
+
+async function hydrateUploadStateFromSession(): Promise<void> {
+  try {
+    const sessionState = await chrome.storage.session.get([
+      'uploadStatus',
+      'uploadError',
+      'uploadNextRetryAt',
+      'uploadedRecordingId'
+    ])
+    if (isUploadStatus(sessionState?.uploadStatus)) {
+      currentUploadStatus = sessionState.uploadStatus
+    }
+    currentUploadError = typeof sessionState?.uploadError === 'string' ? sessionState.uploadError : null
+    currentUploadNextRetryAt = typeof sessionState?.uploadNextRetryAt === 'number' ? sessionState.uploadNextRetryAt : null
+    currentUploadedRecordingId = typeof sessionState?.uploadedRecordingId === 'string' ? sessionState.uploadedRecordingId : null
+  } catch {}
+}
+
 async function getMicPreferencesForOffscreen(): Promise<MicPreferences> {
   try {
     return await getMicPreferences()
@@ -414,6 +435,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         sendResponse({ ok: true, recording: true, recordingStartedAt })
         return
       }
+      await hydrateUploadStateFromSession()
       if (isUploadBlockingNewRecording()) {
         sendResponse({ ok: false, error: 'Upload is still in progress' })
         return
@@ -429,7 +451,6 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           const streamId = await getStreamIdForTab(tabId)
           const micPreferences = await getMicPreferencesForOffscreen()
           const tab = await chrome.tabs.get(tabId).catch(() => null)
-          setUploadState('idle')
           const r = await postToOffscreen({
             type: 'OFFSCREEN_START',
             streamId,
@@ -473,6 +494,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
             : null
           if (!recordingStartedAt) recordingStartedAt = Date.now()
           persistRecordingState(true, recordingStartedAt)
+          if (currentUploadStatus === 'uploaded') setUploadState('idle')
           setBadge(true, tabId)
           broadcastRecordingState({ warning: r.warning })
           sendResponse({ ok: true, micIncluded: r.micIncluded, warning: r.warning, recordingStartedAt })
@@ -534,10 +556,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           ? sessionState.recordingStartRequestedAt
           : null
         recordingStopping = !!sessionState?.recordingStopping
-        if (sessionState?.uploadStatus === 'uploading' ||
-            sessionState?.uploadStatus === 'upload_retrying' ||
-            sessionState?.uploadStatus === 'uploaded' ||
-            sessionState?.uploadStatus === 'idle') {
+        if (isUploadStatus(sessionState?.uploadStatus)) {
           currentUploadStatus = sessionState.uploadStatus
         }
         currentUploadError = typeof sessionState?.uploadError === 'string' ? sessionState.uploadError : null

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,85 @@
+import * as Sentry from '@sentry/browser'
+
+declare const __SENTRY_DSN__: string
+declare const __SENTRY_ENVIRONMENT__: string
+declare const __EXTENSION_VERSION__: string
+
+let initialized = false
+let componentName = 'unknown'
+
+function getExtensionVersion(): string {
+  return __EXTENSION_VERSION__ || 'unknown'
+}
+
+function hasSentryDsn(): boolean {
+  return typeof __SENTRY_DSN__ === 'string' && __SENTRY_DSN__.trim().length > 0
+}
+
+export function initDiagnostics(component: string): void {
+  componentName = component
+  if (initialized || !hasSentryDsn()) return
+
+  initialized = true
+  try {
+    Sentry.init({
+      dsn: __SENTRY_DSN__,
+      environment: __SENTRY_ENVIRONMENT__ || 'chrome-extension-dev',
+      release: `google-meet-recorder@${getExtensionVersion()}`,
+      sendDefaultPii: false,
+      tracesSampleRate: 0,
+      maxBreadcrumbs: 20,
+      beforeBreadcrumb(breadcrumb) {
+        if (breadcrumb.category === 'console') return null
+        return breadcrumb
+      },
+      beforeSend(event) {
+        event.request = undefined
+        event.server_name = undefined
+        event.user = undefined
+        event.tags = {
+          ...event.tags,
+          extension_component: componentName,
+          extension_id: chrome.runtime.id
+        }
+        return event
+      }
+    })
+    Sentry.setTag('extension_component', componentName)
+    Sentry.setContext('extension', {
+      id: chrome.runtime.id,
+      version: getExtensionVersion()
+    })
+  } catch (error) {
+    console.error('[diagnostics] Sentry init failed', error)
+  }
+}
+
+export function captureException(error: unknown, context?: Record<string, unknown>): void {
+  if (!initialized) return
+  try {
+    Sentry.withScope((scope) => {
+      scope.setTag('extension_component', componentName)
+      if (context) scope.setContext('context', context)
+      Sentry.captureException(error)
+    })
+  } catch (captureError) {
+    console.error('[diagnostics] Sentry captureException failed', captureError)
+  }
+}
+
+export function captureMessage(
+  message: string,
+  level: 'debug' | 'info' | 'warning' | 'error' = 'info',
+  context?: Record<string, unknown>
+): void {
+  if (!initialized) return
+  try {
+    Sentry.withScope((scope) => {
+      scope.setTag('extension_component', componentName)
+      if (context) scope.setContext('context', context)
+      Sentry.captureMessage(message, level)
+    })
+  } catch (captureError) {
+    console.error('[diagnostics] Sentry captureMessage failed', captureError)
+  }
+}

--- a/src/meetWatcher.ts
+++ b/src/meetWatcher.ts
@@ -97,7 +97,7 @@ function scheduleTick(): void {
 }
 
 tick()
-setInterval(scheduleTick, POLL_MS)
+setInterval(tick, POLL_MS)
 
 const observer = new MutationObserver(() => scheduleTick())
 observer.observe(document.documentElement, {

--- a/src/meetWatcher.ts
+++ b/src/meetWatcher.ts
@@ -97,7 +97,7 @@ function scheduleTick(): void {
 }
 
 tick()
-setInterval(tick, POLL_MS)
+setInterval(scheduleTick, POLL_MS)
 
 const observer = new MutationObserver(() => scheduleTick())
 observer.observe(document.documentElement, {

--- a/src/meetWatcher.ts
+++ b/src/meetWatcher.ts
@@ -1,0 +1,101 @@
+// src/meetWatcher.ts
+
+import { captureException, initDiagnostics } from './diagnostics'
+
+initDiagnostics('meetWatcher')
+
+const MEETING_PATH_RE = /^\/[a-z]{3}-[a-z]{4}-[a-z]{3}(?:$|[/?#])/i
+const POLL_MS = 1000
+const ABSENT_CONFIRMATIONS = 3
+
+let lastSentInMeeting: boolean | null = null
+let absentCount = 0
+
+function hasMeetingPath(): boolean {
+  return location.hostname === 'meet.google.com' && MEETING_PATH_RE.test(location.pathname)
+}
+
+function normalize(text: string | null | undefined): string {
+  return (text || '').trim().toLowerCase()
+}
+
+function looksLikeLeaveControl(label: string | null): boolean {
+  const value = normalize(label)
+  return value.includes('leave call') ||
+    value.includes('leave meeting') ||
+    value.includes('hang up') ||
+    value.includes('opuść') ||
+    value.includes('opusc') ||
+    value.includes('rozłącz') ||
+    value.includes('rozlacz') ||
+    value.includes('zakończ połączenie') ||
+    value.includes('zakoncz polaczenie')
+}
+
+function hasLeaveControl(): boolean {
+  const controls = document.querySelectorAll<HTMLElement>(
+    'button[aria-label], div[role="button"][aria-label], button[data-tooltip], div[role="button"][data-tooltip]'
+  )
+
+  for (let index = 0; index < controls.length; index += 1) {
+    const control = controls[index]
+    const label = control.getAttribute('aria-label') ||
+      control.getAttribute('data-tooltip') ||
+      control.title ||
+      control.textContent
+    if (looksLikeLeaveControl(label)) return true
+  }
+
+  return false
+}
+
+function detectInMeeting(): boolean {
+  return hasMeetingPath() && hasLeaveControl()
+}
+
+function sendMeetingState(inMeeting: boolean): void {
+  if (lastSentInMeeting === inMeeting) return
+  lastSentInMeeting = inMeeting
+  chrome.runtime.sendMessage({
+    type: 'MEET_MEETING_STATE',
+    inMeeting,
+    url: location.href,
+    title: document.title
+  }).catch((error) => {
+    captureException(error, { operation: 'sendMeetingState' })
+  })
+}
+
+function tick(): void {
+  try {
+    const detected = detectInMeeting()
+    if (detected) {
+      absentCount = 0
+      sendMeetingState(true)
+      return
+    }
+
+    if (lastSentInMeeting === true) {
+      absentCount += 1
+      if (absentCount >= ABSENT_CONFIRMATIONS) {
+        sendMeetingState(false)
+      }
+      return
+    }
+
+    sendMeetingState(false)
+  } catch (error) {
+    captureException(error, { operation: 'tick' })
+  }
+}
+
+tick()
+setInterval(tick, POLL_MS)
+
+const observer = new MutationObserver(() => tick())
+observer.observe(document.documentElement, {
+  childList: true,
+  subtree: true,
+  attributes: true,
+  attributeFilter: ['aria-label', 'data-tooltip', 'role']
+})

--- a/src/meetWatcher.ts
+++ b/src/meetWatcher.ts
@@ -10,6 +10,7 @@ const ABSENT_CONFIRMATIONS = 3
 
 let lastSentInMeeting: boolean | null = null
 let absentCount = 0
+let scheduledTick: number | null = null
 
 function hasMeetingPath(): boolean {
   return location.hostname === 'meet.google.com' && MEETING_PATH_RE.test(location.pathname)
@@ -67,6 +68,7 @@ function sendMeetingState(inMeeting: boolean): void {
 }
 
 function tick(): void {
+  scheduledTick = null
   try {
     const detected = detectInMeeting()
     if (detected) {
@@ -89,10 +91,15 @@ function tick(): void {
   }
 }
 
+function scheduleTick(): void {
+  if (scheduledTick !== null) return
+  scheduledTick = window.setTimeout(() => tick(), POLL_MS)
+}
+
 tick()
 setInterval(tick, POLL_MS)
 
-const observer = new MutationObserver(() => tick())
+const observer = new MutationObserver(() => scheduleTick())
 observer.observe(document.documentElement, {
   childList: true,
   subtree: true,

--- a/src/micPreferences.ts
+++ b/src/micPreferences.ts
@@ -1,0 +1,60 @@
+export const MIC_DEVICE_ID_KEY = 'preferredMicDeviceId'
+export const MIC_LABEL_KEY = 'preferredMicLabel'
+export const MIC_PREFERENCE_KEYS = [MIC_DEVICE_ID_KEY, MIC_LABEL_KEY]
+
+export interface MicPreferences {
+  preferredMicDeviceId: string | null
+  preferredMicLabel: string | null
+}
+
+export function getChromeRuntimeError(operation: string): Error | null {
+  const runtimeError = chrome.runtime.lastError
+  if (!runtimeError) return null
+  return new Error(`chrome.storage.local.${operation} failed: ${runtimeError.message}`)
+}
+
+export function getMicPreferences(): Promise<MicPreferences> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get(MIC_PREFERENCE_KEYS, (items) => {
+      const error = getChromeRuntimeError('get')
+      if (error) {
+        reject(error)
+        return
+      }
+
+      resolve({
+        preferredMicDeviceId: items[MIC_DEVICE_ID_KEY] ?? null,
+        preferredMicLabel: items[MIC_LABEL_KEY] ?? null
+      })
+    })
+  })
+}
+
+export function setMicPreferences(preferences: MicPreferences): Promise<void> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.set({
+      [MIC_DEVICE_ID_KEY]: preferences.preferredMicDeviceId,
+      [MIC_LABEL_KEY]: preferences.preferredMicLabel
+    }, () => {
+      const error = getChromeRuntimeError('set')
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+}
+
+export function clearMicPreferences(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.remove(MIC_PREFERENCE_KEYS, () => {
+      const error = getChromeRuntimeError('remove')
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+}

--- a/src/micsetup.ts
+++ b/src/micsetup.ts
@@ -1,21 +1,138 @@
 // src/micsetup.ts
 
+const DEFAULT_MIC_VALUE = '__default__'
+
+interface MicSetupPreferences {
+  preferredMicDeviceId?: string | null
+  preferredMicLabel?: string | null
+  preferredMicUpdatedAt?: number
+}
+
+function storageGet(keys: string[]): Promise<MicSetupPreferences> {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(keys, (items) => resolve(items as MicSetupPreferences))
+  })
+}
+
+function storageSet(items: MicSetupPreferences): Promise<void> {
+  return new Promise((resolve) => {
+    chrome.storage.local.set(items, () => resolve())
+  })
+}
+
+function storageRemove(keys: string[]): Promise<void> {
+  return new Promise((resolve) => {
+    chrome.storage.local.remove(keys, () => resolve())
+  })
+}
+
+function describeError(error: unknown): string {
+  if (error instanceof DOMException) return `${error.name}: ${error.message}`
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-    const btn = document.getElementById('enable') as HTMLButtonElement | null;
-    const statusEl = document.getElementById('status') as HTMLParagraphElement | null;
-  
-    if (!btn || !statusEl) return;
-  
-    btn.addEventListener('click', async () => {
-      statusEl.textContent = 'Requesting microphone…';
-      try {
-        const s = await navigator.mediaDevices.getUserMedia({ audio: true });
-        s.getTracks().forEach(t => t.stop());
-        statusEl.textContent = 'Microphone enabled. You can close this tab.';
-      } catch (e: any) {
-        statusEl.textContent = `Mic blocked: ${e?.name || e}. Check Chrome & OS settings.`;
-        console.error('[micsetup] getUserMedia error:', e);
+  const refreshBtn = document.getElementById('enable') as HTMLButtonElement | null
+  const saveBtn = document.getElementById('save-mic') as HTMLButtonElement | null
+  const selectEl = document.getElementById('mic-select') as HTMLSelectElement | null
+  const statusEl = document.getElementById('status') as HTMLParagraphElement | null
+
+  if (!refreshBtn || !saveBtn || !selectEl || !statusEl) return
+
+  const setStatus = (message: string) => { statusEl.textContent = message }
+
+  const requestPermission = async (): Promise<boolean> => {
+    setStatus('Requesting microphone permission...')
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      stream.getTracks().forEach(track => track.stop())
+      return true
+    } catch (error) {
+      console.error('[micsetup] getUserMedia error:', error)
+      setStatus(`Microphone blocked: ${describeError(error)}. Check Chrome and OS settings.`)
+      return false
+    }
+  }
+
+  const renderDevices = async () => {
+    selectEl.disabled = true
+    saveBtn.disabled = true
+    selectEl.replaceChildren()
+
+    const prefs = await storageGet(['preferredMicDeviceId', 'preferredMicLabel'])
+    const devices = await navigator.mediaDevices.enumerateDevices()
+    const audioInputs = devices.filter(device => device.kind === 'audioinput')
+
+    const defaultOption = new Option('Default microphone', DEFAULT_MIC_VALUE)
+    selectEl.append(defaultOption)
+
+    audioInputs.forEach((device, index) => {
+      const label = device.label || `Microphone ${index + 1}`
+      selectEl.append(new Option(label, device.deviceId))
+    })
+
+    if (prefs.preferredMicDeviceId && audioInputs.some(device => device.deviceId === prefs.preferredMicDeviceId)) {
+      selectEl.value = prefs.preferredMicDeviceId
+    } else {
+      selectEl.value = DEFAULT_MIC_VALUE
+      if (prefs.preferredMicDeviceId) {
+        await storageRemove(['preferredMicDeviceId', 'preferredMicLabel'])
+        await storageSet({ preferredMicUpdatedAt: Date.now() })
       }
-    });
-  });
-  
+    }
+
+    selectEl.disabled = false
+    saveBtn.disabled = false
+    setStatus(audioInputs.length
+      ? 'Choose a microphone and save.'
+      : 'No microphone devices found. Default microphone will be used when available.')
+  }
+
+  const loadDevices = async () => {
+    const allowed = await requestPermission()
+    if (!allowed) return
+
+    try {
+      await renderDevices()
+    } catch (error) {
+      console.error('[micsetup] enumerateDevices error:', error)
+      setStatus(`Could not list microphones: ${describeError(error)}`)
+    }
+  }
+
+  refreshBtn.addEventListener('click', () => {
+    loadDevices().catch((error) => {
+      console.error('[micsetup] refresh error:', error)
+      setStatus(`Could not refresh microphones: ${describeError(error)}`)
+    })
+  })
+
+  saveBtn.addEventListener('click', async () => {
+    try {
+      const selectedValue = selectEl.value
+      if (selectedValue === DEFAULT_MIC_VALUE) {
+        await storageRemove(['preferredMicDeviceId', 'preferredMicLabel'])
+        await storageSet({ preferredMicUpdatedAt: Date.now() })
+        setStatus('Saved: Default microphone.')
+        return
+      }
+
+      const selectedOption = selectEl.selectedOptions[0]
+      await storageSet({
+        preferredMicDeviceId: selectedValue,
+        preferredMicLabel: selectedOption?.textContent || 'Selected microphone',
+        preferredMicUpdatedAt: Date.now()
+      })
+      setStatus(`Saved: ${selectedOption?.textContent || 'Selected microphone'}.`)
+    } catch (error) {
+      console.error('[micsetup] save error:', error)
+      setStatus(`Could not save microphone: ${describeError(error)}`)
+    }
+  })
+
+  loadDevices().catch((error) => {
+    console.error('[micsetup] initial load error:', error)
+    setStatus(`Could not load microphones: ${describeError(error)}`)
+  })
+})

--- a/src/micsetup.ts
+++ b/src/micsetup.ts
@@ -6,6 +6,7 @@ import { clearMicPreferences, getMicPreferences, setMicPreferences } from './mic
 initDiagnostics('micsetup')
 
 const DEFAULT_MIC_VALUE = '__default__'
+const PSEUDO_DEVICE_IDS = new Set(['default', 'communications'])
 
 function describeError(error: unknown): string {
   if (error instanceof DOMException) return `${error.name}: ${error.message}`
@@ -42,32 +43,37 @@ document.addEventListener('DOMContentLoaded', () => {
     saveBtn.disabled = true
     selectEl.replaceChildren()
 
-    const prefs = await getMicPreferences()
-    const devices = await navigator.mediaDevices.enumerateDevices()
-    const audioInputs = devices.filter(device => device.kind === 'audioinput')
+    try {
+      const prefs = await getMicPreferences()
+      const devices = await navigator.mediaDevices.enumerateDevices()
+      const audioInputs = devices.filter(device =>
+        device.kind === 'audioinput' && !PSEUDO_DEVICE_IDS.has(device.deviceId)
+      )
 
-    const defaultOption = new Option('Default microphone', DEFAULT_MIC_VALUE)
-    selectEl.append(defaultOption)
+      const defaultOption = new Option('Default microphone', DEFAULT_MIC_VALUE)
+      selectEl.append(defaultOption)
 
-    audioInputs.forEach((device, index) => {
-      const label = device.label || `Microphone ${index + 1}`
-      selectEl.append(new Option(label, device.deviceId))
-    })
+      audioInputs.forEach((device, index) => {
+        const label = device.label || `Microphone ${index + 1}`
+        selectEl.append(new Option(label, device.deviceId))
+      })
 
-    if (prefs.preferredMicDeviceId && audioInputs.some(device => device.deviceId === prefs.preferredMicDeviceId)) {
-      selectEl.value = prefs.preferredMicDeviceId
-    } else {
-      selectEl.value = DEFAULT_MIC_VALUE
-      if (prefs.preferredMicDeviceId) {
-        await clearMicPreferences()
+      if (prefs.preferredMicDeviceId && audioInputs.some(device => device.deviceId === prefs.preferredMicDeviceId)) {
+        selectEl.value = prefs.preferredMicDeviceId
+      } else {
+        selectEl.value = DEFAULT_MIC_VALUE
+        if (prefs.preferredMicDeviceId) {
+          await clearMicPreferences()
+        }
       }
-    }
 
-    selectEl.disabled = false
-    saveBtn.disabled = false
-    setStatus(audioInputs.length
-      ? 'Choose a microphone and save.'
-      : 'No microphone devices found. Default microphone will be used when available.')
+      setStatus(audioInputs.length
+        ? 'Choose a microphone and save.'
+        : 'No microphone devices found. Default microphone will be used when available.')
+    } finally {
+      selectEl.disabled = false
+      saveBtn.disabled = false
+    }
   }
 
   const loadDevices = async () => {
@@ -87,6 +93,14 @@ document.addEventListener('DOMContentLoaded', () => {
     loadDevices().catch((error) => {
       console.error('[micsetup] refresh error:', error)
       captureException(error, { operation: 'refreshDevices' })
+      setStatus(`Could not refresh microphones: ${describeError(error)}`)
+    })
+  })
+
+  navigator.mediaDevices.addEventListener?.('devicechange', () => {
+    renderDevices().catch((error) => {
+      console.error('[micsetup] devicechange refresh error:', error)
+      captureException(error, { operation: 'devicechangeRefresh' })
       setStatus(`Could not refresh microphones: ${describeError(error)}`)
     })
   })

--- a/src/micsetup.ts
+++ b/src/micsetup.ts
@@ -1,30 +1,8 @@
 // src/micsetup.ts
 
+import { clearMicPreferences, getMicPreferences, setMicPreferences } from './micPreferences'
+
 const DEFAULT_MIC_VALUE = '__default__'
-
-interface MicSetupPreferences {
-  preferredMicDeviceId?: string | null
-  preferredMicLabel?: string | null
-  preferredMicUpdatedAt?: number
-}
-
-function storageGet(keys: string[]): Promise<MicSetupPreferences> {
-  return new Promise((resolve) => {
-    chrome.storage.local.get(keys, (items) => resolve(items as MicSetupPreferences))
-  })
-}
-
-function storageSet(items: MicSetupPreferences): Promise<void> {
-  return new Promise((resolve) => {
-    chrome.storage.local.set(items, () => resolve())
-  })
-}
-
-function storageRemove(keys: string[]): Promise<void> {
-  return new Promise((resolve) => {
-    chrome.storage.local.remove(keys, () => resolve())
-  })
-}
 
 function describeError(error: unknown): string {
   if (error instanceof DOMException) return `${error.name}: ${error.message}`
@@ -60,7 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
     saveBtn.disabled = true
     selectEl.replaceChildren()
 
-    const prefs = await storageGet(['preferredMicDeviceId', 'preferredMicLabel'])
+    const prefs = await getMicPreferences()
     const devices = await navigator.mediaDevices.enumerateDevices()
     const audioInputs = devices.filter(device => device.kind === 'audioinput')
 
@@ -77,8 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
       selectEl.value = DEFAULT_MIC_VALUE
       if (prefs.preferredMicDeviceId) {
-        await storageRemove(['preferredMicDeviceId', 'preferredMicLabel'])
-        await storageSet({ preferredMicUpdatedAt: Date.now() })
+        await clearMicPreferences()
       }
     }
 
@@ -112,17 +89,15 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
       const selectedValue = selectEl.value
       if (selectedValue === DEFAULT_MIC_VALUE) {
-        await storageRemove(['preferredMicDeviceId', 'preferredMicLabel'])
-        await storageSet({ preferredMicUpdatedAt: Date.now() })
+        await clearMicPreferences()
         setStatus('Saved: Default microphone.')
         return
       }
 
       const selectedOption = selectEl.selectedOptions[0]
-      await storageSet({
+      await setMicPreferences({
         preferredMicDeviceId: selectedValue,
-        preferredMicLabel: selectedOption?.textContent || 'Selected microphone',
-        preferredMicUpdatedAt: Date.now()
+        preferredMicLabel: selectedOption?.textContent || 'Selected microphone'
       })
       setStatus(`Saved: ${selectedOption?.textContent || 'Selected microphone'}.`)
     } catch (error) {

--- a/src/micsetup.ts
+++ b/src/micsetup.ts
@@ -1,6 +1,9 @@
 // src/micsetup.ts
 
+import { captureException, initDiagnostics } from './diagnostics'
 import { clearMicPreferences, getMicPreferences, setMicPreferences } from './micPreferences'
+
+initDiagnostics('micsetup')
 
 const DEFAULT_MIC_VALUE = '__default__'
 
@@ -28,6 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return true
     } catch (error) {
       console.error('[micsetup] getUserMedia error:', error)
+      captureException(error, { operation: 'requestPermission' })
       setStatus(`Microphone blocked: ${describeError(error)}. Check Chrome and OS settings.`)
       return false
     }
@@ -74,6 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
       await renderDevices()
     } catch (error) {
       console.error('[micsetup] enumerateDevices error:', error)
+      captureException(error, { operation: 'loadDevices' })
       setStatus(`Could not list microphones: ${describeError(error)}`)
     }
   }
@@ -81,6 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
   refreshBtn.addEventListener('click', () => {
     loadDevices().catch((error) => {
       console.error('[micsetup] refresh error:', error)
+      captureException(error, { operation: 'refreshDevices' })
       setStatus(`Could not refresh microphones: ${describeError(error)}`)
     })
   })
@@ -102,12 +108,14 @@ document.addEventListener('DOMContentLoaded', () => {
       setStatus(`Saved: ${selectedOption?.textContent || 'Selected microphone'}.`)
     } catch (error) {
       console.error('[micsetup] save error:', error)
+      captureException(error, { operation: 'saveMicrophone' })
       setStatus(`Could not save microphone: ${describeError(error)}`)
     }
   })
 
   loadDevices().catch((error) => {
     console.error('[micsetup] initial load error:', error)
+    captureException(error, { operation: 'initialLoad' })
     setStatus(`Could not load microphones: ${describeError(error)}`)
   })
 })

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1,16 +1,13 @@
 // src/offscreen.ts
 
+import { clearMicPreferences, getMicPreferences } from './micPreferences'
+
 // Włączone oznacza dodanie lokalnego mikrofonu do miksu nagrania.
 // UWAGA: offscreen nie może pokazać początkowej prośby o uprawnienie mikrofonu.
 // Trzeba raz przygotować uprawnienie mikrofonu z widocznej strony
 // (popup/opcje/karta rozszerzenia) przez navigator.mediaDevices.getUserMedia({ audio: true }).
 const WANT_MIC_MIX = true
 const MEDIA_CAPTURE_TIMEOUT_MS = 10_000
-
-interface OffscreenMicPreferences {
-  preferredMicDeviceId?: string | null
-  preferredMicLabel?: string | null
-}
 
 window.addEventListener('error', (e) => {
   console.error('[offscreen] window.onerror', e?.message, e?.error)
@@ -113,22 +110,6 @@ function inferSuffixFromActiveTabUrl(url?: string | null): string {
   } catch { return 'google-meet' }
 }
 
-function getOffscreenMicPreferences(): Promise<OffscreenMicPreferences> {
-  return new Promise((resolve) => {
-    chrome.storage.local.get(['preferredMicDeviceId', 'preferredMicLabel'], (items) => {
-      resolve(items as OffscreenMicPreferences)
-    })
-  })
-}
-
-function clearPreferredMicDevice(): Promise<void> {
-  return new Promise((resolve) => {
-    chrome.storage.local.remove(['preferredMicDeviceId', 'preferredMicLabel'], () => {
-      chrome.storage.local.set({ preferredMicUpdatedAt: Date.now() }, () => resolve())
-    })
-  })
-}
-
 function makeMicAudioConstraints(deviceId?: string | null): MediaTrackConstraints {
   return {
     ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
@@ -177,7 +158,7 @@ function attachRmsMeter(track: MediaStreamTrack, label: 'RAW' | 'FINAL') {
 // Nagrywanie i miksowanie.
 async function maybeGetMicStream(): Promise<MediaStream | null> {
   if (!WANT_MIC_MIX) return null
-  const prefs = await getOffscreenMicPreferences()
+  const prefs = await getMicPreferences()
 
   if (prefs.preferredMicDeviceId) {
     try {
@@ -194,7 +175,7 @@ async function maybeGetMicStream(): Promise<MediaStream | null> {
       log('selected mic getUserMedia failed; falling back to default mic:', prefs.preferredMicLabel || prefs.preferredMicDeviceId, e)
       if (isMissingSelectedMicError(e)) {
         log('selected mic is no longer available; clearing saved microphone preference')
-        await clearPreferredMicDevice()
+        await clearMicPreferences()
       }
     }
   }

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -376,33 +376,50 @@ function buildUploadInput(videoBlob: Blob, microphoneBlob: Blob | null): UploadR
 
 async function uploadRecordingUntilSuccess(input: UploadRecordingInput, attempt = 1): Promise<void> {
   uploadInProgress = true
-  pushUploadState(attempt === 1 ? 'uploading' : 'upload_retrying', { attempt })
+  let currentAttempt = attempt
 
-  try {
-    const result = await uploadRecordingOnce(input)
-    uploadInProgress = false
-    pushUploadState('uploaded', {
-      attempt,
-      recordingId: result.recordingId,
-      assets: result.assets
-    })
-    log('Upload completed', { recordingId: result.recordingId, assets: result.assets, attempt })
-  } catch (e) {
-    captureException(e, {
-      operation: 'uploadRecordingUntilSuccess',
-      attempt,
-      nextRetryMs: UPLOAD_RETRY_INTERVAL_MS
-    })
-    const nextRetryAt = Date.now() + UPLOAD_RETRY_INTERVAL_MS
-    log('Upload failed; retrying in 15 seconds', e)
-    pushUploadState('upload_retrying', {
-      attempt,
-      error: e instanceof Error ? e.message : String(e),
-      nextRetryAt
-    })
-    await sleep(UPLOAD_RETRY_INTERVAL_MS)
-    return uploadRecordingUntilSuccess(input, attempt + 1)
+  while (true) {
+    pushUploadState(currentAttempt === 1 ? 'uploading' : 'upload_retrying', { attempt: currentAttempt })
+
+    try {
+      const result = await uploadRecordingOnce(input)
+      uploadInProgress = false
+      pushUploadState('uploaded', {
+        attempt: currentAttempt,
+        recordingId: result.recordingId,
+        assets: result.assets
+      })
+      log('Upload completed', { recordingId: result.recordingId, assets: result.assets, attempt: currentAttempt })
+      return
+    } catch (e) {
+      captureException(e, {
+        operation: 'uploadRecordingUntilSuccess',
+        attempt: currentAttempt,
+        nextRetryMs: UPLOAD_RETRY_INTERVAL_MS
+      })
+      const nextRetryAt = Date.now() + UPLOAD_RETRY_INTERVAL_MS
+      log('Upload failed; retrying in 15 seconds', e)
+      pushUploadState('upload_retrying', {
+        attempt: currentAttempt,
+        error: e instanceof Error ? e.message : String(e),
+        nextRetryAt
+      })
+      await sleep(UPLOAD_RETRY_INTERVAL_MS)
+      currentAttempt += 1
+    }
   }
+}
+
+function stopMicrophoneRecorderAfterPrimaryError(): void {
+  resolveMicrophoneStop(null)
+  if (microphoneRecorder && microphoneRecorder.state !== 'inactive') {
+    try {
+      microphoneRecorder.stop()
+    } catch (e) {
+      log('microphone recorder stop after primary recorder error failed', e)
+    }
+  }
+  microphoneStoppedPromise = Promise.resolve(null)
 }
 
 function stopActiveRecorders(): void {
@@ -557,6 +574,7 @@ async function prepareAndRecord(
       clearTimeout(startTimeout)
       log('MediaRecorder error', e)
       captureException(e, { operation: 'MediaRecorder.onerror' })
+      stopMicrophoneRecorderAfterPrimaryError()
       try { baseStream.getTracks().forEach(t => t.stop()) } catch {}
       cleanupRecordingResources()
       mediaRecorder = null

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -2,15 +2,17 @@
 
 import { captureException, captureMessage, initDiagnostics } from './diagnostics'
 import type { MicPreferences } from './micPreferences'
+import { uploadRecordingOnce, type UploadRecordingInput } from './uploadClient'
 
 initDiagnostics('offscreen')
 
-// Włączone oznacza dodanie lokalnego mikrofonu do miksu nagrania.
+// Włączone oznacza przygotowanie osobnego assetu mikrofonu do uploadu.
 // UWAGA: offscreen nie może pokazać początkowej prośby o uprawnienie mikrofonu.
 // Trzeba raz przygotować uprawnienie mikrofonu z widocznej strony
 // (popup/opcje/karta rozszerzenia) przez navigator.mediaDevices.getUserMedia({ audio: true }).
-const WANT_MIC_MIX = true
+const WANT_MIC_ASSET = true
 const MEDIA_CAPTURE_TIMEOUT_MS = 10_000
+const UPLOAD_RETRY_INTERVAL_MS = 15_000
 
 window.addEventListener('error', (e) => {
   console.error('[offscreen] window.onerror', e?.message, e?.error)
@@ -41,8 +43,21 @@ function respond(req: any, payload: any) { getPort().postMessage({ __respFor: re
 
 // Popup używa tego do przełączania przycisków.
 function pushState(recording: boolean, extra?: Record<string, any>) {
-  try { (chrome.storage as any)?.session?.set?.({ recording }).catch?.(() => {}) } catch {}
-  getPort().postMessage({ type: 'RECORDING_STATE', recording, ...extra })
+  if (recording && !currentRecordingStartedAtMs) currentRecordingStartedAtMs = Date.now()
+  const recordingStartedAt = recording ? currentRecordingStartedAtMs : null
+  try {
+    (chrome.storage as any)?.session?.set?.({
+      recording,
+      recordingStartedAt
+    }).catch?.(() => {})
+  } catch {}
+  getPort().postMessage({ type: 'RECORDING_STATE', recording, recordingStartedAt, ...extra })
+}
+
+type UploadStatus = 'idle' | 'uploading' | 'upload_retrying' | 'uploaded'
+
+function pushUploadState(status: UploadStatus, extra?: Record<string, any>) {
+  getPort().postMessage({ type: 'UPLOAD_STATE', status, ...extra })
 }
 
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms))
@@ -117,15 +132,6 @@ function withStreamTimeout(
   })
 }
 
-function inferSuffixFromActiveTabUrl(url?: string | null): string {
-  try {
-    if (!url) return 'google-meet'
-    const u = new URL(url)
-    const last = u.pathname.split('/').pop() || 'google-meet'
-    return last
-  } catch { return 'google-meet' }
-}
-
 function makeMicAudioConstraints(deviceId?: string | null): MediaTrackConstraints {
   return {
     ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
@@ -180,7 +186,7 @@ function attachRmsMeter(track: MediaStreamTrack, label: 'RAW' | 'MIC' | 'FINAL')
   }
 }
 
-// Nagrywanie i miksowanie.
+// Nagrywanie i upload.
 async function requestClearMicPreferences(): Promise<void> {
   try {
     const response = await chrome.runtime.sendMessage({ type: 'CLEAR_MIC_PREFERENCES' })
@@ -194,7 +200,7 @@ async function requestClearMicPreferences(): Promise<void> {
 }
 
 async function maybeGetMicStream(prefs: MicPreferences): Promise<MediaStream | null> {
-  if (!WANT_MIC_MIX) return null
+  if (!WANT_MIC_ASSET) return null
 
   if (prefs.preferredMicDeviceId) {
     try {
@@ -235,46 +241,22 @@ async function maybeGetMicStream(prefs: MicPreferences): Promise<MediaStream | n
   }
 }
 
-function mixAudio(tabStream: MediaStream, micStream: MediaStream | null): MediaStream {
+function routeTabAudioToOutput(tabStream: MediaStream): void {
   const tabAudio = tabStream.getAudioTracks()[0]
-  if (!micStream || !tabAudio) return tabStream
+  if (!tabAudio) return
 
   const AC = (window.AudioContext || (window as any).webkitAudioContext) as typeof AudioContext
   const ctx = trackAudioContext(new AC())
   void ctx.resume().catch(() => {})
-  const dst = ctx.createMediaStreamDestination()
 
   try {
     const tabSource = trackAudioNode(ctx.createMediaStreamSource(new MediaStream([tabAudio])))
-    tabSource.connect(dst)
     // Chrome tabCapture może odciąć lokalny odsłuch przechwytywanej karty.
-    // Kierujemy tylko audio karty do głośników, bez monitoringu mikrofonu.
     tabSource.connect(ctx.destination)
   } catch (err) {
-    log('tab source connect failed for mixing; using tab audio only', err)
+    log('tab source connect failed for local playback', err)
     captureException(err, { operation: 'mixTabAudio' })
-    return tabStream
   }
-
-  try {
-    const micTrack = micStream.getAudioTracks()[0]
-    if (micTrack) {
-      const micSource = trackAudioNode(ctx.createMediaStreamSource(new MediaStream([micTrack])))
-      micSource.connect(dst)
-    }
-  } catch (e) {
-    log('mic source connect failed; continuing with tab audio only', e)
-    captureException(e, { operation: 'mixMicAudio' })
-  }
-
-  const final = new MediaStream([
-    ...tabStream.getVideoTracks(),
-    ...dst.stream.getAudioTracks()
-  ])
-  trackStream(final)
-
-  // NIE zatrzymuj tutaj tabAudio; zatrzymanie zabije źródło nadrzędne.
-  return final
 }
 
 // Buduje ograniczenia z użyciem streamId. Najpierw próbuje 'tab', potem 'desktop'.
@@ -317,16 +299,134 @@ async function captureWithStreamId(streamId: string): Promise<MediaStream> {
 }
 
 let mediaRecorder: MediaRecorder | null = null
+let microphoneRecorder: MediaRecorder | null = null
 let chunks: BlobPart[] = []
+let microphoneChunks: BlobPart[] = []
 let capturing = false
+let uploadInProgress = false
+let currentRecordingStartedAtMs: number | null = null
+let currentRecordingContext: RecordingContext | null = null
+let microphoneStoppedPromise: Promise<Blob | null> | null = null
+let resolveMicrophoneStopped: ((blob: Blob | null) => void) | null = null
+
+interface RecordingContext {
+  tabUrl?: string | null
+  tabTitle?: string | null
+}
 
 interface RecordingStartInfo {
   micIncluded: boolean
   warning?: string
 }
 
-async function prepareAndRecord(baseStream: MediaStream, micPreferences: MicPreferences): Promise<RecordingStartInfo> {
+function chooseVideoMime(): string {
+  return MediaRecorder.isTypeSupported('video/webm;codecs=vp8,opus')
+    ? 'video/webm;codecs=vp8,opus'
+    : 'video/webm'
+}
+
+function chooseMicrophoneMime(): string {
+  return MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+    ? 'audio/webm;codecs=opus'
+    : 'audio/webm'
+}
+
+function inferMeetingId(url?: string | null): string | undefined {
+  try {
+    if (!url) return undefined
+    const u = new URL(url)
+    if (u.hostname !== 'meet.google.com') return undefined
+    const suffix = u.pathname.split('/').filter(Boolean).pop()
+    if (!suffix) return undefined
+    return /^[a-z]{3}-[a-z]{4}-[a-z]{3}$/i.test(suffix) ? suffix : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function fallbackTitleFromUrl(url?: string | null): string {
+  try {
+    if (!url) return 'Browser recording'
+    const u = new URL(url)
+    const path = u.pathname.split('/').filter(Boolean).pop()
+    return path ? `${u.hostname}/${path}` : u.hostname
+  } catch {
+    return 'Browser recording'
+  }
+}
+
+function buildUploadInput(videoBlob: Blob, microphoneBlob: Blob | null): UploadRecordingInput {
+  const now = Date.now()
+  const startedAtMs = currentRecordingStartedAtMs || now
+  const tabTitle = currentRecordingContext?.tabTitle?.trim()
+  const tabUrl = currentRecordingContext?.tabUrl || null
+  const meetingId = inferMeetingId(tabUrl)
+  const title = tabTitle || fallbackTitleFromUrl(tabUrl)
+
+  return {
+    title,
+    meetingId,
+    meetingTitle: tabTitle || undefined,
+    startedAt: new Date(startedAtMs).toISOString(),
+    durationMs: Math.max(1, now - startedAtMs),
+    videoBlob,
+    microphoneBlob: microphoneBlob && microphoneBlob.size > 0 ? microphoneBlob : null
+  }
+}
+
+async function uploadRecordingUntilSuccess(input: UploadRecordingInput, attempt = 1): Promise<void> {
+  uploadInProgress = true
+  pushUploadState(attempt === 1 ? 'uploading' : 'upload_retrying', { attempt })
+
+  try {
+    const result = await uploadRecordingOnce(input)
+    uploadInProgress = false
+    pushUploadState('uploaded', {
+      attempt,
+      recordingId: result.recordingId,
+      assets: result.assets
+    })
+    log('Upload completed', { recordingId: result.recordingId, assets: result.assets, attempt })
+  } catch (e) {
+    captureException(e, {
+      operation: 'uploadRecordingUntilSuccess',
+      attempt,
+      nextRetryMs: UPLOAD_RETRY_INTERVAL_MS
+    })
+    const nextRetryAt = Date.now() + UPLOAD_RETRY_INTERVAL_MS
+    log('Upload failed; retrying in 15 seconds', e)
+    pushUploadState('upload_retrying', {
+      attempt,
+      error: e instanceof Error ? e.message : String(e),
+      nextRetryAt
+    })
+    await sleep(UPLOAD_RETRY_INTERVAL_MS)
+    return uploadRecordingUntilSuccess(input, attempt + 1)
+  }
+}
+
+function stopActiveRecorders(): void {
+  if (microphoneRecorder && microphoneRecorder.state !== 'inactive') {
+    try { microphoneRecorder.stop() } catch (e) { log('microphone recorder stop failed', e); resolveMicrophoneStop(null) }
+  }
+  if (mediaRecorder && mediaRecorder.state !== 'inactive') {
+    mediaRecorder.stop()
+  }
+}
+
+function resolveMicrophoneStop(blob: Blob | null): void {
+  const resolver: ((blob: Blob | null) => void) | null = resolveMicrophoneStopped
+  if (typeof resolver === 'function') resolver(blob)
+}
+
+async function prepareAndRecord(
+  baseStream: MediaStream,
+  micPreferences: MicPreferences,
+  recordingContext: RecordingContext
+): Promise<RecordingStartInfo> {
   trackStream(baseStream)
+  currentRecordingStartedAtMs = Date.now()
+  currentRecordingContext = recordingContext
   const a = baseStream.getAudioTracks()
   const v = baseStream.getVideoTracks()
   log('getUserMedia() tracks:', {
@@ -351,25 +451,25 @@ async function prepareAndRecord(baseStream: MediaStream, micPreferences: MicPref
   // Mierniki debugowe.
   const rawAudio = baseStream.getAudioTracks()[0]
   if (rawAudio) attachRmsMeter(rawAudio, 'RAW')
+  routeTabAudioToOutput(baseStream)
 
   const micStream = await maybeGetMicStream(micPreferences)
   const micTrack = micStream?.getAudioTracks()[0] || null
   if (micTrack) {
-    log('mic track ready for mixing:', 'muted:', micTrack.muted, 'enabled:', micTrack.enabled)
+    log('mic track ready for separate asset:', 'muted:', micTrack.muted, 'enabled:', micTrack.enabled)
     attachRmsMeter(micTrack, 'MIC')
-  } else if (WANT_MIC_MIX) {
+  } else if (WANT_MIC_ASSET) {
     captureMessage('microphone stream unavailable; recording tab audio only', 'warning', {
       operation: 'prepareAndRecord'
     })
   }
-  const mixedStream = mixAudio(baseStream, micStream)
 
-  const finalAudio = mixedStream.getAudioTracks()[0]
+  const finalAudio = baseStream.getAudioTracks()[0]
   if (finalAudio) attachRmsMeter(finalAudio, 'FINAL')
   if (!finalAudio) log('WARNING: final stream has NO audio track — recording will be silent')
   if (!finalAudio) captureMessage('final stream has no audio track', 'warning', { operation: 'prepareAndRecord' })
 
-  log('final stream tracks -> video:', mixedStream.getVideoTracks().length, 'audio:', mixedStream.getAudioTracks().length)
+  log('video_audio stream tracks -> video:', baseStream.getVideoTracks().length, 'audio:', baseStream.getAudioTracks().length)
 
   // Kontrola bezpieczeństwa; nie jest fatalna.
   if (rawAudio) {
@@ -395,11 +495,48 @@ async function prepareAndRecord(baseStream: MediaStream, micPreferences: MicPref
   }
 
   chunks = []
-  const mime = MediaRecorder.isTypeSupported('video/webm;codecs=vp8,opus')
-    ? 'video/webm;codecs=vp8,opus'
-    : 'video/webm'
+  microphoneChunks = []
+  const mime = chooseVideoMime()
+  const microphoneMime = chooseMicrophoneMime()
 
-  mediaRecorder = new MediaRecorder(mixedStream, {
+  microphoneStoppedPromise = Promise.resolve(null)
+  resolveMicrophoneStopped = null
+
+  if (micTrack) {
+    try {
+      const microphoneStream = trackStream(new MediaStream([micTrack]))
+      microphoneStoppedPromise = new Promise<Blob | null>((resolve) => {
+        resolveMicrophoneStopped = resolve
+      })
+      microphoneRecorder = new MediaRecorder(microphoneStream, {
+        mimeType: microphoneMime,
+        audioBitsPerSecond: 128_000
+      })
+
+      microphoneRecorder.ondataavailable = (e: BlobEvent) => {
+        if (e.data && e.data.size) microphoneChunks.push(e.data)
+      }
+
+      microphoneRecorder.onerror = (e: any) => {
+        log('Microphone MediaRecorder error', e)
+        captureException(e, { operation: 'MicrophoneMediaRecorder.onerror' })
+        resolveMicrophoneStop(null)
+      }
+
+      microphoneRecorder.onstop = () => {
+        const microphoneBlob = new Blob(microphoneChunks, { type: microphoneMime })
+        log('Microphone finalized; chunks =', microphoneChunks.length, 'blob.size =', microphoneBlob.size)
+        resolveMicrophoneStop(microphoneBlob.size > 0 ? microphoneBlob : null)
+      }
+    } catch (e) {
+      log('microphone recorder setup failed; continuing with video_audio only', e)
+      captureException(e, { operation: 'setupMicrophoneRecorder' })
+      microphoneRecorder = null
+      microphoneStoppedPromise = Promise.resolve(null)
+    }
+  }
+
+  mediaRecorder = new MediaRecorder(baseStream, {
     mimeType: mime,
     videoBitsPerSecond: 3_000_000,
     audioBitsPerSecond: 128_000
@@ -420,9 +557,10 @@ async function prepareAndRecord(baseStream: MediaStream, micPreferences: MicPref
       clearTimeout(startTimeout)
       log('MediaRecorder error', e)
       captureException(e, { operation: 'MediaRecorder.onerror' })
-      try { mixedStream.getTracks().forEach(t => t.stop()) } catch {}
+      try { baseStream.getTracks().forEach(t => t.stop()) } catch {}
       cleanupRecordingResources()
       mediaRecorder = null
+      microphoneRecorder = null
       capturing = false
       pushState(false)
       reject(new Error(e?.name || 'MediaRecorder error'))
@@ -434,38 +572,46 @@ async function prepareAndRecord(baseStream: MediaStream, micPreferences: MicPref
 
     mediaRecorder!.onstop = async () => {
       try {
-        const blob = new Blob(chunks, { type: mime })
-        log('Finalizing; chunks =', chunks.length, 'blob.size =', blob.size)
+        const videoBlob = new Blob(chunks, { type: mime })
+        const microphoneBlob = microphoneStoppedPromise ? await microphoneStoppedPromise : null
+        log('Finalizing; video chunks =', chunks.length, 'video blob.size =', videoBlob.size, 'microphone blob.size =', microphoneBlob?.size || 0)
 
-        // Sufiks nazwy pliku.
-        let suffix = 'google-meet'
-        try {
-          const tabs = await chrome.tabs.query({ active: true, currentWindow: true })
-          suffix = inferSuffixFromActiveTabUrl(tabs[0]?.url || null)
-        } catch {}
-
-        const filename = `google-meet-recording-${suffix}-${Date.now()}.webm`
-        const blobUrl = URL.createObjectURL(blob)
-        getPort().postMessage({ type: 'OFFSCREEN_SAVE', filename, blobUrl })
+        const uploadInput = buildUploadInput(videoBlob, microphoneBlob)
+        void uploadRecordingUntilSuccess(uploadInput).catch((e) => {
+          log('Unexpected upload retry loop failure', e)
+          captureException(e, { operation: 'uploadRecordingUntilSuccess.unhandled' })
+        })
       } catch (e) {
-        log('Finalize/Save failed', e)
+        log('Finalize/Upload failed', e)
         captureException(e, { operation: 'finalizeRecording' })
       } finally {
         cleanupRecordingResources()
         mediaRecorder = null
+        microphoneRecorder = null
         chunks = []
+        microphoneChunks = []
         capturing = false
         pushState(false)
       }
     }
   })
 
+  if (microphoneRecorder) {
+    try {
+      microphoneRecorder.start(1000)
+    } catch (e) {
+      log('microphone recorder start failed; continuing with video_audio only', e)
+      captureException(e, { operation: 'startMicrophoneRecorder' })
+      resolveMicrophoneStop(null)
+      microphoneRecorder = null
+    }
+  }
   mediaRecorder.start(1000)
 
   // Jeśli karta nawiguje albo kończy się ścieżka wideo, zatrzymaj automatycznie.
-  mixedStream.getVideoTracks()[0]?.addEventListener('ended', () => {
+  baseStream.getVideoTracks()[0]?.addEventListener('ended', () => {
     log('Video track ended')
-    if (mediaRecorder && capturing) { try { mediaRecorder.stop() } catch {} }
+    if (mediaRecorder && capturing) { try { stopActiveRecorders() } catch {} }
   })
 
   await started
@@ -475,20 +621,29 @@ async function prepareAndRecord(baseStream: MediaStream, micPreferences: MicPref
   }
 }
 
-async function startRecordingFromStreamId(streamId: string, micPreferences: MicPreferences): Promise<RecordingStartInfo> {
+async function startRecordingFromStreamId(
+  streamId: string,
+  micPreferences: MicPreferences,
+  recordingContext: RecordingContext
+): Promise<RecordingStartInfo> {
   if (capturing) {
     log('Already recording; ignoring start')
     return { micIncluded: true }
   }
+  if (uploadInProgress) {
+    throw new Error('Upload is still in progress')
+  }
   cleanupRecordingResources()
   try {
     const baseStream = await captureWithStreamId(streamId)
-    return await prepareAndRecord(baseStream, micPreferences)
+    return await prepareAndRecord(baseStream, micPreferences, recordingContext)
   } catch (e) {
     cleanupRecordingResources()
     captureException(e, { operation: 'startRecordingFromStreamId' })
     mediaRecorder = null
+    microphoneRecorder = null
     chunks = []
+    microphoneChunks = []
     capturing = false
     pushState(false)
     throw e
@@ -500,7 +655,7 @@ function stopRecording() {
     console.warn('[offscreen] Stop called but not recording')
     throw new Error('Not currently recording')
   }
-  try { mediaRecorder.stop() } catch (e) { console.error('[offscreen] Stop error', e); captureException(e, { operation: 'stopRecording' }); throw e }
+  try { stopActiveRecorders() } catch (e) { console.error('[offscreen] Stop error', e); captureException(e, { operation: 'stopRecording' }); throw e }
 }
 
 // RPC przez port.
@@ -514,9 +669,10 @@ rpcPort.onMessage.addListener(async (msg: any) => {
         preferredMicDeviceId: null,
         preferredMicLabel: null
       }) as MicPreferences
+      const recordingContext = (msg.recordingContext || {}) as RecordingContext
       try {
         // Poczekaj, aż nagrywanie faktycznie wystartuje.
-        const recordingInfo = await startRecordingFromStreamId(streamId, micPreferences)
+        const recordingInfo = await startRecordingFromStreamId(streamId, micPreferences, recordingContext)
         return respond(msg, { ok: true, ...recordingInfo })
       } catch (e: any) {
         captureException(e, { operation: 'OFFSCREEN_START' })
@@ -540,17 +696,13 @@ rpcPort.onMessage.addListener(async (msg: any) => {
         const res = await (chrome.storage as any)?.session?.get?.(['recording'])
         recording = !!res?.recording
       } catch {}
-      return respond(msg, { recording })
+      return respond(msg, { recording, uploadInProgress })
     }
 
     if (msg?.type === 'DIAG_ECHO') {
       return respond(msg, { ok: true, pong: 'offscreen-alive' })
     }
 
-    if (msg?.type === 'REVOKE_BLOB_URL' && typeof msg.blobUrl === 'string') {
-      try { URL.revokeObjectURL(msg.blobUrl) } catch {}
-      return
-    }
   } catch (e) {
     console.error('[offscreen] error', e)
     captureException(e, { operation: 'rpcPort.onMessage' })

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -49,6 +49,7 @@ const sleep = (ms: number) => new Promise(res => setTimeout(res, ms))
 
 let activeStreams = new Set<MediaStream>()
 let activeAudioContexts = new Set<AudioContext>()
+let activeAudioNodes = new Set<AudioNode>()
 let activeIntervals = new Set<number>()
 
 function trackStream<T extends MediaStream | null>(stream: T): T {
@@ -61,9 +62,19 @@ function trackAudioContext<T extends AudioContext>(ctx: T): T {
   return ctx
 }
 
+function trackAudioNode<T extends AudioNode>(node: T): T {
+  activeAudioNodes.add(node)
+  return node
+}
+
 function cleanupRecordingResources() {
   activeIntervals.forEach((id) => { try { clearInterval(id) } catch {} })
   activeIntervals.clear()
+
+  activeAudioNodes.forEach((node) => {
+    try { node.disconnect() } catch {}
+  })
+  activeAudioNodes.clear()
 
   activeStreams.forEach((stream) => {
     try { stream.getTracks().forEach((track) => track.stop()) } catch {}
@@ -138,13 +149,13 @@ function isMissingSelectedMicError(error: unknown): boolean {
 }
 
 // Prosty jednokanałowy miernik RMS do debugowania.
-function attachRmsMeter(track: MediaStreamTrack, label: 'RAW' | 'FINAL') {
+function attachRmsMeter(track: MediaStreamTrack, label: 'RAW' | 'MIC' | 'FINAL') {
   try {
     const AC = (window.AudioContext || (window as any).webkitAudioContext) as typeof AudioContext
     const ctx = trackAudioContext(new AC())
     void ctx.resume().catch(() => {})
-    const src = ctx.createMediaStreamSource(new MediaStream([track]))
-    const analyser = ctx.createAnalyser()
+    const src = trackAudioNode(ctx.createMediaStreamSource(new MediaStream([track])))
+    const analyser = trackAudioNode(ctx.createAnalyser())
     analyser.fftSize = 256
     const buf = new Uint8Array(analyser.frequencyBinCount)
     src.connect(analyser)
@@ -234,8 +245,11 @@ function mixAudio(tabStream: MediaStream, micStream: MediaStream | null): MediaS
   const dst = ctx.createMediaStreamDestination()
 
   try {
-    const tabSource = ctx.createMediaStreamSource(new MediaStream([tabAudio]))
+    const tabSource = trackAudioNode(ctx.createMediaStreamSource(new MediaStream([tabAudio])))
     tabSource.connect(dst)
+    // Chrome tabCapture może odciąć lokalny odsłuch przechwytywanej karty.
+    // Kierujemy tylko audio karty do głośników, bez monitoringu mikrofonu.
+    tabSource.connect(ctx.destination)
   } catch (err) {
     log('tab source connect failed for mixing; using tab audio only', err)
     captureException(err, { operation: 'mixTabAudio' })
@@ -245,7 +259,7 @@ function mixAudio(tabStream: MediaStream, micStream: MediaStream | null): MediaS
   try {
     const micTrack = micStream.getAudioTracks()[0]
     if (micTrack) {
-      const micSource = ctx.createMediaStreamSource(new MediaStream([micTrack]))
+      const micSource = trackAudioNode(ctx.createMediaStreamSource(new MediaStream([micTrack])))
       micSource.connect(dst)
     }
   } catch (e) {
@@ -306,7 +320,12 @@ let mediaRecorder: MediaRecorder | null = null
 let chunks: BlobPart[] = []
 let capturing = false
 
-async function prepareAndRecord(baseStream: MediaStream, micPreferences: MicPreferences): Promise<void> {
+interface RecordingStartInfo {
+  micIncluded: boolean
+  warning?: string
+}
+
+async function prepareAndRecord(baseStream: MediaStream, micPreferences: MicPreferences): Promise<RecordingStartInfo> {
   trackStream(baseStream)
   const a = baseStream.getAudioTracks()
   const v = baseStream.getVideoTracks()
@@ -334,6 +353,15 @@ async function prepareAndRecord(baseStream: MediaStream, micPreferences: MicPref
   if (rawAudio) attachRmsMeter(rawAudio, 'RAW')
 
   const micStream = await maybeGetMicStream(micPreferences)
+  const micTrack = micStream?.getAudioTracks()[0] || null
+  if (micTrack) {
+    log('mic track ready for mixing:', 'muted:', micTrack.muted, 'enabled:', micTrack.enabled)
+    attachRmsMeter(micTrack, 'MIC')
+  } else if (WANT_MIC_MIX) {
+    captureMessage('microphone stream unavailable; recording tab audio only', 'warning', {
+      operation: 'prepareAndRecord'
+    })
+  }
   const mixedStream = mixAudio(baseStream, micStream)
 
   const finalAudio = mixedStream.getAudioTracks()[0]
@@ -349,8 +377,8 @@ async function prepareAndRecord(baseStream: MediaStream, micPreferences: MicPref
       const AC = (window.AudioContext || (window as any).webkitAudioContext) as typeof AudioContext
       const ctx = trackAudioContext(new AC())
       await ctx.resume().catch(() => {})
-      const src = ctx.createMediaStreamSource(new MediaStream([rawAudio]))
-      const analyser = ctx.createAnalyser()
+      const src = trackAudioNode(ctx.createMediaStreamSource(new MediaStream([rawAudio])))
+      const analyser = trackAudioNode(ctx.createAnalyser())
       analyser.fftSize = 256
       const buf = new Uint8Array(analyser.frequencyBinCount)
       src.connect(analyser)
@@ -441,14 +469,21 @@ async function prepareAndRecord(baseStream: MediaStream, micPreferences: MicPref
   })
 
   await started
+  return {
+    micIncluded: !!micTrack,
+    warning: micTrack ? undefined : 'NO_MIC_AUDIO'
+  }
 }
 
-async function startRecordingFromStreamId(streamId: string, micPreferences: MicPreferences): Promise<void> {
-  if (capturing) { log('Already recording; ignoring start'); return }
+async function startRecordingFromStreamId(streamId: string, micPreferences: MicPreferences): Promise<RecordingStartInfo> {
+  if (capturing) {
+    log('Already recording; ignoring start')
+    return { micIncluded: true }
+  }
   cleanupRecordingResources()
   try {
     const baseStream = await captureWithStreamId(streamId)
-    await prepareAndRecord(baseStream, micPreferences)
+    return await prepareAndRecord(baseStream, micPreferences)
   } catch (e) {
     cleanupRecordingResources()
     captureException(e, { operation: 'startRecordingFromStreamId' })
@@ -481,8 +516,8 @@ rpcPort.onMessage.addListener(async (msg: any) => {
       }) as MicPreferences
       try {
         // Poczekaj, aż nagrywanie faktycznie wystartuje.
-        await startRecordingFromStreamId(streamId, micPreferences)
-        return respond(msg, { ok: true })
+        const recordingInfo = await startRecordingFromStreamId(streamId, micPreferences)
+        return respond(msg, { ok: true, ...recordingInfo })
       } catch (e: any) {
         captureException(e, { operation: 'OFFSCREEN_START' })
         return respond(msg, { ok: false, error: `${e?.name || 'Error'}: ${e?.message || e}` })

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1,6 +1,9 @@
 // src/offscreen.ts
 
-import { clearMicPreferences, getMicPreferences } from './micPreferences'
+import { captureException, captureMessage, initDiagnostics } from './diagnostics'
+import type { MicPreferences } from './micPreferences'
+
+initDiagnostics('offscreen')
 
 // Włączone oznacza dodanie lokalnego mikrofonu do miksu nagrania.
 // UWAGA: offscreen nie może pokazać początkowej prośby o uprawnienie mikrofonu.
@@ -11,9 +14,11 @@ const MEDIA_CAPTURE_TIMEOUT_MS = 10_000
 
 window.addEventListener('error', (e) => {
   console.error('[offscreen] window.onerror', e?.message, e?.error)
+  captureException(e?.error || e?.message, { operation: 'window.onerror' })
 })
 window.addEventListener('unhandledrejection', (e: any) => {
   console.error('[offscreen] unhandledrejection', e?.reason || e)
+  captureException(e?.reason || e, { operation: 'unhandledrejection' })
 })
 console.log('[offscreen] script loaded')
 
@@ -160,13 +165,25 @@ function attachRmsMeter(track: MediaStreamTrack, label: 'RAW' | 'FINAL') {
     })
   } catch (e) {
     log('meter setup failed (non-fatal)', e)
+    captureException(e, { operation: 'attachRmsMeter' })
   }
 }
 
 // Nagrywanie i miksowanie.
-async function maybeGetMicStream(): Promise<MediaStream | null> {
+async function requestClearMicPreferences(): Promise<void> {
+  try {
+    const response = await chrome.runtime.sendMessage({ type: 'CLEAR_MIC_PREFERENCES' })
+    if (response?.ok === false) {
+      log('clear saved microphone preference failed:', response.error)
+    }
+  } catch (e) {
+    log('clear saved microphone preference failed:', e)
+    captureException(e, { operation: 'requestClearMicPreferences' })
+  }
+}
+
+async function maybeGetMicStream(prefs: MicPreferences): Promise<MediaStream | null> {
   if (!WANT_MIC_MIX) return null
-  const prefs = await getMicPreferences()
 
   if (prefs.preferredMicDeviceId) {
     try {
@@ -181,9 +198,10 @@ async function maybeGetMicStream(): Promise<MediaStream | null> {
       return mic
     } catch (e) {
       log('selected mic getUserMedia failed; falling back to default mic:', prefs.preferredMicLabel || prefs.preferredMicDeviceId, e)
+      captureException(e, { operation: 'selectedMicGetUserMedia' })
       if (isMissingSelectedMicError(e)) {
         log('selected mic is no longer available; clearing saved microphone preference')
-        await clearMicPreferences()
+        await requestClearMicPreferences()
       }
     }
   }
@@ -201,6 +219,7 @@ async function maybeGetMicStream(): Promise<MediaStream | null> {
     return mic
   } catch (e) {
     log('mic getUserMedia failed (continuing without mic):', e)
+    captureException(e, { operation: 'defaultMicGetUserMedia' })
     return null
   }
 }
@@ -219,6 +238,7 @@ function mixAudio(tabStream: MediaStream, micStream: MediaStream | null): MediaS
     tabSource.connect(dst)
   } catch (err) {
     log('tab source connect failed for mixing; using tab audio only', err)
+    captureException(err, { operation: 'mixTabAudio' })
     return tabStream
   }
 
@@ -230,6 +250,7 @@ function mixAudio(tabStream: MediaStream, micStream: MediaStream | null): MediaS
     }
   } catch (e) {
     log('mic source connect failed; continuing with tab audio only', e)
+    captureException(e, { operation: 'mixMicAudio' })
   }
 
   const final = new MediaStream([
@@ -272,6 +293,7 @@ async function captureWithStreamId(streamId: string): Promise<MediaStream> {
     return s
   } catch (e1: any) {
     log('[gUM] failed for chromeMediaSource=tab:', e1?.name || e1, e1?.message || e1)
+    captureException(e1, { operation: 'tabCaptureGetUserMedia' })
   }
   log(`Attempting getUserMedia with streamId ${streamId} source= desktop`)
   return await withStreamTimeout(
@@ -284,7 +306,7 @@ let mediaRecorder: MediaRecorder | null = null
 let chunks: BlobPart[] = []
 let capturing = false
 
-async function prepareAndRecord(baseStream: MediaStream): Promise<void> {
+async function prepareAndRecord(baseStream: MediaStream, micPreferences: MicPreferences): Promise<void> {
   trackStream(baseStream)
   const a = baseStream.getAudioTracks()
   const v = baseStream.getVideoTracks()
@@ -311,12 +333,13 @@ async function prepareAndRecord(baseStream: MediaStream): Promise<void> {
   const rawAudio = baseStream.getAudioTracks()[0]
   if (rawAudio) attachRmsMeter(rawAudio, 'RAW')
 
-  const micStream = await maybeGetMicStream()
+  const micStream = await maybeGetMicStream(micPreferences)
   const mixedStream = mixAudio(baseStream, micStream)
 
   const finalAudio = mixedStream.getAudioTracks()[0]
   if (finalAudio) attachRmsMeter(finalAudio, 'FINAL')
   if (!finalAudio) log('WARNING: final stream has NO audio track — recording will be silent')
+  if (!finalAudio) captureMessage('final stream has no audio track', 'warning', { operation: 'prepareAndRecord' })
 
   log('final stream tracks -> video:', mixedStream.getVideoTracks().length, 'audio:', mixedStream.getAudioTracks().length)
 
@@ -368,6 +391,7 @@ async function prepareAndRecord(baseStream: MediaStream): Promise<void> {
     mediaRecorder!.onerror = (e: any) => {
       clearTimeout(startTimeout)
       log('MediaRecorder error', e)
+      captureException(e, { operation: 'MediaRecorder.onerror' })
       try { mixedStream.getTracks().forEach(t => t.stop()) } catch {}
       cleanupRecordingResources()
       mediaRecorder = null
@@ -397,6 +421,7 @@ async function prepareAndRecord(baseStream: MediaStream): Promise<void> {
         getPort().postMessage({ type: 'OFFSCREEN_SAVE', filename, blobUrl })
       } catch (e) {
         log('Finalize/Save failed', e)
+        captureException(e, { operation: 'finalizeRecording' })
       } finally {
         cleanupRecordingResources()
         mediaRecorder = null
@@ -418,14 +443,15 @@ async function prepareAndRecord(baseStream: MediaStream): Promise<void> {
   await started
 }
 
-async function startRecordingFromStreamId(streamId: string): Promise<void> {
+async function startRecordingFromStreamId(streamId: string, micPreferences: MicPreferences): Promise<void> {
   if (capturing) { log('Already recording; ignoring start'); return }
   cleanupRecordingResources()
   try {
     const baseStream = await captureWithStreamId(streamId)
-    await prepareAndRecord(baseStream)
+    await prepareAndRecord(baseStream, micPreferences)
   } catch (e) {
     cleanupRecordingResources()
+    captureException(e, { operation: 'startRecordingFromStreamId' })
     mediaRecorder = null
     chunks = []
     capturing = false
@@ -439,7 +465,7 @@ function stopRecording() {
     console.warn('[offscreen] Stop called but not recording')
     throw new Error('Not currently recording')
   }
-  try { mediaRecorder.stop() } catch (e) { console.error('[offscreen] Stop error', e); throw e }
+  try { mediaRecorder.stop() } catch (e) { console.error('[offscreen] Stop error', e); captureException(e, { operation: 'stopRecording' }); throw e }
 }
 
 // RPC przez port.
@@ -449,11 +475,16 @@ rpcPort.onMessage.addListener(async (msg: any) => {
     if (msg?.type === 'OFFSCREEN_START') {
       const streamId = msg.streamId as string | undefined
       if (!streamId) return respond(msg, { ok: false, error: 'Missing streamId' })
+      const micPreferences = (msg.micPreferences || {
+        preferredMicDeviceId: null,
+        preferredMicLabel: null
+      }) as MicPreferences
       try {
         // Poczekaj, aż nagrywanie faktycznie wystartuje.
-        await startRecordingFromStreamId(streamId)
+        await startRecordingFromStreamId(streamId, micPreferences)
         return respond(msg, { ok: true })
       } catch (e: any) {
+        captureException(e, { operation: 'OFFSCREEN_START' })
         return respond(msg, { ok: false, error: `${e?.name || 'Error'}: ${e?.message || e}` })
       }
     }
@@ -487,6 +518,7 @@ rpcPort.onMessage.addListener(async (msg: any) => {
     }
   } catch (e) {
     console.error('[offscreen] error', e)
+    captureException(e, { operation: 'rpcPort.onMessage' })
     respond(msg, { ok: false, error: String(e) })
   }
 })

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -119,9 +119,17 @@ function makeMicAudioConstraints(deviceId?: string | null): MediaTrackConstraint
   }
 }
 
+function getOverconstrainedConstraint(error: DOMException): string | null {
+  const constraint = (error as DOMException & { constraint?: unknown }).constraint
+  return typeof constraint === 'string' ? constraint : null
+}
+
 function isMissingSelectedMicError(error: unknown): boolean {
-  return error instanceof DOMException &&
-    (error.name === 'OverconstrainedError' || error.name === 'NotFoundError')
+  if (!(error instanceof DOMException)) return false
+  if (error.name === 'NotFoundError') return true
+  if (error.name !== 'OverconstrainedError') return false
+
+  return getOverconstrainedConstraint(error) === 'deviceId'
 }
 
 // Prosty jednokanałowy miernik RMS do debugowania.

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -7,6 +7,11 @@
 const WANT_MIC_MIX = true
 const MEDIA_CAPTURE_TIMEOUT_MS = 10_000
 
+interface OffscreenMicPreferences {
+  preferredMicDeviceId?: string | null
+  preferredMicLabel?: string | null
+}
+
 window.addEventListener('error', (e) => {
   console.error('[offscreen] window.onerror', e?.message, e?.error)
 })
@@ -108,6 +113,36 @@ function inferSuffixFromActiveTabUrl(url?: string | null): string {
   } catch { return 'google-meet' }
 }
 
+function getOffscreenMicPreferences(): Promise<OffscreenMicPreferences> {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(['preferredMicDeviceId', 'preferredMicLabel'], (items) => {
+      resolve(items as OffscreenMicPreferences)
+    })
+  })
+}
+
+function clearPreferredMicDevice(): Promise<void> {
+  return new Promise((resolve) => {
+    chrome.storage.local.remove(['preferredMicDeviceId', 'preferredMicLabel'], () => {
+      chrome.storage.local.set({ preferredMicUpdatedAt: Date.now() }, () => resolve())
+    })
+  })
+}
+
+function makeMicAudioConstraints(deviceId?: string | null): MediaTrackConstraints {
+  return {
+    ...(deviceId ? { deviceId: { exact: deviceId } } : {}),
+    echoCancellation: true,
+    noiseSuppression: true,
+    autoGainControl: true
+  }
+}
+
+function isMissingSelectedMicError(error: unknown): boolean {
+  return error instanceof DOMException &&
+    (error.name === 'OverconstrainedError' || error.name === 'NotFoundError')
+}
+
 // Prosty jednokanałowy miernik RMS do debugowania.
 function attachRmsMeter(track: MediaStreamTrack, label: 'RAW' | 'FINAL') {
   try {
@@ -142,15 +177,33 @@ function attachRmsMeter(track: MediaStreamTrack, label: 'RAW' | 'FINAL') {
 // Nagrywanie i miksowanie.
 async function maybeGetMicStream(): Promise<MediaStream | null> {
   if (!WANT_MIC_MIX) return null
+  const prefs = await getOffscreenMicPreferences()
+
+  if (prefs.preferredMicDeviceId) {
+    try {
+      const mic = await withStreamTimeout(
+        navigator.mediaDevices.getUserMedia({
+          audio: makeMicAudioConstraints(prefs.preferredMicDeviceId)
+        }),
+        'selected mic getUserMedia'
+      )
+      const t = mic.getAudioTracks()[0]
+      log('selected mic stream acquired:', prefs.preferredMicLabel || prefs.preferredMicDeviceId, 'track:', !!t, 'muted:', t?.muted, 'enabled:', t?.enabled)
+      return mic
+    } catch (e) {
+      log('selected mic getUserMedia failed; falling back to default mic:', prefs.preferredMicLabel || prefs.preferredMicDeviceId, e)
+      if (isMissingSelectedMicError(e)) {
+        log('selected mic is no longer available; clearing saved microphone preference')
+        await clearPreferredMicDevice()
+      }
+    }
+  }
+
   try {
     // Działa tylko wtedy, gdy źródło rozszerzenia ma już nadane uprawnienie mikrofonu.
     const mic = await withStreamTimeout(
       navigator.mediaDevices.getUserMedia({
-        audio: {
-          echoCancellation: true,
-          noiseSuppression: true,
-          autoGainControl: true
-        }
+        audio: makeMicAudioConstraints()
       }),
       'mic getUserMedia'
     )

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,8 +1,14 @@
 // src/popup.ts
 
 const micBtn = document.getElementById('enable-mic') as HTMLButtonElement | null;
+const micStatusEl = document.getElementById('mic-status') as HTMLDivElement | null;
 const startBtn = document.getElementById('start-rec') as HTMLButtonElement | null;
 const stopBtn = document.getElementById('stop-rec') as HTMLButtonElement | null;
+
+interface PopupMicPreferences {
+  preferredMicDeviceId?: string | null
+  preferredMicLabel?: string | null
+}
 
 function setUI(recording: boolean) {
   if (!startBtn || !stopBtn) return;
@@ -19,30 +25,63 @@ async function openMicSetupTab() {
   await chrome.tabs.create({ url: chrome.runtime.getURL('micsetup.html') });
 }
 
+function getPopupMicPreferences(): Promise<PopupMicPreferences> {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(['preferredMicDeviceId', 'preferredMicLabel'], (items) => {
+      resolve(items as PopupMicPreferences)
+    })
+  })
+}
+
+async function refreshMicStatus() {
+  if (!micStatusEl) return
+  try {
+    const prefs = await getPopupMicPreferences()
+    micStatusEl.textContent = `Mic: ${prefs.preferredMicDeviceId ? (prefs.preferredMicLabel || 'Selected microphone') : 'Default microphone'}`
+  } catch {
+    micStatusEl.textContent = ''
+  }
+}
+
 // Odzwierciedla stan uprawnienia mikrofonu w etykiecie przycisku.
 async function refreshMicButton() {
-  if (!micBtn || !('permissions' in navigator)) return;
+  if (!micBtn) return;
+  micBtn.disabled = false;
+  if (!('permissions' in navigator)) {
+    micBtn.textContent = 'Microphone Settings';
+    micBtn.title = 'Choose which microphone should be included in recordings';
+    await refreshMicStatus();
+    return;
+  }
   try {
     // @ts-ignore - Chrome obsługuje tę nazwę uprawnienia.
     const status = await (navigator as any).permissions.query({ name: 'microphone' });
     const set = () => {
       micBtn.textContent =
         status.state === 'granted'
-          ? 'Microphone Enabled ✓'
+          ? 'Microphone Settings'
           : status.state === 'denied'
-          ? 'Microphone Blocked'
+          ? 'Microphone Settings'
           : 'Enable Microphone';
-      micBtn.disabled = status.state === 'granted';
+      micBtn.disabled = false;
       micBtn.title =
         status.state === 'granted'
-          ? 'Microphone is already enabled for this extension'
+          ? 'Choose which microphone should be included in recordings'
+          : status.state === 'denied'
+          ? 'Open microphone settings to review blocked access'
           : 'Grant microphone permission so your voice is included in recordings';
     };
     set();
-    status.onchange = set;
+    status.onchange = () => {
+      set();
+      refreshMicStatus().catch(() => {});
+    };
   } catch {
     // Permissions API może nie być dostępne.
+    micBtn.textContent = 'Microphone Settings';
+    micBtn.title = 'Choose which microphone should be included in recordings';
   }
+  await refreshMicStatus();
 }
 
 // Inicjalizacja: odczyt bieżącego stanu nagrywania i aktualizacja UI.
@@ -54,6 +93,7 @@ void (async () => {
     setUI(false);
   }
   refreshMicButton().catch(() => {});
+  refreshMicStatus().catch(() => {});
 })();
 
 // Reakcja na komunikaty stanu z tła/offscreen.
@@ -65,31 +105,17 @@ chrome.runtime.onMessage.addListener((msg) => {
   }
 });
 
-// Wstępne nadanie uprawnienia mikrofonu.
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName !== 'local') return;
+  if (changes.preferredMicDeviceId || changes.preferredMicLabel) {
+    refreshMicStatus().catch(() => {});
+  }
+});
+
+// Otwiera konfigurację mikrofonu.
 micBtn?.addEventListener('click', async () => {
   try {
-    if ('permissions' in navigator) {
-      // @ts-ignore
-      const p = await (navigator as any).permissions.query({ name: 'microphone' });
-      if (p.state === 'granted') {
-        alert('Microphone is already enabled for this extension.');
-        await refreshMicButton();
-        return;
-      }
-      if (p.state === 'denied') {
-        await openMicSetupTab();
-        return;
-      }
-    }
-    // Próba inline.
-    try {
-      const s = await navigator.mediaDevices.getUserMedia({ audio: true });
-      s.getTracks().forEach(t => t.stop());
-      alert('Microphone enabled for the extension.');
-      await refreshMicButton();
-    } catch {
-      await openMicSetupTab();
-    }
+    await openMicSetupTab();
   } catch (e) {
     console.error('[popup] mic enable flow error', e);
     alert('Could not open the microphone setup page. Please try again.');

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,14 +1,11 @@
 // src/popup.ts
 
+import { getMicPreferences, MIC_DEVICE_ID_KEY, MIC_LABEL_KEY } from './micPreferences'
+
 const micBtn = document.getElementById('enable-mic') as HTMLButtonElement | null;
 const micStatusEl = document.getElementById('mic-status') as HTMLDivElement | null;
 const startBtn = document.getElementById('start-rec') as HTMLButtonElement | null;
 const stopBtn = document.getElementById('stop-rec') as HTMLButtonElement | null;
-
-interface PopupMicPreferences {
-  preferredMicDeviceId?: string | null
-  preferredMicLabel?: string | null
-}
 
 function setUI(recording: boolean) {
   if (!startBtn || !stopBtn) return;
@@ -25,18 +22,10 @@ async function openMicSetupTab() {
   await chrome.tabs.create({ url: chrome.runtime.getURL('micsetup.html') });
 }
 
-function getPopupMicPreferences(): Promise<PopupMicPreferences> {
-  return new Promise((resolve) => {
-    chrome.storage.local.get(['preferredMicDeviceId', 'preferredMicLabel'], (items) => {
-      resolve(items as PopupMicPreferences)
-    })
-  })
-}
-
 async function refreshMicStatus() {
   if (!micStatusEl) return
   try {
-    const prefs = await getPopupMicPreferences()
+    const prefs = await getMicPreferences()
     micStatusEl.textContent = `Mic: ${prefs.preferredMicDeviceId ? (prefs.preferredMicLabel || 'Selected microphone') : 'Default microphone'}`
   } catch {
     micStatusEl.textContent = ''
@@ -93,7 +82,6 @@ void (async () => {
     setUI(false);
   }
   refreshMicButton().catch(() => {});
-  refreshMicStatus().catch(() => {});
 })();
 
 // Reakcja na komunikaty stanu z tła/offscreen.
@@ -107,7 +95,7 @@ chrome.runtime.onMessage.addListener((msg) => {
 
 chrome.storage.onChanged.addListener((changes, areaName) => {
   if (areaName !== 'local') return;
-  if (changes.preferredMicDeviceId || changes.preferredMicLabel) {
+  if (changes[MIC_DEVICE_ID_KEY] || changes[MIC_LABEL_KEY]) {
     refreshMicStatus().catch(() => {});
   }
 });

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,6 +1,9 @@
 // src/popup.ts
 
+import { captureException, initDiagnostics } from './diagnostics'
 import { getMicPreferences, MIC_DEVICE_ID_KEY, MIC_LABEL_KEY } from './micPreferences'
+
+initDiagnostics('popup')
 
 const micBtn = document.getElementById('enable-mic') as HTMLButtonElement | null;
 const micStatusEl = document.getElementById('mic-status') as HTMLDivElement | null;
@@ -106,6 +109,7 @@ micBtn?.addEventListener('click', async () => {
     await openMicSetupTab();
   } catch (e) {
     console.error('[popup] mic enable flow error', e);
+    captureException(e, { operation: 'openMicSetupTab' });
     alert('Could not open the microphone setup page. Please try again.');
   }
 });
@@ -148,6 +152,7 @@ startBtn?.addEventListener('click', async () => {
     toast('Recording started');
   } catch (e: any) {
     console.error('[popup] START_RECORDING error', e);
+    captureException(e, { operation: 'START_RECORDING' });
     setUI(false);
     alert(`Failed to start recording:\n${e?.message || e}`);
   } finally {
@@ -168,6 +173,7 @@ stopBtn?.addEventListener('click', async () => {
     toast('Stopping… finalizing…');
   } catch (e: any) {
     console.error('[popup] STOP_RECORDING error', e);
+    captureException(e, { operation: 'STOP_RECORDING' });
     alert(`Failed to stop recording:\n${e?.message || e}`);
     setUI(false);
   } finally {

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -12,6 +12,12 @@ const recordingStatusEl = document.getElementById('recording-status') as HTMLDiv
 
 let recordingTimerId: number | null = null;
 let isRecording = false;
+let isStarting = false;
+let isStopping = false;
+let currentRecordingStartedAt: number | null = null;
+type UploadStatus = 'idle' | 'uploading' | 'upload_retrying' | 'uploaded';
+let uploadStatus: UploadStatus = 'idle';
+let uploadRetryTimerId: number | null = null;
 
 function formatDuration(ms: number): string {
   const totalSeconds = Math.max(0, Math.floor(ms / 1000));
@@ -24,18 +30,28 @@ function formatDuration(ms: number): string {
   return `${hours}:${mm}:${ss}`;
 }
 
-function stopRecordingTimer() {
+function stopRecordingTimer(clearStatus = true) {
   if (recordingTimerId !== null) {
     window.clearInterval(recordingTimerId);
     recordingTimerId = null;
   }
-  if (recordingStatusEl) recordingStatusEl.textContent = 'Not recording';
+  if (clearStatus && recordingStatusEl) recordingStatusEl.textContent = 'Not recording';
+}
+
+function stopUploadRetryTimer() {
+  if (uploadRetryTimerId !== null) {
+    window.clearInterval(uploadRetryTimerId);
+    uploadRetryTimerId = null;
+  }
 }
 
 function startRecordingTimer(startedAt?: number | null) {
   if (!recordingStatusEl) return;
   if (recordingTimerId !== null) window.clearInterval(recordingTimerId);
-  const baseStartedAt = typeof startedAt === 'number' ? startedAt : Date.now();
+  const baseStartedAt = typeof startedAt === 'number'
+    ? startedAt
+    : currentRecordingStartedAt ?? Date.now();
+  currentRecordingStartedAt = baseStartedAt;
   const render = () => {
     recordingStatusEl.textContent = `Recording: ${formatDuration(Date.now() - baseStartedAt)}`;
   };
@@ -43,16 +59,81 @@ function startRecordingTimer(startedAt?: number | null) {
   recordingTimerId = window.setInterval(render, 1000);
 }
 
-function setUI(recording: boolean, recordingStartedAt?: number | null) {
+function setUI(
+  recording: boolean,
+  recordingStartedAt?: number | null,
+  starting = isStarting,
+  stopping = isStopping
+) {
   isRecording = recording;
+  isStarting = starting;
+  isStopping = stopping;
+  if (typeof recordingStartedAt === 'number') currentRecordingStartedAt = recordingStartedAt;
+  if (!recording && !starting && !stopping) currentRecordingStartedAt = null;
   if (!recordingToggleBtn) return;
+  if (uploadStatus === 'uploading' || uploadStatus === 'upload_retrying') {
+    stopRecordingTimer(false);
+    recordingToggleBtn.disabled = true;
+    recordingToggleBtn.textContent = uploadStatus === 'uploading' ? 'Uploading...' : 'Retrying Upload...';
+    return;
+  }
+  if (isStarting) {
+    stopRecordingTimer(false);
+    recordingToggleBtn.disabled = true;
+    recordingToggleBtn.textContent = 'Starting...';
+    if (recordingStatusEl) recordingStatusEl.textContent = 'Starting recording...';
+    return;
+  }
+  if (isStopping) {
+    stopRecordingTimer(false);
+    recordingToggleBtn.disabled = true;
+    recordingToggleBtn.textContent = 'Stopping...';
+    if (recordingStatusEl) recordingStatusEl.textContent = 'Stopping recording...';
+    return;
+  }
   recordingToggleBtn.disabled = false;
-  recordingToggleBtn.textContent = recording ? 'Stop & Download' : 'Start Recording';
+  recordingToggleBtn.textContent = recording ? 'Stop & Upload' : 'Start Recording';
   if (recording) {
     startRecordingTimer(recordingStartedAt);
   } else {
     stopRecordingTimer();
   }
+}
+
+function setUploadUI(status: UploadStatus, error?: string | null, nextRetryAt?: number | null) {
+  uploadStatus = status;
+  stopUploadRetryTimer();
+
+  if (status === 'idle') {
+    if (!isRecording && recordingStatusEl) recordingStatusEl.textContent = 'Not recording';
+    setUI(isRecording, currentRecordingStartedAt);
+    return;
+  }
+
+  if (status === 'uploaded') {
+    setUI(false, null, false, false);
+    if (recordingStatusEl) recordingStatusEl.textContent = 'Uploaded';
+    return;
+  }
+
+  const renderRetry = () => {
+    if (!recordingStatusEl) return;
+    if (status === 'uploading') {
+      recordingStatusEl.textContent = 'Uploading...';
+      return;
+    }
+    const waitMs = typeof nextRetryAt === 'number' ? Math.max(0, nextRetryAt - Date.now()) : 0;
+    const waitSeconds = Math.ceil(waitMs / 1000);
+    recordingStatusEl.textContent = error
+      ? `Upload failed. Retrying in ${waitSeconds}s.`
+      : `Retrying upload in ${waitSeconds}s.`;
+  };
+
+  renderRetry();
+  if (status === 'upload_retrying') {
+    uploadRetryTimerId = window.setInterval(renderRetry, 1000);
+  }
+  setUI(false, null, false, false);
 }
 
 function toast(msg: string) {
@@ -119,19 +200,25 @@ async function refreshMicButton() {
 void (async () => {
   try {
     const st = await chrome.runtime.sendMessage({ type: 'GET_RECORDING_STATUS' });
-    setUI(!!st?.recording, st?.recordingStartedAt ?? null);
+    uploadStatus = st?.uploadStatus || 'idle';
+    setUI(!!st?.recording, st?.recordingStartedAt ?? st?.startRequestedAt ?? null, !!st?.starting, !!st?.stopping);
+    setUploadUI(uploadStatus, st?.uploadError ?? null, st?.uploadNextRetryAt ?? null);
   } catch {
-    setUI(false);
+    setUI(false, null, false, false);
   }
   refreshMicButton().catch(() => {});
 })();
 
 // Reakcja na komunikaty stanu z tła/offscreen.
 chrome.runtime.onMessage.addListener((msg) => {
-  if (msg?.type === 'RECORDING_STATE') setUI(!!msg.recording, msg.recordingStartedAt ?? null);
-  if (msg?.type === 'RECORDING_SAVED') {
-    toast(`Saved: ${msg.filename || 'recording.webm'}`);
-    setUI(false);
+  if (msg?.type === 'RECORDING_STATE') {
+    setUI(!!msg.recording, msg.recordingStartedAt ?? msg.startRequestedAt ?? null, !!msg.starting, !!msg.stopping);
+  }
+  if (msg?.type === 'UPLOAD_STATE') {
+    const status = msg.status as UploadStatus | undefined;
+    if (status === 'idle' || status === 'uploading' || status === 'upload_retrying' || status === 'uploaded') {
+      setUploadUI(status, typeof msg.error === 'string' ? msg.error : null, typeof msg.nextRetryAt === 'number' ? msg.nextRetryAt : null);
+    }
   }
 });
 
@@ -158,7 +245,7 @@ let inFlight = false;
 async function startRecording() {
   if (!recordingToggleBtn) return;
   inFlight = true;
-  recordingToggleBtn.disabled = true;
+  setUI(false, null, true, false);
 
   try {
     // Automatyczne przygotowanie mikrofonu, jeśli nie ma jeszcze uprawnienia.
@@ -184,9 +271,21 @@ async function startRecording() {
 
     const resp = await chrome.runtime.sendMessage({ type: 'START_RECORDING', tabId: tab.id });
     if (!resp) throw new Error('No response from background');
+    if (resp.starting) {
+      setUI(false, null, true, false);
+      return;
+    }
+    if (resp.stopping) {
+      setUI(isRecording, null, false, true);
+      return;
+    }
+    if (resp.recording) {
+      setUI(true, resp.recordingStartedAt ?? null, false, false);
+      return;
+    }
     if (resp.ok === false) throw new Error(resp.error || 'Failed to start');
 
-    setUI(true, resp.recordingStartedAt ?? null);
+    setUI(true, resp.recordingStartedAt ?? null, false, false);
     toast('Recording started');
     if (resp.warning === 'NO_MIC_AUDIO') {
       alert('Recording started, but microphone audio is unavailable. The file will contain tab audio only.');
@@ -194,7 +293,7 @@ async function startRecording() {
   } catch (e: any) {
     console.error('[popup] START_RECORDING error', e);
     captureException(e, { operation: 'START_RECORDING' });
-    setUI(false);
+    setUI(false, null, false, false);
     alert(`Failed to start recording:\n${e?.message || e}`);
   } finally {
     inFlight = false;
@@ -204,18 +303,18 @@ async function startRecording() {
 async function stopRecording() {
   if (!recordingToggleBtn) return;
   inFlight = true;
-  recordingToggleBtn.disabled = true;
+  setUI(true, null, false, true);
 
   try {
     const resp = await chrome.runtime.sendMessage({ type: 'STOP_RECORDING' });
     if (!resp) throw new Error('No response from background');
     if (resp.ok === false) throw new Error(resp.error || 'Failed to stop');
-    toast('Stopping… finalizing…');
+    toast('Stopping... uploading...');
   } catch (e: any) {
     console.error('[popup] STOP_RECORDING error', e);
     captureException(e, { operation: 'STOP_RECORDING' });
     alert(`Failed to stop recording:\n${e?.message || e}`);
-    setUI(false);
+    setUI(false, null, false, false);
   } finally {
     inFlight = false;
   }

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -150,6 +150,9 @@ startBtn?.addEventListener('click', async () => {
 
     setUI(true);
     toast('Recording started');
+    if (resp.warning === 'NO_MIC_AUDIO') {
+      alert('Recording started, but microphone audio is unavailable. The file will contain tab audio only.');
+    }
   } catch (e: any) {
     console.error('[popup] START_RECORDING error', e);
     captureException(e, { operation: 'START_RECORDING' });

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -7,13 +7,52 @@ initDiagnostics('popup')
 
 const micBtn = document.getElementById('enable-mic') as HTMLButtonElement | null;
 const micStatusEl = document.getElementById('mic-status') as HTMLDivElement | null;
-const startBtn = document.getElementById('start-rec') as HTMLButtonElement | null;
-const stopBtn = document.getElementById('stop-rec') as HTMLButtonElement | null;
+const recordingToggleBtn = document.getElementById('recording-toggle') as HTMLButtonElement | null;
+const recordingStatusEl = document.getElementById('recording-status') as HTMLDivElement | null;
 
-function setUI(recording: boolean) {
-  if (!startBtn || !stopBtn) return;
-  startBtn.disabled = recording;
-  stopBtn.disabled = !recording;
+let recordingTimerId: number | null = null;
+let isRecording = false;
+
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const mm = String(minutes).padStart(2, '0');
+  const ss = String(seconds).padStart(2, '0');
+  if (!hours) return `${mm}:${ss}`;
+  return `${hours}:${mm}:${ss}`;
+}
+
+function stopRecordingTimer() {
+  if (recordingTimerId !== null) {
+    window.clearInterval(recordingTimerId);
+    recordingTimerId = null;
+  }
+  if (recordingStatusEl) recordingStatusEl.textContent = 'Not recording';
+}
+
+function startRecordingTimer(startedAt?: number | null) {
+  if (!recordingStatusEl) return;
+  if (recordingTimerId !== null) window.clearInterval(recordingTimerId);
+  const baseStartedAt = typeof startedAt === 'number' ? startedAt : Date.now();
+  const render = () => {
+    recordingStatusEl.textContent = `Recording: ${formatDuration(Date.now() - baseStartedAt)}`;
+  };
+  render();
+  recordingTimerId = window.setInterval(render, 1000);
+}
+
+function setUI(recording: boolean, recordingStartedAt?: number | null) {
+  isRecording = recording;
+  if (!recordingToggleBtn) return;
+  recordingToggleBtn.disabled = false;
+  recordingToggleBtn.textContent = recording ? 'Stop & Download' : 'Start Recording';
+  if (recording) {
+    startRecordingTimer(recordingStartedAt);
+  } else {
+    stopRecordingTimer();
+  }
 }
 
 function toast(msg: string) {
@@ -80,7 +119,7 @@ async function refreshMicButton() {
 void (async () => {
   try {
     const st = await chrome.runtime.sendMessage({ type: 'GET_RECORDING_STATUS' });
-    setUI(!!st?.recording);
+    setUI(!!st?.recording, st?.recordingStartedAt ?? null);
   } catch {
     setUI(false);
   }
@@ -89,7 +128,7 @@ void (async () => {
 
 // Reakcja na komunikaty stanu z tła/offscreen.
 chrome.runtime.onMessage.addListener((msg) => {
-  if (msg?.type === 'RECORDING_STATE') setUI(!!msg.recording);
+  if (msg?.type === 'RECORDING_STATE') setUI(!!msg.recording, msg.recordingStartedAt ?? null);
   if (msg?.type === 'RECORDING_SAVED') {
     toast(`Saved: ${msg.filename || 'recording.webm'}`);
     setUI(false);
@@ -116,11 +155,10 @@ micBtn?.addEventListener('click', async () => {
 
 let inFlight = false;
 
-// Start nagrywania.
-startBtn?.addEventListener('click', async () => {
-  if (!startBtn || !stopBtn || inFlight) return;
+async function startRecording() {
+  if (!recordingToggleBtn) return;
   inFlight = true;
-  startBtn.disabled = true;
+  recordingToggleBtn.disabled = true;
 
   try {
     // Automatyczne przygotowanie mikrofonu, jeśli nie ma jeszcze uprawnienia.
@@ -148,7 +186,7 @@ startBtn?.addEventListener('click', async () => {
     if (!resp) throw new Error('No response from background');
     if (resp.ok === false) throw new Error(resp.error || 'Failed to start');
 
-    setUI(true);
+    setUI(true, resp.recordingStartedAt ?? null);
     toast('Recording started');
     if (resp.warning === 'NO_MIC_AUDIO') {
       alert('Recording started, but microphone audio is unavailable. The file will contain tab audio only.');
@@ -161,13 +199,12 @@ startBtn?.addEventListener('click', async () => {
   } finally {
     inFlight = false;
   }
-});
+}
 
-// Stop nagrywania.
-stopBtn?.addEventListener('click', async () => {
-  if (!startBtn || !stopBtn || inFlight) return;
+async function stopRecording() {
+  if (!recordingToggleBtn) return;
   inFlight = true;
-  stopBtn.disabled = true;
+  recordingToggleBtn.disabled = true;
 
   try {
     const resp = await chrome.runtime.sendMessage({ type: 'STOP_RECORDING' });
@@ -181,5 +218,15 @@ stopBtn?.addEventListener('click', async () => {
     setUI(false);
   } finally {
     inFlight = false;
+  }
+}
+
+// Start albo stop nagrywania, zależnie od bieżącego stanu.
+recordingToggleBtn?.addEventListener('click', async () => {
+  if (inFlight) return;
+  if (isRecording) {
+    await stopRecording();
+  } else {
+    await startRecording();
   }
 });

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -26,6 +26,9 @@ interface InitUploadResponse {
 }
 
 const DEFAULT_UPLOAD_API_BASE_URL = 'https://meet2note.com'
+const INIT_UPLOAD_TIMEOUT_MS = 30_000
+const COMPLETE_UPLOAD_TIMEOUT_MS = 30_000
+const ASSET_UPLOAD_TIMEOUT_MS = 5 * 60_000
 
 function getUploadApiBaseUrl(): string {
   const raw = typeof __UPLOAD_API_BASE_URL__ === 'string' && __UPLOAD_API_BASE_URL__.trim()
@@ -41,6 +44,30 @@ function makeUrl(path: string): string {
 
 function httpError(operation: string, response: Response): Error {
   return new Error(`${operation} failed with HTTP ${response.status}`)
+}
+
+async function fetchWithTimeout(
+  operation: string,
+  url: string,
+  init: RequestInit,
+  timeoutMs: number
+): Promise<Response> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal
+    })
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`${operation} timed out after ${Math.round(timeoutMs / 1000)} seconds`)
+    }
+    throw error
+  } finally {
+    clearTimeout(timeoutId)
+  }
 }
 
 async function parseInitResponse(response: Response): Promise<InitUploadResponse> {
@@ -68,11 +95,16 @@ async function initUpload(input: UploadRecordingInput): Promise<InitUploadRespon
   if (input.startedAt) body.startedAt = input.startedAt
   if (typeof input.durationMs === 'number' && input.durationMs > 0) body.durationMs = Math.floor(input.durationMs)
 
-  const response = await fetch(makeUrl('/api/upload/init'), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body)
-  })
+  const response = await fetchWithTimeout(
+    'init upload',
+    makeUrl('/api/upload/init'),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body)
+    },
+    INIT_UPLOAD_TIMEOUT_MS
+  )
 
   if (!response.ok) throw httpError('init upload', response)
   return parseInitResponse(response)
@@ -84,14 +116,19 @@ async function uploadAsset(
   path: 'video' | 'microphone',
   blob: Blob
 ): Promise<void> {
-  const response = await fetch(makeUrl(`/api/upload/${encodeURIComponent(recordingId)}/${path}`), {
-    method: 'PUT',
-    headers: {
-      'Content-Type': 'application/octet-stream',
-      'X-Upload-Token': uploadToken
+  const response = await fetchWithTimeout(
+    `upload ${path}`,
+    makeUrl(`/api/upload/${encodeURIComponent(recordingId)}/${path}`),
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'X-Upload-Token': uploadToken
+      },
+      body: blob
     },
-    body: blob
-  })
+    ASSET_UPLOAD_TIMEOUT_MS
+  )
 
   if (!response.ok) throw httpError(`upload ${path}`, response)
 }
@@ -101,14 +138,19 @@ async function completeUpload(
   uploadToken: string,
   assets: UploadAsset[]
 ): Promise<void> {
-  const response = await fetch(makeUrl(`/api/upload/${encodeURIComponent(recordingId)}/complete`), {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Upload-Token': uploadToken
+  const response = await fetchWithTimeout(
+    'complete upload',
+    makeUrl(`/api/upload/${encodeURIComponent(recordingId)}/complete`),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Upload-Token': uploadToken
+      },
+      body: JSON.stringify({ assets })
     },
-    body: JSON.stringify({ assets })
-  })
+    COMPLETE_UPLOAD_TIMEOUT_MS
+  )
 
   if (!response.ok) throw httpError('complete upload', response)
 }

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -1,0 +1,143 @@
+import { captureException } from './diagnostics'
+
+declare const __UPLOAD_API_BASE_URL__: string
+
+export type UploadAsset = 'video_audio' | 'microphone'
+
+export interface UploadRecordingInput {
+  title: string
+  meetingId?: string
+  meetingTitle?: string
+  startedAt?: string
+  durationMs?: number
+  videoBlob: Blob
+  microphoneBlob?: Blob | null
+}
+
+export interface UploadRecordingResult {
+  recordingId: string
+  assets: UploadAsset[]
+}
+
+interface InitUploadResponse {
+  recordingId: string
+  uploadToken: string
+  expiresAt: string
+}
+
+const DEFAULT_UPLOAD_API_BASE_URL = 'https://meet2note.com'
+
+function getUploadApiBaseUrl(): string {
+  const raw = typeof __UPLOAD_API_BASE_URL__ === 'string' && __UPLOAD_API_BASE_URL__.trim()
+    ? __UPLOAD_API_BASE_URL__.trim()
+    : DEFAULT_UPLOAD_API_BASE_URL
+
+  return raw.replace(/\/+$/, '')
+}
+
+function makeUrl(path: string): string {
+  return `${getUploadApiBaseUrl()}${path}`
+}
+
+function httpError(operation: string, response: Response): Error {
+  return new Error(`${operation} failed with HTTP ${response.status}`)
+}
+
+async function parseInitResponse(response: Response): Promise<InitUploadResponse> {
+  const data = await response.json().catch(() => null)
+  if (!data || typeof data !== 'object') throw new Error('init upload returned invalid JSON')
+
+  const recordingId = (data as { recordingId?: unknown }).recordingId
+  const uploadToken = (data as { uploadToken?: unknown }).uploadToken
+  const expiresAt = (data as { expiresAt?: unknown }).expiresAt
+
+  if (typeof recordingId !== 'string' || !recordingId) throw new Error('init upload missing recordingId')
+  if (typeof uploadToken !== 'string' || !uploadToken) throw new Error('init upload missing uploadToken')
+  if (typeof expiresAt !== 'string' || !expiresAt) throw new Error('init upload missing expiresAt')
+
+  return { recordingId, uploadToken, expiresAt }
+}
+
+async function initUpload(input: UploadRecordingInput): Promise<InitUploadResponse> {
+  const body: Record<string, unknown> = {
+    title: input.title
+  }
+
+  if (input.meetingId) body.meetingId = input.meetingId
+  if (input.meetingTitle) body.meetingTitle = input.meetingTitle
+  if (input.startedAt) body.startedAt = input.startedAt
+  if (typeof input.durationMs === 'number' && input.durationMs > 0) body.durationMs = Math.floor(input.durationMs)
+
+  const response = await fetch(makeUrl('/api/upload/init'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+
+  if (!response.ok) throw httpError('init upload', response)
+  return parseInitResponse(response)
+}
+
+async function uploadAsset(
+  recordingId: string,
+  uploadToken: string,
+  path: 'video' | 'microphone',
+  blob: Blob
+): Promise<void> {
+  const response = await fetch(makeUrl(`/api/upload/${encodeURIComponent(recordingId)}/${path}`), {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/octet-stream',
+      'X-Upload-Token': uploadToken
+    },
+    body: blob
+  })
+
+  if (!response.ok) throw httpError(`upload ${path}`, response)
+}
+
+async function completeUpload(
+  recordingId: string,
+  uploadToken: string,
+  assets: UploadAsset[]
+): Promise<void> {
+  const response = await fetch(makeUrl(`/api/upload/${encodeURIComponent(recordingId)}/complete`), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Upload-Token': uploadToken
+    },
+    body: JSON.stringify({ assets })
+  })
+
+  if (!response.ok) throw httpError('complete upload', response)
+}
+
+export async function uploadRecordingOnce(input: UploadRecordingInput): Promise<UploadRecordingResult> {
+  try {
+    const session = await initUpload(input)
+    const assets: UploadAsset[] = ['video_audio']
+
+    await uploadAsset(session.recordingId, session.uploadToken, 'video', input.videoBlob)
+
+    if (input.microphoneBlob && input.microphoneBlob.size > 0) {
+      await uploadAsset(session.recordingId, session.uploadToken, 'microphone', input.microphoneBlob)
+      assets.push('microphone')
+    }
+
+    await completeUpload(session.recordingId, session.uploadToken, assets)
+
+    return {
+      recordingId: session.recordingId,
+      assets
+    }
+  } catch (error) {
+    captureException(error, {
+      operation: 'uploadRecordingOnce',
+      hasMicrophoneAsset: !!input.microphoneBlob,
+      videoBytes: input.videoBlob.size,
+      microphoneBytes: input.microphoneBlob?.size || 0
+    })
+    throw error
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     background: './src/background.ts',
     offscreen: './src/offscreen.ts',
     micsetup: './src/micsetup.ts',
+    meetWatcher: './src/meetWatcher.ts',
   },
   output: {
     path: path.resolve(__dirname, 'dist'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,8 @@ module.exports = {
     new webpack.DefinePlugin({
       __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN || ''),
       __SENTRY_ENVIRONMENT__: JSON.stringify(process.env.SENTRY_ENVIRONMENT || 'chrome-extension-dev'),
-      __EXTENSION_VERSION__: JSON.stringify(manifest.version)
+      __EXTENSION_VERSION__: JSON.stringify(manifest.version),
+      __UPLOAD_API_BASE_URL__: JSON.stringify(process.env.UPLOAD_API_BASE_URL || 'https://meet2note.com')
     }),
     new CleanWebpackPlugin(),
     new CopyWebpackPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 const path = require('path')
+const webpack = require('webpack')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
+const manifest = require('./manifest.json')
 
 module.exports = {
   mode: 'production',
@@ -26,6 +28,11 @@ module.exports = {
     ]
   },
   plugins: [
+    new webpack.DefinePlugin({
+      __SENTRY_DSN__: JSON.stringify(process.env.SENTRY_DSN || ''),
+      __SENTRY_ENVIRONMENT__: JSON.stringify(process.env.SENTRY_ENVIRONMENT || 'chrome-extension-dev'),
+      __EXTENSION_VERSION__: JSON.stringify(manifest.version)
+    }),
     new CleanWebpackPlugin(),
     new CopyWebpackPlugin({
       patterns: [


### PR DESCRIPTION
## Zakres

1. Dodaje konfigurację mikrofonu w popupie i osobnej stronie ustawień.
2. Dodaje diagnostykę Sentry dla komponentów rozszerzenia.
3. Dodaje lifecycle nagrywania świadomy Google Meet, w tym stan gotowości `RDY`, auto-stop po opuszczeniu spotkania i timer nagrywania.
4. Przenosi domyślny przepływ po zatrzymaniu nagrywania na upload do backendu `https://meet2note.com` zamiast lokalnego pobierania pliku.
5. Dodaje retry uploadu co 15 sekund aż do skutku oraz stany UI `Uploading...` i `Retrying Upload...`.
6. Doprecyzowuje lokalny workflow builda przez `make` i Docker Compose.
7. Aktualizuje dokumentację, mapę systemu, runbook i spec `003`.

## Weryfikacja

1. `make check`
2. `git diff --check`

## Uwagi dla review

1. Proszę zgłaszać wszystkie znalezione uwagi w jednej rundzie review, bez dzielenia ich na wiele małych porcji.
2. Szczególnie proszę sprawdzić:
   a) odporność start/stop nagrywania na timeout offscreen,
   b) synchronizację stanu popup/background/offscreen,
   c) retry uploadu i blokowanie nowego nagrania podczas uploadu,
   d) minimalność uprawnień w `manifest.json`,
   e) koszt skanowania DOM w `meetWatcher`.