### PR TITLE
[codex] Add Meet2Note extension token flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,14 +84,17 @@ Ten plik definiuje zasady dla agentow AI i automatyzacji pracujacych w tym repoz
 5. Docelowy endpoint dla uploadu z rozszerzenia to `https://meet2note.com`.
    a) Na obecnym etapie traktuj `https://meet2note.com` jako srodowisko deweloperskie/prod-like, mimo ze domena wyglada produkcyjnie.
    b) Lokalny backend nadal moze dzialac pod `http://localhost:3000`.
-   c) Nie hardcoduj sekretow ani tokenow; upload uzywa tokenu zwracanego przez backend po inicjalizacji uploadu.
+   c) Nie hardcoduj sekretow ani tokenow; dlugotrwaly `extensionToken` jest zapisywany lokalnie po flow `Connect to Meet2Note`.
    d) Po wdrozeniu uploadu nie pobieraj automatycznie lokalnego pliku `.webm`; upload ma zastapic lokalny zapis.
 
-6. Obecny kontrakt uploadu:
-   a) `POST /api/upload/init` tworzy sesje uploadu i zwraca `recordingId`, `uploadToken` oraz `expiresAt`.
-   b) `PUT /api/upload/{recordingId}/video` wysyla asset `video_audio` jako `application/octet-stream` z naglowkiem `X-Upload-Token`.
-   c) `PUT /api/upload/{recordingId}/microphone` wysyla opcjonalny asset mikrofonu jako `application/octet-stream` z naglowkiem `X-Upload-Token`.
-   d) `POST /api/upload/{recordingId}/complete` konczy upload z naglowkiem `X-Upload-Token`.
+6. Obecny kontrakt polaczenia i uploadu:
+   a) `GET /extension/connect` uruchamia backendowy flow polaczenia wtyczki z kontem Meet2Note.
+   b) `POST /api/extension/token` wymienia jednorazowy `code` na dlugotrwaly `extensionToken`.
+   c) `POST /api/upload/init` wymaga `Authorization: Bearer <extensionToken>`, tworzy sesje uploadu i zwraca `recordingId`, `uploadToken` oraz `expiresAt`.
+   d) `PUT /api/upload/{recordingId}/video` wysyla asset `video_audio` jako `application/octet-stream` z naglowkami `Authorization` i `X-Upload-Token`.
+   e) `PUT /api/upload/{recordingId}/microphone` wysyla opcjonalny asset mikrofonu jako `application/octet-stream` z naglowkami `Authorization` i `X-Upload-Token`.
+   f) `POST /api/upload/{recordingId}/complete` konczy upload z naglowkami `Authorization` i `X-Upload-Token`.
+   g) Przy `401` albo `403` nie ponawiaj zwyklego uploadu bez konca; wyczysc token i pokaz koniecznosc ponownego polaczenia z Meet2Note.
 
 ## Komunikacja cross-repo
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,12 +117,10 @@ Gdy czlowiek napisze `+PR`, uruchom lokalna procedure pracy z Pull Requestem.
 2. Review Copilota
    a) Popros o review Copilota, jesli repozytorium to obsluguje.
    b) Poczekaj na wynik review.
-   c) Jesli Copilot zglosi uwagi, nie wdrazaj ich automatycznie.
-   d) Zbierz uwagi Copilota i przedstaw je czlowiekowi do decyzji, najlepiej pojedynczo.
-   e) Przy omawianiu uwagi podaj wystarczajacy kontekst techniczny, zeby czlowiek mogl podjac decyzje bez znajomosci detali implementacji.
-   f) Wyjasnij, czego uwaga dotyczy, jaki jest praktyczny skutek, jakie sa sensowne opcje i jaka opcje rekomendujesz.
-   g) Kazda uwage omow z czlowiekiem przed zmiana w kodzie.
-   h) Dopiero po zatwierdzeniu konkretnej uwagi przez czlowieka wprowadz zmiane.
+   c) Do odwolania wykonuj tylko jedna runde PR/CR z Copilotem.
+   d) Jesli Copilot zglosi techniczne uwagi, wdrazaj je wedlug wlasnej rekomendacji bez pytania czlowieka o kazda z nich.
+   e) Pytaj czlowieka tylko wtedy, gdy uwaga jest trade-offem, moze zmienic zalozenia funkcjonalne albo wymaga decyzji produktowej.
+   f) Jesli pytasz o uwage CR, podaj licznik w formacie `Pytanie X z Y` i wyjasnij kontekst szerzej niz jednym zdaniem.
 
 3. Odpowiedzi do review
    a) Na kazda uwage Copilota odpowiedz w watku:
@@ -134,17 +132,13 @@ Gdy czlowiek napisze `+PR`, uruchom lokalna procedure pracy z Pull Requestem.
 
 4. Kolejne rundy
    a) Po wdrozeniu zatwierdzonych przez czlowieka poprawek zrob commit i push.
-   b) Po odpowiedzeniu na wszystkie uwagi z danej rundy popros Copilota o ponowne review poprawek w tym samym PR.
-   c) Po ponowieniu review czekaj do 10 minut na kolejna porcje uwag Copilota.
-   d) Ponow review Copilota tylko wtedy, gdy nie przekracza to ustalonego limitu rund.
-   e) Domyslny limit to 3 rundy CR - poprawki - CR.
-   f) Po trzeciej rundzie poprawek wyslanych do PR nie pros Copilota o kolejne review automatycznie; uznaj proces Copilot CR za zakonczony.
+   b) Nie pros Copilota o ponowne review po wdrozeniu poprawek z jego rundy, chyba ze czlowiek wyraznie o to poprosi.
+   c) Po jednej rundzie CR i odpowiedzeniu na jej watki uznaj proces Copilot CR za zakonczony.
 
 5. Wazne zasady
-   a) Nigdy nie wdrazaj sugestii Copilota w ciemno.
-   b) Copilot jest reviewerem pomocniczym, nie decydentem.
-   c) Decyzje o zastosowaniu kazdej sugestii podejmuje czlowiek.
-   d) Jesli czlowiek prosi o szybkie poprawki, nadal pokaz uwagi Copilota przed ich wdrozeniem.
+   a) Copilot jest reviewerem pomocniczym, nie decydentem.
+   b) Decyzje techniczne podejmuj samodzielnie wedlug najlepszej rekomendacji, respektujac architekture projektu.
+   c) Decyzje produktowe, trade-offy i zmiany zalozen funkcjonalnych nadal eskaluj do czlowieka.
 
 ## Chrome Extension
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Jeśli wolisz wariant z botem albo aplikacją desktopową do nagrywania, zobacz 
 
 **Upload do backendu** - wysyła `video_audio` i opcjonalny `microphone` do `https://meet2note.com`.
 
+**Połączenie z kontem Meet2Note** - popup otwiera flow `Connect to Meet2Note`, zapisuje długotrwały token w `chrome.storage.local` i używa go przy uploadzie.
+
 **Retry uploadu** - jeśli upload się nie powiedzie, ponawia próbę co 15 sekund aż do sukcesu, bez lokalnego pobierania pliku.
 
 **Architektura MV3/Offscreen** - nagrywanie działa w ukrytym dokumencie offscreen.
@@ -25,9 +27,11 @@ Jeśli wolisz wariant z botem albo aplikacją desktopową do nagrywania, zobacz 
 
 1. Popup pozwala przygotować mikrofon oraz sterować nagrywaniem.
 
-2. Service worker w tle tworzy i koordynuje dokument offscreen oraz pobiera właściwy `streamId` przechwytywania dla aktywnej karty.
+2. Popup pozwala połączyć rozszerzenie z kontem Meet2Note przez backendowy flow i stronę callbacku `connect-callback.html`.
 
-3. Strona offscreen przechwytuje kartę, nagrywa osobny asset mikrofonu, finalizuje bloby i wysyła je do backendu.
+3. Service worker w tle tworzy i koordynuje dokument offscreen oraz pobiera właściwy `streamId` przechwytywania dla aktywnej karty.
+
+4. Strona offscreen przechwytuje kartę, nagrywa osobny asset mikrofonu, finalizuje bloby i wysyła je do backendu z tokenem użytkownika.
 
 ## Wymagania
 
@@ -78,8 +82,9 @@ Przy zmianach widocznych w przeglądarce wykonaj też test dymny z [`docs/runboo
 
 
 Otwórz Google Meet i kliknij ikonę rozszerzenia:
-1. **Enable Microphone / Microphone Settings** - otwiera konfigurację mikrofonu i pozwala wybrać urządzenie wejściowe.
-2. **Start Recording / Stop & Upload** - nagrywa kartę i wysyła wynik do `https://meet2note.com`.
+1. **Connect to Meet2Note** - otwiera backendowy flow połączenia z kontem użytkownika.
+2. **Enable Microphone / Microphone Settings** - otwiera konfigurację mikrofonu i pozwala wybrać urządzenie wejściowe.
+3. **Start Recording / Stop & Upload** - nagrywa kartę i wysyła wynik do `https://meet2note.com`.
 
 ## Instalacja i budowanie
 
@@ -122,9 +127,11 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
    a) Jest jeden przycisk konfiguracji mikrofonu: przy pierwszym użyciu ma etykietę **Enable Microphone**, otwiera stronę konfiguracji i prosi o dostęp do mikrofonu.
    b) Po nadaniu uprawnienia ten sam przycisk zmienia etykietę na **Microphone Settings** i pozwala później zmienić mikrofon.
    c) Na stronie konfiguracji wybierz `Default microphone` albo konkretne urządzenie wejściowe i kliknij `Save Microphone`.
-   d) **Start Recording** rozpoczyna nagrywanie bieżącej karty (wideo + audio systemowe). Jeśli mikrofon jest dostępny, zostanie nagrany jako osobny asset.
-   e) Podczas nagrywania ten sam przycisk zmienia się na **Stop & Upload**, finalizuje nagranie i wysyła assety do `https://meet2note.com`.
-   f) Status pod przyciskami pokazuje, czy nagrywanie trwa, czy trwa upload oraz kiedy nastąpi kolejna próba retry.
+   d) Jeśli popup pokazuje `Not connected`, kliknij **Connect to Meet2Note** i przejdź przez flow logowania/połączenia w backendzie.
+   e) Po połączeniu popup pokazuje konto Meet2Note, a token użytkownika jest zapisany w `chrome.storage.local`.
+   f) **Start Recording** rozpoczyna nagrywanie bieżącej karty (wideo + audio systemowe). Jeśli mikrofon jest dostępny, zostanie nagrany jako osobny asset.
+   g) Podczas nagrywania ten sam przycisk zmienia się na **Stop & Upload**, finalizuje nagranie i wysyła assety do `https://meet2note.com`.
+   h) Status pod przyciskami pokazuje, czy nagrywanie trwa, czy trwa upload oraz kiedy nastąpi kolejna próba retry.
 
 > Na aktywnym spotkaniu Google Meet rozszerzenie pokazuje znacznik `RDY`, a podczas nagrywania `REC`. Jeśli nagranie zostało rozpoczęte na karcie Meet, wyjście ze spotkania automatycznie zatrzymuje nagrywanie i uruchamia upload do backendu. Rozszerzenie nie zapisuje nagrań lokalnie przez Chrome Downloads API.
 
@@ -138,6 +145,7 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
 ├─ compose.yml
 ├─ Makefile
 ├─ popup.html
+├─ connect-callback.html
 ├─ offscreen.html
 ├─ micsetup.html
 ├─ .github/             # szablony GitHub, instrukcje Copilota i CI
@@ -145,6 +153,8 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
 ├─ scripts/             # lokalne skrypty pomocnicze
 ├─ src/
 │  ├─ background.ts     # service worker MV3: tworzy offscreen i koordynuje strumienie
+│  ├─ connectCallback.ts # callback flow połączenia Meet2Note
+│  ├─ extensionAuth.ts  # token użytkownika, state flow połączenia i storage
 │  ├─ offscreen.ts      # uruchamia nagrywarkę i wysyła assety do backendu
 │  ├─ popup.tsx         # UI popupu w React + Ant Design: mikrofon, start/stop
 │  ├─ micPreferences.ts # wspólne helpery zapisu wyboru mikrofonu
@@ -163,7 +173,8 @@ const WANT_MIC_ASSET = true
 
 2. Backend uploadu
   a) Domyślny URL: `https://meet2note.com`.
-  b) Możesz go zmienić przy buildzie:
+  b) Ten sam URL jest używany dla flow `Connect to Meet2Note`, callbacku wymiany kodu i uploadu.
+  c) Możesz go zmienić przy buildzie:
 
 ```
 UPLOAD_API_BASE_URL=http://localhost:3000 make build
@@ -234,8 +245,8 @@ Są już zadeklarowane w `package.json`:
 1. `activeTab`, `tabs` - odczyt aktywnej karty, potrzebny do wskazania i opisania nagrania.
 2. `tabCapture` / `desktopCapture` - przechwytywanie wideo i audio z bieżącej karty.
 3. `offscreen` - tworzenie dokumentu offscreen dla logiki nagrywania i uploadu działającej w tle.
-4. `storage` - zapis tymczasowych wskazówek o stanie nagrywania/uploadu dla synchronizacji UI.
-5. `host_permissions` dla `https://meet2note.com/*` - upload nagrań do backendu.
+4. `storage` - zapis tymczasowych wskazówek o stanie nagrywania/uploadu, wyboru mikrofonu oraz długotrwałego tokenu Meet2Note.
+5. `host_permissions` dla `https://meet2note.com/*` - flow połączenia konta, wymiana jednorazowego kodu i upload nagrań do backendu.
 6. `host_permissions` dla `https://sentry.eengine.pl/*` - wysyłka zdarzeń diagnostycznych do Sentry, gdy build zawiera DSN.
 7. `content_scripts` dla `https://meet.google.com/*` - content script wykrywa wejście i wyjście ze spotkania, żeby pokazać stan `RDY` i automatycznie zatrzymać nagrywanie po opuszczeniu spotkania.
 
@@ -270,6 +281,13 @@ Odpowiedź:
 1. Sprawdź, czy `https://meet2note.com` działa i czy przeglądarka ma połączenie z siecią.
 2. Rozszerzenie ponawia pełną próbę uploadu co 15 sekund aż do sukcesu.
 3. Nie zamykaj przeglądarki ani nie przeładowuj rozszerzenia, bo gotowe bloby są trzymane w pamięci i mogą zostać utracone.
+
+Pytanie: Popup pokazuje `Connect to Meet2Note` albo `Reconnect to Meet2Note`. Co zrobić?
+Odpowiedź:
+1. Kliknij `Connect to Meet2Note`.
+2. Jeśli backend poprosi o logowanie, zaloguj się kontem Google.
+3. Po udanym callbacku wróć do popupu i sprawdź, czy pokazuje połączone konto.
+4. Jeśli backend odrzuci token przy uploadzie, rozszerzenie przerywa zwykły retry i wymaga ponownego połączenia.
 
 Pytanie: Dlaczego przyciski w popupie nie włączają się albo nie wyłączają poprawnie?
 Odpowiedź:

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Rozszerzenie używa następujących uprawnień Chrome:
 `activeTab`, `tabCapture`, `offscreen`, `storage`, `tabs`, `desktopCapture`.
 
 Rozszerzenie ma też wąskie `host_permissions` dla:
-1. `https://meet2note.com/*` - upload nagrań do backendu.
-2. `https://sentry.eengine.pl/*` - opcjonalna diagnostyka błędów, jeśli build zawiera DSN Sentry.
+1. `https://meet2note.com/*` - flow połączenia konta, wymiana kodu i upload nagrań do backendu.
+2. `http://localhost/*` oraz `http://127.0.0.1/*` - lokalne testy integracyjne z backendem podczas developmentu.
+3. `https://sentry.eengine.pl/*` - opcjonalna diagnostyka błędów, jeśli build zawiera DSN Sentry.
 
 ## Szybki start
 
@@ -247,8 +248,9 @@ Są już zadeklarowane w `package.json`:
 3. `offscreen` - tworzenie dokumentu offscreen dla logiki nagrywania i uploadu działającej w tle.
 4. `storage` - zapis tymczasowych wskazówek o stanie nagrywania/uploadu, wyboru mikrofonu oraz długotrwałego tokenu Meet2Note.
 5. `host_permissions` dla `https://meet2note.com/*` - flow połączenia konta, wymiana jednorazowego kodu i upload nagrań do backendu.
-6. `host_permissions` dla `https://sentry.eengine.pl/*` - wysyłka zdarzeń diagnostycznych do Sentry, gdy build zawiera DSN.
-7. `content_scripts` dla `https://meet.google.com/*` - content script wykrywa wejście i wyjście ze spotkania, żeby pokazać stan `RDY` i automatycznie zatrzymać nagrywanie po opuszczeniu spotkania.
+6. `host_permissions` dla `http://localhost/*` oraz `http://127.0.0.1/*` - lokalne endpointy developerskie używane podczas testów integracji i uploadu poza docelowym środowiskiem `https://meet2note.com`.
+7. `host_permissions` dla `https://sentry.eengine.pl/*` - wysyłka zdarzeń diagnostycznych do Sentry, gdy build zawiera DSN.
+8. `content_scripts` dla `https://meet.google.com/*` - content script wykrywa wejście i wyjście ze spotkania, żeby pokazać stan `RDY` i automatycznie zatrzymać nagrywanie po opuszczeniu spotkania.
 
 ## Rozwiązywanie problemów / FAQ
 

--- a/compose.yml
+++ b/compose.yml
@@ -16,6 +16,7 @@ services:
       - ./tsconfig.json:/workspace/tsconfig.json:ro
       - ./webpack.config.js:/workspace/webpack.config.js:ro
       - ./manifest.json:/workspace/manifest.json:ro
+      - ./connect-callback.html:/workspace/connect-callback.html:ro
       - ./popup.html:/workspace/popup.html:ro
       - ./offscreen.html:/workspace/offscreen.html:ro
       - ./micsetup.html:/workspace/micsetup.html:ro

--- a/connect-callback.html
+++ b/connect-callback.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Meet2Note Connection</title>
+  <style>
+    body {
+      align-items: center;
+      background: #f5f5f5;
+      color: #1f1f1f;
+      display: flex;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      justify-content: center;
+      margin: 0;
+      min-height: 100vh;
+    }
+    main {
+      background: #fff;
+      border: 1px solid #d9d9d9;
+      border-radius: 6px;
+      max-width: 420px;
+      padding: 24px;
+      width: calc(100% - 48px);
+    }
+    h1 {
+      font-size: 20px;
+      margin: 0 0 8px;
+    }
+    p {
+      color: #595959;
+      font-size: 14px;
+      line-height: 1.45;
+      margin: 0;
+    }
+    body[data-state="success"] h1 {
+      color: #237804;
+    }
+    body[data-state="error"] h1 {
+      color: #a8071a;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1 id="status">Connecting to Meet2Note...</h1>
+    <p id="detail">Finishing extension connection.</p>
+  </main>
+  <script src="connectCallback.js"></script>
+</body>
+</html>

--- a/docs/runbooks/002-smoke-test-po-zmianach.md
+++ b/docs/runbooks/002-smoke-test-po-zmianach.md
@@ -21,19 +21,23 @@ Szybko potwierdzic, ze build oraz najwazniejsze sciezki rozszerzenia dzialaja po
 6. Kliknij `Enable Microphone` albo `Microphone Settings`.
 7. Na stronie konfiguracji wybierz `Default microphone`, zapisz wybór i wroc do testowanej karty.
 8. Jesli dostepne sa co najmniej dwa mikrofony, wybierz konkretny mikrofon, zapisz wybor i potwierdz, ze popup pokazuje zapisany mikrofon.
-9. Uruchom `Start Recording`, zatrzymaj nagranie przez `Stop & Upload` i potwierdz upload do `https://meet2note.com`.
-10. Potwierdz, ze Chrome nie pobiera lokalnego pliku `.webm`.
-11. Jesli testujesz retry, czasowo odetnij backend albo siec, zatrzymaj nagranie i potwierdz, ze popup pokazuje ponawianie uploadu co okolo 15 sekund.
-12. Przywroc backend albo siec i potwierdz, ze kolejna proba uploadu konczy sie sukcesem.
-13. Sprawdz konsole service workera, offscreen document i karty testowej pod katem nowych bledow.
+9. Jesli popup pokazuje `Not connected`, kliknij `Connect to Meet2Note`, przejdz przez backend i potwierdz, ze callback zapisuje polaczenie.
+10. Uruchom `Start Recording`, zatrzymaj nagranie przez `Stop & Upload` i potwierdz upload do `https://meet2note.com`.
+11. Potwierdz, ze Chrome nie pobiera lokalnego pliku `.webm`.
+12. Jesli testujesz retry, czasowo odetnij backend albo siec, zatrzymaj nagranie i potwierdz, ze popup pokazuje ponawianie uploadu co okolo 15 sekund.
+13. Jesli testujesz autoryzacje, usun albo uszkodz token w `chrome.storage.local` i potwierdz, ze popup wymaga ponownego polaczenia zamiast bez konca ponawiac upload.
+14. Przywroc backend albo siec i potwierdz, ze kolejna proba uploadu konczy sie sukcesem.
+15. Sprawdz konsole service workera, offscreen document i karty testowej pod katem nowych bledow.
 
 ## Kryteria zaliczenia
 
 - `make check` konczy sie sukcesem.
 - `dist/` laduje sie jako rozszerzenie bez bledow manifestu.
 - Popup i strona konfiguracji mikrofonu renderuja UI Ant Design bez pustego ekranu.
+- Callback `connect-callback.html` jest w `dist/` i zapisuje polaczenie Meet2Note po poprawnym `code`/`state`.
 - Strona konfiguracji mikrofonu pokazuje `Default microphone` i pozwala zapisac wybor.
 - Nagrywanie startuje, zatrzymuje sie i wysyla assety do backendu, jesli dotknieto kodu recording/offscreen/upload/permissions.
 - Po sukcesie Chrome nie pobiera lokalnego `.webm`.
 - Na aktywnym spotkaniu Meet znacznik rozszerzenia pokazuje `RDY`, po starcie `REC`, a wyjscie ze spotkania zatrzymuje nagrywanie i uruchamia upload.
 - Przy bledzie uploadu popup pokazuje retry, a kolejna proba nastepuje co okolo 15 sekund.
+- Przy bledzie autoryzacji `401`/`403` popup pokazuje koniecznosc ponownego polaczenia z Meet2Note.

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -20,12 +20,14 @@ Docelowy backend dla uploadu i przetwarzania nagrań będzie rozwijany w powiąz
 | --- | --- | --- |
 | Manifest | `manifest.json` | Deklaruje metadane MV3, uprawnienia, worker tła i dostępne zasoby. |
 | Popup | `popup.html`, `src/popup.tsx` | Interfejs React + Ant Design do otwierania ustawień mikrofonu oraz startu/stopu nagrywania. |
+| Callback Meet2Note | `connect-callback.html`, `src/connectCallback.ts` | Kończy flow połączenia z backendu, waliduje `state`, wymienia jednorazowy `code` na token i zapisuje go lokalnie. |
 | Watcher Google Meet | `src/meetWatcher.ts`, `manifest.json` | Content script na `meet.google.com`, który wykrywa aktywne spotkanie i opuszczenie spotkania. |
 | Service worker tła | `src/background.ts` | Koordynuje przechwytywanie karty, cykl życia dokumentu offscreen, stan nagrywania/uploadu i znaczniki. |
 | Nagrywarka offscreen | `offscreen.html`, `src/offscreen.ts` | Przechwytuje media z karty, nagrywa osobny asset mikrofonu, finalizuje bloby i wysyła je do backendu. |
 | Klient uploadu | `src/uploadClient.ts` | Wykonuje kontrakt uploadu backendu: `/init`, upload assetów, `/complete`. |
 | Strona konfiguracji mikrofonu | `micsetup.html`, `src/micsetup.tsx` | Widoczna strona React + Ant Design używana do nadania uprawnienia mikrofonu, wyboru urządzenia i zapisu konfiguracji w `chrome.storage.local`. |
 | Preferencje mikrofonu | `src/micPreferences.ts` | Wspólne klucze i helpery `chrome.storage.local` dla zapisanego wyboru mikrofonu. |
+| Autoryzacja Meet2Note | `src/extensionAuth.ts` | Wspólne helpery `chrome.storage.local` dla długotrwałego `extensionToken`, danych użytkownika i `state` flow połączenia. |
 | Diagnostyka Sentry | `src/diagnostics.ts`, `scripts/sentry-public-dsn.sh`, `Makefile` | Opcjonalnie inicjalizuje Sentry, jeśli build ma dostęp do publicznego DSN albo sekretów pozwalających pobrać DSN przez API. |
 | Build kontenerowy | `compose.yml`, `Makefile` | Domyślny lokalny punkt wejścia do builda i walidacji. Uruchamia npm w Docker Compose bez lokalnego Node.js. |
 | Build webpacka | `webpack.config.js`, `tsconfig.json` | Kompiluje entrypointy TypeScript i kopiuje statyczne pliki rozszerzenia do `dist/`. |
@@ -35,26 +37,30 @@ Docelowy backend dla uploadu i przetwarzania nagrań będzie rozwijany w powiąz
 
 Ten opis dokumentuje aktualne ustalenia integracyjne między wtyczką i backendem.
 
-1. Rozszerzenie inicjuje upload przez `POST /api/upload/init`.
-2. Backend zwraca `recordingId`, `uploadToken` oraz `expiresAt`.
-3. Rozszerzenie wysyła główny asset `video_audio` przez `PUT /api/upload/{recordingId}/video`.
-4. Jeśli mikrofon jest dostępny, rozszerzenie wysyła osobny asset `microphone` przez `PUT /api/upload/{recordingId}/microphone`.
-5. Każdy upload assetu używa nagłówka `X-Upload-Token`.
-6. Rozszerzenie kończy upload przez `POST /api/upload/{recordingId}/complete`.
-7. Jeśli upload się nie powiedzie, offscreen ponawia pełny upload co 15 sekund aż do sukcesu, bez lokalnego zapisu pliku.
+1. Rozszerzenie przechodzi flow `GET /extension/connect`, a callback wymienia jednorazowy `code` przez `POST /api/extension/token`.
+2. Długotrwały `extensionToken` jest zapisywany w `chrome.storage.local` i wysyłany jako `Authorization: Bearer <extensionToken>`.
+3. Rozszerzenie inicjuje upload przez `POST /api/upload/init`.
+4. Backend zwraca `recordingId`, `uploadToken` oraz `expiresAt`.
+5. Rozszerzenie wysyła główny asset `video_audio` przez `PUT /api/upload/{recordingId}/video`.
+6. Jeśli mikrofon jest dostępny, rozszerzenie wysyła osobny asset `microphone` przez `PUT /api/upload/{recordingId}/microphone`.
+7. Każdy upload assetu używa nagłówków `Authorization` oraz `X-Upload-Token`.
+8. Rozszerzenie kończy upload przez `POST /api/upload/{recordingId}/complete`.
+9. Jeśli upload się nie powiedzie, offscreen ponawia pełny upload co 15 sekund aż do sukcesu, bez lokalnego zapisu pliku.
+10. Jeśli backend zwróci `401` albo `403`, zwykły retry jest przerywany, token jest czyszczony i popup wymaga ponownego połączenia z Meet2Note.
 
 ## Granice uruchomieniowe
 
 1. Pliki wynikowe trafiają bezpośrednio do `https://meet2note.com`, bez automatycznego pobierania lokalnego `.webm`.
 2. Gotowe bloby są trzymane tylko w pamięci na czas uploadu i retry.
-3. Wybór mikrofonu jest zapisywany lokalnie w `chrome.storage.local`.
-4. Content script na Google Meet nie czyta ani nie wysyła treści spotkania; wykrywa tylko stan obecności w spotkaniu.
-5. `dist/` jest wygenerowanym wynikiem builda i nie powinien być edytowany ręcznie.
+3. Wybór mikrofonu i token Meet2Note są zapisywane lokalnie w `chrome.storage.local`.
+4. Tokenów, kodów wymiany, nagłówka `Authorization`, `X-Upload-Token` ani blobów nagrań nie wolno logować do konsoli ani Sentry.
+5. Content script na Google Meet nie czyta ani nie wysyła treści spotkania; wykrywa tylko stan obecności w spotkaniu.
+6. `dist/` jest wygenerowanym wynikiem builda i nie powinien być edytowany ręcznie.
 
 ## Lokalna walidacja
 
 1. Uruchom `make check`.
 2. Załaduj `dist/` w `chrome://extensions`.
-3. Sprawdź start/stop nagrywania, upload do backendu i retry, jeśli zmieniasz kod przechwytywania, offscreen, uploadu albo uprawnień.
+3. Sprawdź flow `Connect to Meet2Note`, start/stop nagrywania, upload do backendu i retry, jeśli zmieniasz kod przechwytywania, offscreen, uploadu albo uprawnień.
 
 GitHub Actions może nadal wywoływać skrypty npm bezpośrednio, ale wspierany lokalny przepływ pracy to `make`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.6.11",
+    "version": "1.7.0",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",
@@ -28,6 +28,7 @@
       }
     ],
     "web_accessible_resources": [
-      { "resources": ["offscreen.html"], "matches": ["<all_urls>"] }
+      { "resources": ["offscreen.html"], "matches": ["<all_urls>"] },
+      { "resources": ["connect-callback.html"], "matches": ["https://meet2note.com/*"] }
     ]
   }

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,12 @@
       "128": "icons/icon-128.png"
     },
     "permissions": ["activeTab", "tabCapture", "offscreen", "storage", "tabs", "desktopCapture"],
-    "host_permissions": ["https://sentry.eengine.pl/*", "https://meet2note.com/*"],
+    "host_permissions": [
+      "https://sentry.eengine.pl/*",
+      "https://meet2note.com/*",
+      "http://localhost/*",
+      "http://127.0.0.1/*"
+    ],
     "action": {
       "default_popup": "popup.html",
       "default_icon": {

--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,13 @@
     ],
     "web_accessible_resources": [
       { "resources": ["offscreen.html"], "matches": ["<all_urls>"] },
-      { "resources": ["connect-callback.html"], "matches": ["https://meet2note.com/*"] }
+      {
+        "resources": ["connect-callback.html"],
+        "matches": [
+          "https://meet2note.com/*",
+          "http://localhost/*",
+          "http://127.0.0.1/*"
+        ]
+      }
     ]
   }

--- a/popup.html
+++ b/popup.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Google Meet Helper</title>
+    <title>Meet2Note Recorder</title>
   </head>
   <body>
     <div id="root"></div>

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6,3 +6,8 @@ if command -v make >/dev/null 2>&1; then
 else
   npm run check
 fi
+
+test -f dist/connect-callback.html
+test -f dist/connectCallback.js
+grep -q 'connect-callback.html' dist/manifest.json
+grep -F -q 'https://meet2note.com/*' dist/manifest.json

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -9,7 +9,41 @@ fi
 
 test -f dist/connect-callback.html
 test -f dist/connectCallback.js
-grep -q 'connect-callback.html' dist/manifest.json
-grep -F -q 'https://meet2note.com/*' dist/manifest.json
-grep -F -q 'http://localhost/*' dist/manifest.json
-grep -F -q 'http://127.0.0.1/*' dist/manifest.json
+
+node <<'EOF'
+const fs = require('fs')
+
+const manifest = JSON.parse(fs.readFileSync('dist/manifest.json', 'utf8'))
+const requiredOrigins = [
+  'https://meet2note.com/*',
+  'http://localhost/*',
+  'http://127.0.0.1/*'
+]
+
+function assertArrayIncludesAll(arrayValue, requiredValues, fieldName) {
+  if (!Array.isArray(arrayValue)) {
+    console.error(`dist/manifest.json is missing ${fieldName} array`)
+    process.exit(1)
+  }
+
+  for (const value of requiredValues) {
+    if (!arrayValue.includes(value)) {
+      console.error(`dist/manifest.json is missing ${fieldName} entry: ${value}`)
+      process.exit(1)
+    }
+  }
+}
+
+assertArrayIncludesAll(manifest.host_permissions, requiredOrigins, 'host_permissions')
+
+const callbackResource = manifest.web_accessible_resources.find((entry) =>
+  Array.isArray(entry.resources) && entry.resources.includes('connect-callback.html')
+)
+
+if (!callbackResource) {
+  console.error('dist/manifest.json is missing connect-callback.html web accessible resource')
+  process.exit(1)
+}
+
+assertArrayIncludesAll(callbackResource.matches, requiredOrigins, 'connect-callback.html matches')
+EOF

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -36,6 +36,11 @@ function assertArrayIncludesAll(arrayValue, requiredValues, fieldName) {
 
 assertArrayIncludesAll(manifest.host_permissions, requiredOrigins, 'host_permissions')
 
+if (!Array.isArray(manifest.web_accessible_resources)) {
+  console.error('dist/manifest.json is missing web_accessible_resources array')
+  process.exit(1)
+}
+
 const callbackResource = manifest.web_accessible_resources.find((entry) =>
   Array.isArray(entry.resources) && entry.resources.includes('connect-callback.html')
 )

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -11,3 +11,5 @@ test -f dist/connect-callback.html
 test -f dist/connectCallback.js
 grep -q 'connect-callback.html' dist/manifest.json
 grep -F -q 'https://meet2note.com/*' dist/manifest.json
+grep -F -q 'http://localhost/*' dist/manifest.json
+grep -F -q 'http://127.0.0.1/*' dist/manifest.json

--- a/src/background.ts
+++ b/src/background.ts
@@ -604,7 +604,11 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     if (msg?.type === 'GET_MEET2NOTE_EXTENSION_TOKEN') {
       try {
         const token = await getMeet2NoteExtensionToken()
-        sendResponse({ ok: true, token })
+        if (typeof token === 'string' && token.trim()) {
+          sendResponse({ ok: true, token })
+        } else {
+          sendResponse({ ok: false, error: 'Connect to Meet2Note before uploading.' })
+        }
       } catch (e: any) {
         captureException(e, { operation: 'GET_MEET2NOTE_EXTENSION_TOKEN' })
         sendResponse({ ok: false, error: e?.message || String(e) })

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,7 @@
 // src/background.ts
 
 import { captureException, initDiagnostics } from './diagnostics'
+import { getMeet2NoteExtensionToken } from './extensionAuth'
 import { clearMicPreferences, getMicPreferences, type MicPreferences } from './micPreferences'
 
 initDiagnostics('background')
@@ -595,6 +596,17 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         sendResponse({ ok: true })
       } catch (e: any) {
         captureException(e, { operation: 'CLEAR_MIC_PREFERENCES' })
+        sendResponse({ ok: false, error: e?.message || String(e) })
+      }
+      return
+    }
+
+    if (msg?.type === 'GET_MEET2NOTE_EXTENSION_TOKEN') {
+      try {
+        const token = await getMeet2NoteExtensionToken()
+        sendResponse({ ok: true, token })
+      } catch (e: any) {
+        captureException(e, { operation: 'GET_MEET2NOTE_EXTENSION_TOKEN' })
         sendResponse({ ok: false, error: e?.message || String(e) })
       }
       return

--- a/src/background.ts
+++ b/src/background.ts
@@ -17,7 +17,7 @@ let autoStopMeetTabId: number | null = null
 let recordingStartedAt: number | null = null
 const meetTabsInMeeting = new Set<number>()
 
-type UploadStatus = 'idle' | 'uploading' | 'upload_retrying' | 'uploaded'
+type UploadStatus = 'idle' | 'uploading' | 'upload_retrying' | 'uploaded' | 'auth_required'
 
 let currentUploadStatus: UploadStatus = 'idle'
 let currentUploadError: string | null = null
@@ -132,7 +132,11 @@ function isUploadBlockingNewRecording(): boolean {
 }
 
 function isUploadStatus(value: unknown): value is UploadStatus {
-  return value === 'idle' || value === 'uploading' || value === 'upload_retrying' || value === 'uploaded'
+  return value === 'idle' ||
+    value === 'uploading' ||
+    value === 'upload_retrying' ||
+    value === 'uploaded' ||
+    value === 'auth_required'
 }
 
 async function hydrateUploadStateFromSession(): Promise<void> {
@@ -276,7 +280,7 @@ chrome.runtime.onConnect.addListener((port) => {
 
     if (msg?.type === 'UPLOAD_STATE') {
       const status = typeof msg.status === 'string' ? msg.status as UploadStatus : 'idle'
-      if (status === 'uploading' || status === 'upload_retrying' || status === 'uploaded' || status === 'idle') {
+      if (isUploadStatus(status)) {
         setUploadState(status, {
           error: typeof msg.error === 'string' ? msg.error : null,
           nextRetryAt: typeof msg.nextRetryAt === 'number' ? msg.nextRetryAt : null,

--- a/src/connectCallback.ts
+++ b/src/connectCallback.ts
@@ -12,6 +12,24 @@ function setStatus(title: string, detail: string, state: 'pending' | 'success' |
   if (detailElement) detailElement.textContent = detail
 }
 
+async function closeCurrentTab(): Promise<void> {
+  try {
+    const tabs = await chrome.tabs.query({
+      active: true,
+      currentWindow: true
+    })
+    const currentTabId = tabs[0]?.id
+    if (typeof currentTabId === 'number') {
+      await chrome.tabs.remove(currentTabId)
+      return
+    }
+  } catch {
+    // Fall back to window.close below.
+  }
+
+  window.close()
+}
+
 async function handleCallback(): Promise<void> {
   const params = new URLSearchParams(window.location.search)
   const error = params.get('error')
@@ -24,7 +42,9 @@ async function handleCallback(): Promise<void> {
 
   await exchangeMeet2NoteConnectionCode(code, state)
   setStatus('Connected to Meet2Note', 'You can close this tab and return to the extension.', 'success')
-  window.setTimeout(() => window.close(), 2500)
+  setTimeout(() => {
+    void closeCurrentTab()
+  }, 2500)
 }
 
 setStatus('Connecting to Meet2Note...', 'Finishing extension connection.', 'pending')

--- a/src/connectCallback.ts
+++ b/src/connectCallback.ts
@@ -1,0 +1,39 @@
+import { captureException, initDiagnostics } from './diagnostics'
+import { exchangeMeet2NoteConnectionCode } from './extensionAuth'
+
+initDiagnostics('connectCallback')
+
+const statusElement = document.getElementById('status')
+const detailElement = document.getElementById('detail')
+
+function setStatus(title: string, detail: string, state: 'pending' | 'success' | 'error'): void {
+  document.body.dataset.state = state
+  if (statusElement) statusElement.textContent = title
+  if (detailElement) detailElement.textContent = detail
+}
+
+async function handleCallback(): Promise<void> {
+  const params = new URLSearchParams(window.location.search)
+  const error = params.get('error')
+  const code = params.get('code') || ''
+  const state = params.get('state') || ''
+
+  if (error) {
+    throw new Error(`Meet2Note returned an error: ${error}`)
+  }
+
+  await exchangeMeet2NoteConnectionCode(code, state)
+  setStatus('Connected to Meet2Note', 'You can close this tab and return to the extension.', 'success')
+  window.setTimeout(() => window.close(), 2500)
+}
+
+setStatus('Connecting to Meet2Note...', 'Finishing extension connection.', 'pending')
+handleCallback().catch((error) => {
+  console.error('[connect-callback] connection failed', error)
+  captureException(error, { operation: 'connectCallback' })
+  setStatus(
+    'Connection failed',
+    error instanceof Error ? error.message : 'Start the connection flow again from the extension popup.',
+    'error'
+  )
+})

--- a/src/extensionAuth.ts
+++ b/src/extensionAuth.ts
@@ -103,6 +103,10 @@ function generateState(): string {
   return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')
 }
 
+function normalizeStoredToken(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
 export async function getMeet2NoteConnection(): Promise<Meet2NoteConnection> {
   const items = await storageGet<StoredConnection>([
     MEET2NOTE_EXTENSION_TOKEN_KEY,
@@ -110,9 +114,7 @@ export async function getMeet2NoteConnection(): Promise<Meet2NoteConnection> {
     MEET2NOTE_CONNECTED_AT_KEY,
     MEET2NOTE_AUTH_ERROR_KEY
   ])
-  const token = typeof items.meet2noteExtensionToken === 'string'
-    ? items.meet2noteExtensionToken
-    : ''
+  const token = normalizeStoredToken(items.meet2noteExtensionToken)
 
   return {
     connected: token.length > 0,
@@ -124,9 +126,7 @@ export async function getMeet2NoteConnection(): Promise<Meet2NoteConnection> {
 
 export async function getMeet2NoteExtensionToken(): Promise<string | null> {
   const items = await storageGet<StoredConnection>([MEET2NOTE_EXTENSION_TOKEN_KEY])
-  const token = typeof items.meet2noteExtensionToken === 'string'
-    ? items.meet2noteExtensionToken
-    : ''
+  const token = normalizeStoredToken(items.meet2noteExtensionToken)
   return token || null
 }
 
@@ -222,7 +222,7 @@ function parseTokenResponse(data: ExtensionTokenResponse): {
 
 async function fetchTokenExchange(code: string): Promise<Response> {
   const controller = new AbortController()
-  const timeoutId = window.setTimeout(() => controller.abort(), TOKEN_EXCHANGE_TIMEOUT_MS)
+  const timeoutId = setTimeout(() => controller.abort(), TOKEN_EXCHANGE_TIMEOUT_MS)
 
   try {
     return await fetch(makeMeet2NoteUrl('/api/extension/token'), {
@@ -237,7 +237,7 @@ async function fetchTokenExchange(code: string): Promise<Response> {
     }
     throw error
   } finally {
-    window.clearTimeout(timeoutId)
+    clearTimeout(timeoutId)
   }
 }
 

--- a/src/extensionAuth.ts
+++ b/src/extensionAuth.ts
@@ -40,6 +40,7 @@ export const MEET2NOTE_CONNECT_STATE_KEY = 'meet2noteConnectState'
 export const MEET2NOTE_CONNECT_STARTED_AT_KEY = 'meet2noteConnectStartedAt'
 
 const CONNECT_STATE_TTL_MS = 10 * 60_000
+const TOKEN_EXCHANGE_TIMEOUT_MS = 30_000
 
 export class Meet2NoteAuthError extends Error {
   readonly status?: number
@@ -208,17 +209,34 @@ function parseTokenResponse(data: ExtensionTokenResponse): {
   }
 }
 
+async function fetchTokenExchange(code: string): Promise<Response> {
+  const controller = new AbortController()
+  const timeoutId = window.setTimeout(() => controller.abort(), TOKEN_EXCHANGE_TIMEOUT_MS)
+
+  try {
+    return await fetch(makeMeet2NoteUrl('/api/extension/token'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code }),
+      signal: controller.signal
+    })
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`Meet2Note connection timed out after ${Math.round(TOKEN_EXCHANGE_TIMEOUT_MS / 1000)} seconds.`)
+    }
+    throw error
+  } finally {
+    window.clearTimeout(timeoutId)
+  }
+}
+
 export async function exchangeMeet2NoteConnectionCode(code: string, state: string): Promise<void> {
   if (!code) throw new Error('Missing connection code.')
   if (!state) throw new Error('Missing connection state.')
 
   await validateReturnedState(state)
 
-  const response = await fetch(makeMeet2NoteUrl('/api/extension/token'), {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ code })
-  })
+  const response = await fetchTokenExchange(code)
 
   if (!response.ok) {
     throw new Error(`Meet2Note connection failed with HTTP ${response.status}.`)

--- a/src/extensionAuth.ts
+++ b/src/extensionAuth.ts
@@ -1,0 +1,241 @@
+import { makeMeet2NoteUrl } from './meet2noteConfig'
+
+export interface Meet2NoteUser {
+  id?: string
+  email?: string
+  displayName?: string
+}
+
+export interface Meet2NoteConnection {
+  connected: boolean
+  user: Meet2NoteUser | null
+  connectedAt: string | null
+  authError: string | null
+}
+
+interface StoredConnection {
+  meet2noteExtensionToken?: unknown
+  meet2noteConnectedUser?: unknown
+  meet2noteConnectedAt?: unknown
+  meet2noteAuthError?: unknown
+}
+
+interface StoredConnectState {
+  meet2noteConnectState?: unknown
+  meet2noteConnectStartedAt?: unknown
+}
+
+interface ExtensionTokenResponse {
+  extensionToken?: unknown
+  tokenType?: unknown
+  user?: unknown
+  createdAt?: unknown
+}
+
+export const MEET2NOTE_EXTENSION_TOKEN_KEY = 'meet2noteExtensionToken'
+export const MEET2NOTE_CONNECTED_USER_KEY = 'meet2noteConnectedUser'
+export const MEET2NOTE_CONNECTED_AT_KEY = 'meet2noteConnectedAt'
+export const MEET2NOTE_AUTH_ERROR_KEY = 'meet2noteAuthError'
+export const MEET2NOTE_CONNECT_STATE_KEY = 'meet2noteConnectState'
+export const MEET2NOTE_CONNECT_STARTED_AT_KEY = 'meet2noteConnectStartedAt'
+
+const CONNECT_STATE_TTL_MS = 10 * 60_000
+
+export class Meet2NoteAuthError extends Error {
+  readonly status?: number
+
+  constructor(message: string, status?: number) {
+    super(message)
+    this.name = 'Meet2NoteAuthError'
+    this.status = status
+  }
+}
+
+export function isMeet2NoteAuthError(error: unknown): error is Meet2NoteAuthError {
+  return error instanceof Meet2NoteAuthError ||
+    (typeof error === 'object' && error !== null && (error as Error).name === 'Meet2NoteAuthError')
+}
+
+function storageGet<T>(keys: string[]): Promise<T> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get(keys, (items) => {
+      const runtimeError = chrome.runtime.lastError
+      if (runtimeError) return reject(new Error(runtimeError.message))
+      resolve(items as T)
+    })
+  })
+}
+
+function storageSet(items: Record<string, unknown>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.set(items, () => {
+      const runtimeError = chrome.runtime.lastError
+      if (runtimeError) return reject(new Error(runtimeError.message))
+      resolve()
+    })
+  })
+}
+
+function storageRemove(keys: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.remove(keys, () => {
+      const runtimeError = chrome.runtime.lastError
+      if (runtimeError) return reject(new Error(runtimeError.message))
+      resolve()
+    })
+  })
+}
+
+function sanitizeUser(value: unknown): Meet2NoteUser | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  return {
+    id: typeof record.id === 'string' ? record.id : undefined,
+    email: typeof record.email === 'string' ? record.email : undefined,
+    displayName: typeof record.displayName === 'string' ? record.displayName : undefined
+  }
+}
+
+function generateState(): string {
+  const bytes = new Uint8Array(24)
+  crypto.getRandomValues(bytes)
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')
+}
+
+export async function getMeet2NoteConnection(): Promise<Meet2NoteConnection> {
+  const items = await storageGet<StoredConnection>([
+    MEET2NOTE_EXTENSION_TOKEN_KEY,
+    MEET2NOTE_CONNECTED_USER_KEY,
+    MEET2NOTE_CONNECTED_AT_KEY,
+    MEET2NOTE_AUTH_ERROR_KEY
+  ])
+  const token = typeof items.meet2noteExtensionToken === 'string'
+    ? items.meet2noteExtensionToken
+    : ''
+
+  return {
+    connected: token.length > 0,
+    user: token ? sanitizeUser(items.meet2noteConnectedUser) : null,
+    connectedAt: typeof items.meet2noteConnectedAt === 'string' ? items.meet2noteConnectedAt : null,
+    authError: typeof items.meet2noteAuthError === 'string' ? items.meet2noteAuthError : null
+  }
+}
+
+export async function getMeet2NoteExtensionToken(): Promise<string | null> {
+  const items = await storageGet<StoredConnection>([MEET2NOTE_EXTENSION_TOKEN_KEY])
+  const token = typeof items.meet2noteExtensionToken === 'string'
+    ? items.meet2noteExtensionToken
+    : ''
+  return token || null
+}
+
+export async function requireMeet2NoteExtensionToken(): Promise<string> {
+  const token = await getMeet2NoteExtensionToken()
+  if (!token) throw new Meet2NoteAuthError('Connect to Meet2Note before uploading.')
+  return token
+}
+
+export function makeAuthorizationHeader(token: string): string {
+  return `Bearer ${token}`
+}
+
+export async function startMeet2NoteConnectFlow(): Promise<void> {
+  const state = generateState()
+  const redirectUri = chrome.runtime.getURL('connect-callback.html')
+  const url = new URL(makeMeet2NoteUrl('/extension/connect'))
+  url.searchParams.set('redirect_uri', redirectUri)
+  url.searchParams.set('state', state)
+
+  await storageSet({
+    [MEET2NOTE_CONNECT_STATE_KEY]: state,
+    [MEET2NOTE_CONNECT_STARTED_AT_KEY]: Date.now(),
+    [MEET2NOTE_AUTH_ERROR_KEY]: null
+  })
+
+  await chrome.tabs.create({ url: url.toString() })
+}
+
+export async function markMeet2NoteReconnectRequired(message: string): Promise<void> {
+  await storageRemove([
+    MEET2NOTE_EXTENSION_TOKEN_KEY,
+    MEET2NOTE_CONNECTED_USER_KEY,
+    MEET2NOTE_CONNECTED_AT_KEY
+  ])
+  await storageSet({ [MEET2NOTE_AUTH_ERROR_KEY]: message })
+}
+
+export async function clearMeet2NoteAuthError(): Promise<void> {
+  await storageRemove([MEET2NOTE_AUTH_ERROR_KEY])
+}
+
+async function validateReturnedState(returnedState: string): Promise<void> {
+  const items = await storageGet<StoredConnectState>([
+    MEET2NOTE_CONNECT_STATE_KEY,
+    MEET2NOTE_CONNECT_STARTED_AT_KEY
+  ])
+  const expectedState = typeof items.meet2noteConnectState === 'string'
+    ? items.meet2noteConnectState
+    : ''
+  const startedAt = typeof items.meet2noteConnectStartedAt === 'number'
+    ? items.meet2noteConnectStartedAt
+    : 0
+
+  if (!expectedState || expectedState !== returnedState) {
+    await storageRemove([MEET2NOTE_CONNECT_STATE_KEY, MEET2NOTE_CONNECT_STARTED_AT_KEY])
+    throw new Error('Connection state does not match. Start the connection flow again.')
+  }
+
+  if (!startedAt || Date.now() - startedAt > CONNECT_STATE_TTL_MS) {
+    await storageRemove([MEET2NOTE_CONNECT_STATE_KEY, MEET2NOTE_CONNECT_STARTED_AT_KEY])
+    throw new Error('Connection state expired. Start the connection flow again.')
+  }
+}
+
+function parseTokenResponse(data: ExtensionTokenResponse): {
+  extensionToken: string
+  user: Meet2NoteUser | null
+  createdAt: string
+} {
+  const extensionToken = typeof data.extensionToken === 'string' ? data.extensionToken : ''
+  const tokenType = typeof data.tokenType === 'string' ? data.tokenType : 'Bearer'
+  if (!extensionToken) throw new Error('Backend did not return extensionToken.')
+  if (tokenType !== 'Bearer') throw new Error('Backend returned unsupported token type.')
+
+  return {
+    extensionToken,
+    user: sanitizeUser(data.user),
+    createdAt: typeof data.createdAt === 'string' ? data.createdAt : new Date().toISOString()
+  }
+}
+
+export async function exchangeMeet2NoteConnectionCode(code: string, state: string): Promise<void> {
+  if (!code) throw new Error('Missing connection code.')
+  if (!state) throw new Error('Missing connection state.')
+
+  await validateReturnedState(state)
+
+  const response = await fetch(makeMeet2NoteUrl('/api/extension/token'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code })
+  })
+
+  if (!response.ok) {
+    throw new Error(`Meet2Note connection failed with HTTP ${response.status}.`)
+  }
+
+  const data = await response.json().catch(() => null) as ExtensionTokenResponse | null
+  if (!data || typeof data !== 'object') throw new Error('Meet2Note connection returned invalid JSON.')
+  const parsed = parseTokenResponse(data)
+
+  await storageSet({
+    [MEET2NOTE_EXTENSION_TOKEN_KEY]: parsed.extensionToken,
+    [MEET2NOTE_CONNECTED_USER_KEY]: parsed.user,
+    [MEET2NOTE_CONNECTED_AT_KEY]: parsed.createdAt
+  })
+  await storageRemove([
+    MEET2NOTE_CONNECT_STATE_KEY,
+    MEET2NOTE_CONNECT_STARTED_AT_KEY,
+    MEET2NOTE_AUTH_ERROR_KEY
+  ])
+}

--- a/src/extensionAuth.ts
+++ b/src/extensionAuth.ts
@@ -169,6 +169,17 @@ export async function clearMeet2NoteAuthError(): Promise<void> {
   await storageRemove([MEET2NOTE_AUTH_ERROR_KEY])
 }
 
+export async function disconnectMeet2Note(): Promise<void> {
+  await storageRemove([
+    MEET2NOTE_EXTENSION_TOKEN_KEY,
+    MEET2NOTE_CONNECTED_USER_KEY,
+    MEET2NOTE_CONNECTED_AT_KEY,
+    MEET2NOTE_AUTH_ERROR_KEY,
+    MEET2NOTE_CONNECT_STATE_KEY,
+    MEET2NOTE_CONNECT_STARTED_AT_KEY
+  ])
+}
+
 async function validateReturnedState(returnedState: string): Promise<void> {
   const items = await storageGet<StoredConnectState>([
     MEET2NOTE_CONNECT_STATE_KEY,

--- a/src/meet2noteConfig.ts
+++ b/src/meet2noteConfig.ts
@@ -1,0 +1,15 @@
+declare const __UPLOAD_API_BASE_URL__: string
+
+const DEFAULT_MEET2NOTE_BASE_URL = 'https://meet2note.com'
+
+export function getMeet2NoteBaseUrl(): string {
+  const raw = typeof __UPLOAD_API_BASE_URL__ === 'string' && __UPLOAD_API_BASE_URL__.trim()
+    ? __UPLOAD_API_BASE_URL__.trim()
+    : DEFAULT_MEET2NOTE_BASE_URL
+
+  return raw.replace(/\/+$/, '')
+}
+
+export function makeMeet2NoteUrl(path: string): string {
+  return `${getMeet2NoteBaseUrl()}${path}`
+}

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1,6 +1,7 @@
 // src/offscreen.ts
 
 import { captureException, captureMessage, initDiagnostics } from './diagnostics'
+import { isMeet2NoteAuthError, markMeet2NoteReconnectRequired } from './extensionAuth'
 import type { MicPreferences } from './micPreferences'
 import { uploadRecordingOnce, type UploadRecordingInput } from './uploadClient'
 
@@ -55,7 +56,7 @@ function pushState(recording: boolean, extra?: Record<string, any>) {
   getPort().postMessage({ type: 'RECORDING_STATE', recording, recordingStartedAt, ...extra })
 }
 
-type UploadStatus = 'idle' | 'uploading' | 'upload_retrying' | 'uploaded'
+type UploadStatus = 'idle' | 'uploading' | 'upload_retrying' | 'uploaded' | 'auth_required'
 
 function pushUploadState(status: UploadStatus, extra?: Record<string, any>) {
   getPort().postMessage({ type: 'UPLOAD_STATE', status, ...extra })
@@ -397,6 +398,15 @@ async function uploadRecordingUntilSuccess(input: UploadRecordingInput, attempt 
       log('Upload completed', { recordingId: result.recordingId, assets: result.assets, attempt: currentAttempt })
       return
     } catch (e) {
+      if (isMeet2NoteAuthError(e)) {
+        uploadInProgress = false
+        const message = e.message || 'Connect to Meet2Note before uploading.'
+        await markMeet2NoteReconnectRequired(message).catch(() => {})
+        pushUploadState('auth_required', { error: message })
+        log('Upload requires Meet2Note connection', { attempt: currentAttempt })
+        return
+      }
+
       captureException(e, {
         operation: 'uploadRecordingUntilSuccess',
         attempt: currentAttempt,

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1,7 +1,7 @@
 // src/offscreen.ts
 
 import { captureException, captureMessage, initDiagnostics } from './diagnostics'
-import { isMeet2NoteAuthError, markMeet2NoteReconnectRequired } from './extensionAuth'
+import { isMeet2NoteAuthError, markMeet2NoteReconnectRequired, Meet2NoteAuthError } from './extensionAuth'
 import type { MicPreferences } from './micPreferences'
 import { uploadRecordingOnce, type UploadRecordingInput } from './uploadClient'
 
@@ -201,6 +201,17 @@ async function requestClearMicPreferences(): Promise<void> {
   }
 }
 
+async function requestMeet2NoteExtensionToken(): Promise<string> {
+  const response = await chrome.runtime.sendMessage({ type: 'GET_MEET2NOTE_EXTENSION_TOKEN' })
+  if (response?.ok === false) {
+    throw new Meet2NoteAuthError(response.error || 'Could not read Meet2Note connection.')
+  }
+  if (typeof response?.token !== 'string' || !response.token) {
+    throw new Meet2NoteAuthError('Connect to Meet2Note before uploading.')
+  }
+  return response.token
+}
+
 async function maybeGetMicStream(prefs: MicPreferences): Promise<MediaStream | null> {
   if (!WANT_MIC_ASSET) return null
 
@@ -388,7 +399,8 @@ async function uploadRecordingUntilSuccess(input: UploadRecordingInput, attempt 
     pushUploadState(currentAttempt === 1 ? 'uploading' : 'upload_retrying', { attempt: currentAttempt })
 
     try {
-      const result = await uploadRecordingOnce(input)
+      const extensionToken = await requestMeet2NoteExtensionToken()
+      const result = await uploadRecordingOnce(input, extensionToken)
       uploadInProgress = false
       pushUploadState('uploaded', {
         attempt: currentAttempt,

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -303,6 +303,8 @@ function App(): React.ReactElement {
     recordingState.starting ||
     recordingState.stopping ||
     uploadBlocksAction
+  const connectionErrorMessage = meet2NoteConnection.authError ||
+    (uploadState.status === 'auth_required' ? uploadState.error : null)
 
   const openSettings = useCallback(async () => {
     try {
@@ -500,6 +502,14 @@ function App(): React.ReactElement {
             <Text type={meet2NoteConnection.authError ? 'danger' : 'secondary'} style={{ fontSize: 12, lineHeight: 1.25 }}>
               {meet2NoteConnection.authError ? 'Reconnect to Meet2Note' : 'Not connected'}
             </Text>
+            {connectionErrorMessage ? (
+              <Alert
+                type="error"
+                showIcon={false}
+                message={connectionErrorMessage}
+                style={{ fontSize: 12, padding: '4px 8px' }}
+              />
+            ) : null}
           </>
         )}
         {recordingControlsAvailable ? (

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -296,8 +296,13 @@ function App(): React.ReactElement {
     [recordingState, uploadState, now]
   )
   const recordingButtonText = getRecordingButtonText(recordingState, uploadState)
+  const recordingControlsAvailable = meet2NoteConnection.connected
   const uploadBlocksAction = uploadState.status === 'uploading' || uploadState.status === 'upload_retrying'
-  const actionDisabled = inFlight || recordingState.starting || recordingState.stopping || uploadBlocksAction
+  const actionDisabled = !recordingControlsAvailable ||
+    inFlight ||
+    recordingState.starting ||
+    recordingState.stopping ||
+    uploadBlocksAction
 
   const openSettings = useCallback(async () => {
     try {
@@ -497,27 +502,31 @@ function App(): React.ReactElement {
             </Text>
           </>
         )}
-        <Divider style={{ margin: '4px 0' }} />
-        <Button
-          block
-          disabled={actionDisabled}
-          icon={actionIcon}
-          onClick={toggleRecording}
-          type={recordingState.recording ? 'default' : 'primary'}
-        >
-          {recordingButtonText}
-        </Button>
-        <Space size={6} align="start">
-          {uploadState.status === 'uploaded' ? <CheckCircleOutlined style={{ color: '#389e0d' }} /> : null}
-          <Text style={{ fontSize: 12, lineHeight: 1.25 }}>{recordingText}</Text>
-        </Space>
-        {(uploadState.status === 'upload_retrying' || uploadState.status === 'auth_required') && uploadState.error ? (
-          <Alert
-            type={uploadState.status === 'auth_required' ? 'error' : 'warning'}
-            showIcon={false}
-            message={uploadState.error}
-            style={{ fontSize: 12, padding: '4px 8px' }}
-          />
+        {recordingControlsAvailable ? (
+          <>
+            <Divider style={{ margin: '4px 0' }} />
+            <Button
+              block
+              disabled={actionDisabled}
+              icon={actionIcon}
+              onClick={toggleRecording}
+              type={recordingState.recording ? 'default' : 'primary'}
+            >
+              {recordingButtonText}
+            </Button>
+            <Space size={6} align="start">
+              {uploadState.status === 'uploaded' ? <CheckCircleOutlined style={{ color: '#389e0d' }} /> : null}
+              <Text style={{ fontSize: 12, lineHeight: 1.25 }}>{recordingText}</Text>
+            </Space>
+            {(uploadState.status === 'upload_retrying' || uploadState.status === 'auth_required') && uploadState.error ? (
+              <Alert
+                type={uploadState.status === 'auth_required' ? 'error' : 'warning'}
+                showIcon={false}
+                message={uploadState.error}
+                style={{ fontSize: 12, padding: '4px 8px' }}
+              />
+            ) : null}
+          </>
         ) : null}
       </Flex>
     </ConfigProvider>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -505,7 +505,7 @@ function App(): React.ReactElement {
               Meet2Note
             </Text>
             <Text type="secondary" style={{ fontSize: 11, lineHeight: 1.2 }}>
-              Recording extension
+              Just meet. We note.
             </Text>
           </Flex>
         </Flex>

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -3,6 +3,7 @@
 import {
   CheckCircleOutlined,
   CloudUploadOutlined,
+  LinkOutlined,
   LoadingOutlined,
   SettingOutlined,
   VideoCameraOutlined
@@ -11,11 +12,20 @@ import { Alert, Button, ConfigProvider, Divider, Flex, Space, Typography, theme 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { captureException, initDiagnostics } from './diagnostics'
+import {
+  getMeet2NoteConnection,
+  MEET2NOTE_AUTH_ERROR_KEY,
+  MEET2NOTE_CONNECTED_AT_KEY,
+  MEET2NOTE_CONNECTED_USER_KEY,
+  MEET2NOTE_EXTENSION_TOKEN_KEY,
+  startMeet2NoteConnectFlow,
+  type Meet2NoteConnection
+} from './extensionAuth'
 import { getMicPreferences, MIC_DEVICE_ID_KEY, MIC_LABEL_KEY } from './micPreferences'
 
 initDiagnostics('popup')
 
-type UploadStatus = 'idle' | 'uploading' | 'upload_retrying' | 'uploaded'
+type UploadStatus = 'idle' | 'uploading' | 'upload_retrying' | 'uploaded' | 'auth_required'
 
 interface RecordingStatus {
   recording: boolean
@@ -45,7 +55,11 @@ function formatDuration(ms: number): string {
 }
 
 function isUploadStatus(value: unknown): value is UploadStatus {
-  return value === 'idle' || value === 'uploading' || value === 'upload_retrying' || value === 'uploaded'
+  return value === 'idle' ||
+    value === 'uploading' ||
+    value === 'upload_retrying' ||
+    value === 'uploaded' ||
+    value === 'auth_required'
 }
 
 async function openMicSetupTab(): Promise<void> {
@@ -95,6 +109,7 @@ async function readMicButtonLabel(): Promise<{ label: string; title: string }> {
 function getRecordingText(recordingState: RecordingStatus, uploadState: UploadState, now: number): string {
   if (uploadState.status === 'uploaded') return 'Uploaded'
   if (uploadState.status === 'uploading') return 'Uploading...'
+  if (uploadState.status === 'auth_required') return 'Connect to Meet2Note to upload.'
   if (uploadState.status === 'upload_retrying') {
     const waitMs = typeof uploadState.nextRetryAt === 'number'
       ? Math.max(0, uploadState.nextRetryAt - now)
@@ -115,6 +130,7 @@ function getRecordingText(recordingState: RecordingStatus, uploadState: UploadSt
 
 function getRecordingButtonText(recordingState: RecordingStatus, uploadState: UploadState): string {
   if (uploadState.status === 'uploading') return 'Uploading...'
+  if (uploadState.status === 'auth_required') return recordingState.recording ? 'Stop & Upload' : 'Start Recording'
   if (uploadState.status === 'upload_retrying') return 'Retrying Upload...'
   if (recordingState.starting) return 'Starting...'
   if (recordingState.stopping) return 'Stopping...'
@@ -138,8 +154,15 @@ function App(): React.ReactElement {
     label: 'Microphone Settings',
     title: 'Choose which microphone should be included in recordings'
   })
+  const [meet2NoteConnection, setMeet2NoteConnection] = useState<Meet2NoteConnection>({
+    connected: false,
+    user: null,
+    connectedAt: null,
+    authError: null
+  })
   const [now, setNow] = useState(Date.now())
   const [inFlight, setInFlight] = useState(false)
+  const [connectingMeet2Note, setConnectingMeet2Note] = useState(false)
   const inFlightRef = useRef(false)
 
   useEffect(() => {
@@ -157,6 +180,11 @@ function App(): React.ReactElement {
     ])
     setMicButton(button)
     setMicStatus(status)
+  }, [])
+
+  const refreshMeet2NoteConnection = useCallback(async () => {
+    const connection = await getMeet2NoteConnection()
+    setMeet2NoteConnection(connection)
   }, [])
 
   useEffect(() => {
@@ -183,9 +211,12 @@ function App(): React.ReactElement {
           recordingStartedAt: null
         })
       }
-      await refreshMic().catch(() => {})
+      await Promise.all([
+        refreshMic().catch(() => {}),
+        refreshMeet2NoteConnection().catch(() => {})
+      ])
     })()
-  }, [refreshMic])
+  }, [refreshMic, refreshMeet2NoteConnection])
 
   useEffect(() => {
     if (!('permissions' in navigator)) return undefined
@@ -242,6 +273,14 @@ function App(): React.ReactElement {
       if (changes[MIC_DEVICE_ID_KEY] || changes[MIC_LABEL_KEY]) {
         refreshMic().catch(() => {})
       }
+      if (
+        changes[MEET2NOTE_EXTENSION_TOKEN_KEY] ||
+        changes[MEET2NOTE_CONNECTED_USER_KEY] ||
+        changes[MEET2NOTE_CONNECTED_AT_KEY] ||
+        changes[MEET2NOTE_AUTH_ERROR_KEY]
+      ) {
+        refreshMeet2NoteConnection().catch(() => {})
+      }
     }
 
     chrome.runtime.onMessage.addListener(messageListener)
@@ -250,7 +289,7 @@ function App(): React.ReactElement {
       chrome.runtime.onMessage.removeListener(messageListener)
       chrome.storage.onChanged.removeListener(storageListener)
     }
-  }, [refreshMic])
+  }, [refreshMic, refreshMeet2NoteConnection])
 
   const recordingText = useMemo(
     () => getRecordingText(recordingState, uploadState, now),
@@ -267,6 +306,20 @@ function App(): React.ReactElement {
       console.error('[popup] mic settings flow error', error)
       captureException(error, { operation: 'openMicSetupTab' })
       alert('Could not open the microphone setup page. Please try again.')
+    }
+  }, [])
+
+  const connectMeet2Note = useCallback(async () => {
+    setConnectingMeet2Note(true)
+    try {
+      await startMeet2NoteConnectFlow()
+      window.close()
+    } catch (error) {
+      console.error('[popup] Meet2Note connect flow error', error)
+      captureException(error, { operation: 'startMeet2NoteConnectFlow' })
+      alert(`Could not open Meet2Note connection:\n${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      setConnectingMeet2Note(false)
     }
   }, [])
 
@@ -424,6 +477,27 @@ function App(): React.ReactElement {
           {micStatus || 'Mic: Default microphone'}
         </Text>
         <Divider style={{ margin: '4px 0' }} />
+        {meet2NoteConnection.connected ? (
+          <Text type="secondary" style={{ fontSize: 12, lineHeight: 1.25 }}>
+            Connected: {meet2NoteConnection.user?.email || meet2NoteConnection.user?.displayName || 'Meet2Note'}
+          </Text>
+        ) : (
+          <>
+            <Button
+              block
+              icon={<LinkOutlined />}
+              loading={connectingMeet2Note}
+              onClick={connectMeet2Note}
+              type="primary"
+            >
+              Connect to Meet2Note
+            </Button>
+            <Text type={meet2NoteConnection.authError ? 'danger' : 'secondary'} style={{ fontSize: 12, lineHeight: 1.25 }}>
+              {meet2NoteConnection.authError ? 'Reconnect to Meet2Note' : 'Not connected'}
+            </Text>
+          </>
+        )}
+        <Divider style={{ margin: '4px 0' }} />
         <Button
           block
           disabled={actionDisabled}
@@ -437,9 +511,9 @@ function App(): React.ReactElement {
           {uploadState.status === 'uploaded' ? <CheckCircleOutlined style={{ color: '#389e0d' }} /> : null}
           <Text style={{ fontSize: 12, lineHeight: 1.25 }}>{recordingText}</Text>
         </Space>
-        {uploadState.status === 'upload_retrying' && uploadState.error ? (
+        {(uploadState.status === 'upload_retrying' || uploadState.status === 'auth_required') && uploadState.error ? (
           <Alert
-            type="warning"
+            type={uploadState.status === 'auth_required' ? 'error' : 'warning'}
             showIcon={false}
             message={uploadState.error}
             style={{ fontSize: 12, padding: '4px 8px' }}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -5,6 +5,7 @@ import {
   CloudUploadOutlined,
   LinkOutlined,
   LoadingOutlined,
+  LogoutOutlined,
   SettingOutlined,
   VideoCameraOutlined
 } from '@ant-design/icons'
@@ -13,6 +14,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { captureException, initDiagnostics } from './diagnostics'
 import {
+  disconnectMeet2Note,
   getMeet2NoteConnection,
   MEET2NOTE_AUTH_ERROR_KEY,
   MEET2NOTE_CONNECTED_AT_KEY,
@@ -42,6 +44,7 @@ interface UploadState {
 
 const { Text } = Typography
 const START_RECORDING_POPUP_DELAY_MS = 3_000
+const MEET2NOTE_BRAND_ICON_URL = chrome.runtime.getURL('icons/meet2note-favicon.svg')
 
 function formatDuration(ms: number): string {
   const totalSeconds = Math.max(0, Math.floor(ms / 1000))
@@ -163,6 +166,7 @@ function App(): React.ReactElement {
   const [now, setNow] = useState(Date.now())
   const [inFlight, setInFlight] = useState(false)
   const [connectingMeet2Note, setConnectingMeet2Note] = useState(false)
+  const [disconnectingMeet2Note, setDisconnectingMeet2Note] = useState(false)
   const inFlightRef = useRef(false)
 
   useEffect(() => {
@@ -298,6 +302,10 @@ function App(): React.ReactElement {
   const recordingButtonText = getRecordingButtonText(recordingState, uploadState)
   const recordingControlsAvailable = meet2NoteConnection.connected
   const uploadBlocksAction = uploadState.status === 'uploading' || uploadState.status === 'upload_retrying'
+  const connectionActionDisabled = recordingState.recording ||
+    recordingState.starting ||
+    recordingState.stopping ||
+    uploadBlocksAction
   const actionDisabled = !recordingControlsAvailable ||
     inFlight ||
     recordingState.starting ||
@@ -329,6 +337,20 @@ function App(): React.ReactElement {
       setConnectingMeet2Note(false)
     }
   }, [])
+
+  const disconnectMeet2NoteAccount = useCallback(async () => {
+    setDisconnectingMeet2Note(true)
+    try {
+      await disconnectMeet2Note()
+      await refreshMeet2NoteConnection()
+    } catch (error) {
+      console.error('[popup] Meet2Note disconnect flow error', error)
+      captureException(error, { operation: 'disconnectMeet2Note' })
+      alert(`Could not disconnect Meet2Note:\n${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      setDisconnectingMeet2Note(false)
+    }
+  }, [refreshMeet2NoteConnection])
 
   const startRecording = useCallback(async () => {
     inFlightRef.current = true
@@ -472,6 +494,22 @@ function App(): React.ReactElement {
       }}
     >
       <Flex vertical gap={8} style={{ width: 232, padding: 10 }}>
+        <Flex align="center" gap={10}>
+          <img
+            alt="Meet2Note"
+            src={MEET2NOTE_BRAND_ICON_URL}
+            style={{ width: 28, height: 28, display: 'block', borderRadius: 8 }}
+          />
+          <Flex vertical gap={0}>
+            <Text strong style={{ fontSize: 14, lineHeight: 1.1 }}>
+              Meet2Note
+            </Text>
+            <Text type="secondary" style={{ fontSize: 11, lineHeight: 1.2 }}>
+              Recording extension
+            </Text>
+          </Flex>
+        </Flex>
+        <Divider style={{ margin: '2px 0 4px' }} />
         <Button
           block
           icon={<SettingOutlined />}
@@ -485,13 +523,27 @@ function App(): React.ReactElement {
         </Text>
         <Divider style={{ margin: '4px 0' }} />
         {meet2NoteConnection.connected ? (
-          <Text type="secondary" style={{ fontSize: 12, lineHeight: 1.25 }}>
-            Connected: {meet2NoteConnection.user?.email || meet2NoteConnection.user?.displayName || 'Meet2Note'}
-          </Text>
+          <Flex vertical gap={6}>
+            <Text type="secondary" style={{ fontSize: 12, lineHeight: 1.25 }}>
+              Connected: {meet2NoteConnection.user?.email || meet2NoteConnection.user?.displayName || 'Meet2Note'}
+            </Text>
+            <Button
+              block
+              danger
+              disabled={connectionActionDisabled}
+              icon={<LogoutOutlined />}
+              loading={disconnectingMeet2Note}
+              onClick={disconnectMeet2NoteAccount}
+              size="small"
+            >
+              Disconnect
+            </Button>
+          </Flex>
         ) : (
           <>
             <Button
               block
+              disabled={disconnectingMeet2Note}
               icon={<LinkOutlined />}
               loading={connectingMeet2Note}
               onClick={connectMeet2Note}

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -1,6 +1,11 @@
 import { captureException } from './diagnostics'
-
-declare const __UPLOAD_API_BASE_URL__: string
+import {
+  makeAuthorizationHeader,
+  markMeet2NoteReconnectRequired,
+  Meet2NoteAuthError,
+  requireMeet2NoteExtensionToken
+} from './extensionAuth'
+import { makeMeet2NoteUrl } from './meet2noteConfig'
 
 export type UploadAsset = 'video_audio' | 'microphone'
 
@@ -25,24 +30,14 @@ interface InitUploadResponse {
   expiresAt: string
 }
 
-const DEFAULT_UPLOAD_API_BASE_URL = 'https://meet2note.com'
 const INIT_UPLOAD_TIMEOUT_MS = 30_000
 const COMPLETE_UPLOAD_TIMEOUT_MS = 30_000
 const ASSET_UPLOAD_TIMEOUT_MS = 5 * 60_000
 
-function getUploadApiBaseUrl(): string {
-  const raw = typeof __UPLOAD_API_BASE_URL__ === 'string' && __UPLOAD_API_BASE_URL__.trim()
-    ? __UPLOAD_API_BASE_URL__.trim()
-    : DEFAULT_UPLOAD_API_BASE_URL
-
-  return raw.replace(/\/+$/, '')
-}
-
-function makeUrl(path: string): string {
-  return `${getUploadApiBaseUrl()}${path}`
-}
-
 function httpError(operation: string, response: Response): Error {
+  if (response.status === 401 || response.status === 403) {
+    return new Meet2NoteAuthError(`Meet2Note connection required for ${operation}.`, response.status)
+  }
   return new Error(`${operation} failed with HTTP ${response.status}`)
 }
 
@@ -85,7 +80,15 @@ async function parseInitResponse(response: Response): Promise<InitUploadResponse
   return { recordingId, uploadToken, expiresAt }
 }
 
-async function initUpload(input: UploadRecordingInput): Promise<InitUploadResponse> {
+async function uploadAuthHeaders(): Promise<{ Authorization: string }> {
+  const token = await requireMeet2NoteExtensionToken()
+  return { Authorization: makeAuthorizationHeader(token) }
+}
+
+async function initUpload(
+  input: UploadRecordingInput,
+  authHeaders: { Authorization: string }
+): Promise<InitUploadResponse> {
   const body: Record<string, unknown> = {
     title: input.title
   }
@@ -97,10 +100,13 @@ async function initUpload(input: UploadRecordingInput): Promise<InitUploadRespon
 
   const response = await fetchWithTimeout(
     'init upload',
-    makeUrl('/api/upload/init'),
+    makeMeet2NoteUrl('/api/upload/init'),
     {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...authHeaders
+      },
       body: JSON.stringify(body)
     },
     INIT_UPLOAD_TIMEOUT_MS
@@ -114,16 +120,18 @@ async function uploadAsset(
   recordingId: string,
   uploadToken: string,
   path: 'video' | 'microphone',
-  blob: Blob
+  blob: Blob,
+  authHeaders: { Authorization: string }
 ): Promise<void> {
   const response = await fetchWithTimeout(
     `upload ${path}`,
-    makeUrl(`/api/upload/${encodeURIComponent(recordingId)}/${path}`),
+    makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(recordingId)}/${path}`),
     {
       method: 'PUT',
       headers: {
         'Content-Type': 'application/octet-stream',
-        'X-Upload-Token': uploadToken
+        'X-Upload-Token': uploadToken,
+        ...authHeaders
       },
       body: blob
     },
@@ -136,16 +144,18 @@ async function uploadAsset(
 async function completeUpload(
   recordingId: string,
   uploadToken: string,
-  assets: UploadAsset[]
+  assets: UploadAsset[],
+  authHeaders: { Authorization: string }
 ): Promise<void> {
   const response = await fetchWithTimeout(
     'complete upload',
-    makeUrl(`/api/upload/${encodeURIComponent(recordingId)}/complete`),
+    makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(recordingId)}/complete`),
     {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-Upload-Token': uploadToken
+        'X-Upload-Token': uploadToken,
+        ...authHeaders
       },
       body: JSON.stringify({ assets })
     },
@@ -157,23 +167,27 @@ async function completeUpload(
 
 export async function uploadRecordingOnce(input: UploadRecordingInput): Promise<UploadRecordingResult> {
   try {
-    const session = await initUpload(input)
+    const authHeaders = await uploadAuthHeaders()
+    const session = await initUpload(input, authHeaders)
     const assets: UploadAsset[] = ['video_audio']
 
-    await uploadAsset(session.recordingId, session.uploadToken, 'video', input.videoBlob)
+    await uploadAsset(session.recordingId, session.uploadToken, 'video', input.videoBlob, authHeaders)
 
     if (input.microphoneBlob && input.microphoneBlob.size > 0) {
-      await uploadAsset(session.recordingId, session.uploadToken, 'microphone', input.microphoneBlob)
+      await uploadAsset(session.recordingId, session.uploadToken, 'microphone', input.microphoneBlob, authHeaders)
       assets.push('microphone')
     }
 
-    await completeUpload(session.recordingId, session.uploadToken, assets)
+    await completeUpload(session.recordingId, session.uploadToken, assets, authHeaders)
 
     return {
       recordingId: session.recordingId,
       assets
     }
   } catch (error) {
+    if (error instanceof Meet2NoteAuthError) {
+      void markMeet2NoteReconnectRequired(error.message).catch(() => {})
+    }
     captureException(error, {
       operation: 'uploadRecordingOnce',
       hasMicrophoneAsset: !!input.microphoneBlob,

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -1,8 +1,7 @@
 import { captureException } from './diagnostics'
 import {
   makeAuthorizationHeader,
-  Meet2NoteAuthError,
-  requireMeet2NoteExtensionToken
+  Meet2NoteAuthError
 } from './extensionAuth'
 import { makeMeet2NoteUrl } from './meet2noteConfig'
 
@@ -79,8 +78,9 @@ async function parseInitResponse(response: Response): Promise<InitUploadResponse
   return { recordingId, uploadToken, expiresAt }
 }
 
-async function uploadAuthHeaders(): Promise<{ Authorization: string }> {
-  const token = await requireMeet2NoteExtensionToken()
+async function uploadAuthHeaders(extensionToken: string): Promise<{ Authorization: string }> {
+  const token = extensionToken.trim()
+  if (!token) throw new Meet2NoteAuthError('Connect to Meet2Note before uploading.')
   return { Authorization: makeAuthorizationHeader(token) }
 }
 
@@ -164,9 +164,12 @@ async function completeUpload(
   if (!response.ok) throw httpError('complete upload', response)
 }
 
-export async function uploadRecordingOnce(input: UploadRecordingInput): Promise<UploadRecordingResult> {
+export async function uploadRecordingOnce(
+  input: UploadRecordingInput,
+  extensionToken: string
+): Promise<UploadRecordingResult> {
   try {
-    const authHeaders = await uploadAuthHeaders()
+    const authHeaders = await uploadAuthHeaders(extensionToken)
     const session = await initUpload(input, authHeaders)
     const assets: UploadAsset[] = ['video_audio']
 

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -1,7 +1,6 @@
 import { captureException } from './diagnostics'
 import {
   makeAuthorizationHeader,
-  markMeet2NoteReconnectRequired,
   Meet2NoteAuthError,
   requireMeet2NoteExtensionToken
 } from './extensionAuth'
@@ -185,9 +184,6 @@ export async function uploadRecordingOnce(input: UploadRecordingInput): Promise<
       assets
     }
   } catch (error) {
-    if (error instanceof Meet2NoteAuthError) {
-      void markMeet2NoteReconnectRequired(error.message).catch(() => {})
-    }
     captureException(error, {
       operation: 'uploadRecordingOnce',
       hasMicrophoneAsset: !!input.microphoneBlob,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
   entry: {
     popup: './src/popup.tsx',
     background: './src/background.ts',
+    connectCallback: './src/connectCallback.ts',
     offscreen: './src/offscreen.ts',
     micsetup: './src/micsetup.tsx',
     meetWatcher: './src/meetWatcher.ts',
@@ -39,6 +40,7 @@ module.exports = {
     new CopyWebpackPlugin({
       patterns: [
         { from: 'manifest.json',  to: 'manifest.json' },
+        { from: 'connect-callback.html', to: 'connect-callback.html' },
         { from: 'popup.html',     to: 'popup.html' },
         { from: 'offscreen.html', to: 'offscreen.html', noErrorOnMissing: true },
         { from: 'micsetup.html', to: 'micsetup.html' },


### PR DESCRIPTION
## What changed

1. Added the Meet2Note account connection flow in the extension:
   a) popup state and `Connect to Meet2Note` button,
   b) `connect-callback.html` callback page,
   c) one-time `code` exchange for long-lived `extensionToken`,
   d) local token/user storage in `chrome.storage.local`.

2. Updated upload authorization:
   a) `POST /api/upload/init` sends `Authorization: Bearer <extensionToken>`,
   b) asset upload and `/complete` send both `Authorization` and `X-Upload-Token`,
   c) `401`/`403` clears the token and asks the user to reconnect instead of retrying forever.

3. Updated project integration docs and smoke checks:
   a) README, system map, runbook and AGENTS instructions,
   b) webpack/compose/manifest wiring for the callback entrypoint,
   c) smoke test asserts callback files and manifest exposure.

## Verification

1. `make check`
2. `docker compose run --rm builder sh -lc 'npm run smoke'`
3. `git diff --check`

## Notes

1. Backend implementation is tracked in https://github.com/pawel-walaszek/recording-backend/issues/14.
2. This PR does not change backend code.
3. Webpack still warns about existing large Ant Design bundles for `popup.js` and `micsetup.js`.

Closes #5