### PR TITLE
[codex] Implement upload queue history

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Jeśli wolisz wariant z botem albo aplikacją desktopową do nagrywania, zobacz 
 
 **Połączenie z kontem Meet2Note** - popup otwiera flow `Connect to Meet2Note`, zapisuje długotrwały token w `chrome.storage.local` i używa go przy uploadzie.
 
-**Retry uploadu** - jeśli upload się nie powiedzie, ponawia próbę co 15 sekund aż do sukcesu, bez lokalnego pobierania pliku.
+**Kolejka i retry uploadu** - zakończone nagrania trafiają do lokalnej kolejki, a pojedynczy upload w retry nie blokuje kolejnego nagrania.
 
 **Architektura MV3/Offscreen** - nagrywanie działa w ukrytym dokumencie offscreen.
 
@@ -31,7 +31,7 @@ Jeśli wolisz wariant z botem albo aplikacją desktopową do nagrywania, zobacz 
 
 3. Service worker w tle tworzy i koordynuje dokument offscreen oraz pobiera właściwy `streamId` przechwytywania dla aktywnej karty.
 
-4. Strona offscreen przechwytuje kartę, nagrywa osobny asset mikrofonu, finalizuje bloby i wysyła je do backendu z tokenem użytkownika.
+4. Strona offscreen przechwytuje kartę, nagrywa osobny asset mikrofonu, finalizuje bloby i dodaje nagranie do sekwencyjnej kolejki uploadu.
 
 ## Wymagania
 
@@ -134,7 +134,7 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
    e) Po połączeniu popup pokazuje konto Meet2Note, a token użytkownika jest zapisany w `chrome.storage.local`.
    f) **Start Recording** rozpoczyna nagrywanie bieżącej karty (wideo + audio systemowe). Jeśli mikrofon jest dostępny, zostanie nagrany jako osobny asset.
    g) Podczas nagrywania ten sam przycisk zmienia się na **Stop & Upload**, finalizuje nagranie i wysyła assety do `https://meet2note.com`.
-   h) Status pod przyciskami pokazuje, czy nagrywanie trwa, czy trwa upload oraz kiedy nastąpi kolejna próba retry.
+   h) Lista ostatnich nagrań pokazuje status każdego uploadu oraz kiedy nastąpi kolejna próba retry.
 
 > Na aktywnym spotkaniu Google Meet rozszerzenie pokazuje znacznik `RDY`, a podczas nagrywania `REC`. Jeśli nagranie zostało rozpoczęte na karcie Meet, wyjście ze spotkania automatycznie zatrzymuje nagrywanie i uruchamia upload do backendu. Rozszerzenie nie zapisuje nagrań lokalnie przez Chrome Downloads API.
 
@@ -285,8 +285,8 @@ Odpowiedź:
 Pytanie: `Stop & Upload` kończy nagrywanie, ale upload się ponawia. Co zrobić?
 Odpowiedź:
 1. Sprawdź, czy `https://meet2note.com` działa i czy przeglądarka ma połączenie z siecią.
-2. Rozszerzenie ponawia pełną próbę uploadu co 15 sekund aż do sukcesu.
-3. Nie zamykaj przeglądarki ani nie przeładowuj rozszerzenia, bo gotowe bloby są trzymane w pamięci i mogą zostać utracone.
+2. Rozszerzenie ponawia pełną próbę uploadu tej pozycji co 15 sekund, a kolejne nagrania mogą w tym czasie trafiać do kolejki.
+3. Nie zamykaj przeglądarki ani nie przeładowuj rozszerzenia, bo gotowe bloby są trzymane w pamięci i mogą zostać oznaczone jako utracone.
 
 Pytanie: Popup pokazuje `Connect to Meet2Note` albo `Reconnect to Meet2Note`. Co zrobić?
 Odpowiedź:

--- a/docs/runbooks/002-smoke-test-po-zmianach.md
+++ b/docs/runbooks/002-smoke-test-po-zmianach.md
@@ -24,10 +24,11 @@ Szybko potwierdzic, ze build oraz najwazniejsze sciezki rozszerzenia dzialaja po
 9. Jesli popup pokazuje `Not connected`, kliknij `Connect to Meet2Note`, przejdz przez backend i potwierdz, ze callback zapisuje polaczenie.
 10. Uruchom `Start Recording`, zatrzymaj nagranie przez `Stop & Upload` i potwierdz upload do `https://meet2note.com`.
 11. Potwierdz, ze Chrome nie pobiera lokalnego pliku `.webm`.
-12. Jesli testujesz retry, czasowo odetnij backend albo siec, zatrzymaj nagranie i potwierdz, ze popup pokazuje ponawianie uploadu co okolo 15 sekund.
-13. Jesli testujesz autoryzacje, usun albo uszkodz token w `chrome.storage.local` i potwierdz, ze popup wymaga ponownego polaczenia zamiast bez konca ponawiac upload.
-14. Przywroc backend albo siec i potwierdz, ze kolejna proba uploadu konczy sie sukcesem.
-15. Sprawdz konsole service workera, offscreen document i karty testowej pod katem nowych bledow.
+12. Jesli dotknieto kolejki uploadu, potwierdz, ze popup pokazuje sekcje `Recent recordings` nawet przed pierwszym lokalnym nagraniem, a potem rozpocznij drugie nagranie zanim pierwszy upload sie zakonczy i potwierdz, ze popup pokazuje obie pozycje historii.
+13. Jesli testujesz retry, czasowo odetnij backend albo siec, zatrzymaj nagranie i potwierdz, ze popup pokazuje ponawianie uploadu konkretnej pozycji co okolo 15 sekund.
+14. Jesli testujesz autoryzacje, usun albo uszkodz token w `chrome.storage.local` i potwierdz, ze popup wymaga ponownego polaczenia zamiast bez konca ponawiac upload.
+15. Przywroc backend albo siec i potwierdz, ze kolejna proba uploadu konczy sie sukcesem.
+16. Sprawdz konsole service workera, offscreen document i karty testowej pod katem nowych bledow.
 
 ## Kryteria zaliczenia
 
@@ -38,6 +39,7 @@ Szybko potwierdzic, ze build oraz najwazniejsze sciezki rozszerzenia dzialaja po
 - Strona konfiguracji mikrofonu pokazuje `Default microphone` i pozwala zapisac wybor.
 - Nagrywanie startuje, zatrzymuje sie i wysyla assety do backendu, jesli dotknieto kodu recording/offscreen/upload/permissions.
 - Po sukcesie Chrome nie pobiera lokalnego `.webm`.
+- Upload jednego nagrania nie blokuje rozpoczecia kolejnego nagrania.
 - Na aktywnym spotkaniu Meet znacznik rozszerzenia pokazuje `RDY`, po starcie `REC`, a wyjscie ze spotkania zatrzymuje nagrywanie i uruchamia upload.
-- Przy bledzie uploadu popup pokazuje retry, a kolejna proba nastepuje co okolo 15 sekund.
+- Przy bledzie uploadu popup pokazuje retry dla konkretnej pozycji, a kolejna proba nastepuje co okolo 15 sekund.
 - Przy bledzie autoryzacji `401`/`403` popup pokazuje koniecznosc ponownego polaczenia z Meet2Note.

--- a/docs/specs/004-kolejka-uploadu-i-historia-nagran.md
+++ b/docs/specs/004-kolejka-uploadu-i-historia-nagran.md
@@ -75,6 +75,7 @@ Użytkownik powinien widzieć oddzielnie:
    a) Domyślny limit: 10 ostatnich pozycji.
    b) Starsze pozycje terminalne są usuwane po przekroczeniu limitu.
    c) Pozycje nieterminalne (`queued`, `uploading`, `retrying`, `auth_required`) nie są usuwane przez limit, dopóki mają szansę na upload.
+   d) Pamięciowa kolejka blobów w offscreen ma twardy limit 3 pozycji i 2 GiB łącznego rozmiaru blobów; po przekroczeniu limitu nowa pozycja przechodzi w `failed` z czytelnym błędem.
 
 7. Globalny `uploadStatus` zostaje zastąpiony snapshotem kolejki.
    a) Popup nie powinien już blokować przycisku startu tylko dlatego, że istnieje aktywny upload.

--- a/docs/specs/004-kolejka-uploadu-i-historia-nagran.md
+++ b/docs/specs/004-kolejka-uploadu-i-historia-nagran.md
@@ -104,7 +104,7 @@ interface RecordingHistoryItem {
   title: string
   meetingId?: string
   meetingTitle?: string
-  tabUrl?: string
+  tabUrl?: string // origin + pathname, bez query i fragmentu
   startedAt: string
   stoppedAt: string
   durationMs: number

--- a/docs/specs/004-kolejka-uploadu-i-historia-nagran.md
+++ b/docs/specs/004-kolejka-uploadu-i-historia-nagran.md
@@ -32,6 +32,7 @@ Użytkownik powinien widzieć oddzielnie:
    d) Ręczny eksport lokalnego pliku `.webm`.
    e) Ręczne kasowanie pojedynczych pozycji historii z UI, o ile nie okaże się konieczne dla ergonomii.
    f) Migracja starszych, już utraconych uploadów zapisanych tylko jako globalny `uploadStatus`.
+   g) Pobieranie w popupie pełnej historii z panelu Meet2Note, dopóki backend nie udostępnia listy nagrań dla `extensionToken`.
 
 ## Obecne zachowanie
 
@@ -215,6 +216,7 @@ interface UploadQueueSnapshotMessage {
    b) Widoczny limit w popupie: 5 najnowszych pozycji.
    c) Dane pozycji: tytuł, status, czas/długość, `recordingId` po sukcesie albo błąd/retry.
    d) UI ma być gęsty i czytelny w obecnej szerokości popupu.
+   e) Sekcja ma być widoczna także przy pustej lokalnej historii, żeby użytkownik widział, gdzie pojawią się statusy kolejki.
 
 3. Statusy użytkowe:
    a) `queued`: `Waiting to upload`.
@@ -310,6 +312,12 @@ make check
 
 5. Wznowienie `auth_required` po reconnect wymaga koordynacji storage i offscreen.
    a) Mitigacja: po zmianie tokenu background wysyła do offscreen komunikat wznowienia kolejki.
+
+6. Popup nie może jeszcze pobrać tej samej listy, którą pokazuje panel `/recordings`.
+   a) Obecny endpoint `GET /api/recordings` jest oparty o sesję webowego panelu.
+   b) Wtyczka ma trwały `extensionToken`, więc backend powinien udostępnić listę ostatnich nagrań po `Authorization: Bearer <extensionToken>`.
+   c) Backendowe rozszerzenie kontraktu jest opisane w issue [recording-backend#22](https://github.com/pawel-walaszek/recording-backend/issues/22).
+   d) Do czasu zmiany backendu popup pokazuje lokalną historię uploadów z tego profilu przeglądarki.
 
 ## Otwarte Pytania
 

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -19,12 +19,13 @@ Docelowy backend dla uploadu i przetwarzania nagrań będzie rozwijany w powiąz
 | Komponent | Ścieżka | Rola |
 | --- | --- | --- |
 | Manifest | `manifest.json` | Deklaruje metadane MV3, uprawnienia, worker tła i dostępne zasoby. |
-| Popup | `popup.html`, `src/popup.tsx` | Interfejs React + Ant Design do otwierania ustawień mikrofonu oraz startu/stopu nagrywania. |
+| Popup | `popup.html`, `src/popup.tsx` | Interfejs React + Ant Design do otwierania ustawień mikrofonu, startu/stopu nagrywania oraz podglądu historii uploadów. |
 | Callback Meet2Note | `connect-callback.html`, `src/connectCallback.ts` | Kończy flow połączenia z backendu, waliduje `state`, wymienia jednorazowy `code` na token i zapisuje go lokalnie. |
 | Watcher Google Meet | `src/meetWatcher.ts`, `manifest.json` | Content script na `meet.google.com`, który wykrywa aktywne spotkanie i opuszczenie spotkania. |
 | Service worker tła | `src/background.ts` | Koordynuje przechwytywanie karty, cykl życia dokumentu offscreen, stan nagrywania/uploadu i znaczniki. |
 | Nagrywarka offscreen | `offscreen.html`, `src/offscreen.ts` | Przechwytuje media z karty, nagrywa osobny asset mikrofonu, finalizuje bloby i wysyła je do backendu. |
 | Klient uploadu | `src/uploadClient.ts` | Wykonuje kontrakt uploadu backendu: `/init`, upload assetów, `/complete`. |
+| Historia nagrań | `src/recordingHistory.ts` | Definiuje model lokalnej historii uploadów i helpery `chrome.storage.local`. |
 | Strona konfiguracji mikrofonu | `micsetup.html`, `src/micsetup.tsx` | Widoczna strona React + Ant Design używana do nadania uprawnienia mikrofonu, wyboru urządzenia i zapisu konfiguracji w `chrome.storage.local`. |
 | Preferencje mikrofonu | `src/micPreferences.ts` | Wspólne klucze i helpery `chrome.storage.local` dla zapisanego wyboru mikrofonu. |
 | Autoryzacja Meet2Note | `src/extensionAuth.ts` | Wspólne helpery `chrome.storage.local` dla długotrwałego `extensionToken`, danych użytkownika i `state` flow połączenia. |
@@ -45,13 +46,14 @@ Ten opis dokumentuje aktualne ustalenia integracyjne między wtyczką i backende
 6. Jeśli mikrofon jest dostępny, rozszerzenie wysyła osobny asset `microphone` przez `PUT /api/upload/{recordingId}/microphone`.
 7. Każdy upload assetu używa nagłówków `Authorization` oraz `X-Upload-Token`.
 8. Rozszerzenie kończy upload przez `POST /api/upload/{recordingId}/complete`.
-9. Jeśli upload się nie powiedzie, offscreen ponawia pełny upload co 15 sekund aż do sukcesu, bez lokalnego zapisu pliku.
-10. Jeśli backend zwróci `401` albo `403`, zwykły retry jest przerywany, token jest czyszczony i popup wymaga ponownego połączenia z Meet2Note.
+9. Zakończone nagrania trafiają do sekwencyjnej kolejki uploadu w offscreen; jeden aktywny upload nie blokuje startu kolejnego nagrania.
+10. Jeśli upload się nie powiedzie, offscreen ponawia pełny upload konkretnej pozycji co 15 sekund, bez lokalnego zapisu pliku.
+11. Jeśli backend zwróci `401` albo `403`, zwykły retry tej pozycji jest przerywany, token jest czyszczony i popup wymaga ponownego połączenia z Meet2Note.
 
 ## Granice uruchomieniowe
 
 1. Pliki wynikowe trafiają bezpośrednio do `https://meet2note.com`, bez automatycznego pobierania lokalnego `.webm`.
-2. Gotowe bloby są trzymane tylko w pamięci na czas uploadu i retry.
+2. Gotowe bloby są trzymane tylko w pamięci offscreen na czas kolejki, uploadu i retry; trwała historia w `chrome.storage.local` zawiera tylko metadane.
 3. Wybór mikrofonu i token Meet2Note są zapisywane lokalnie w `chrome.storage.local`.
 4. Tokenów, kodów wymiany, nagłówka `Authorization`, `X-Upload-Token` ani blobów nagrań nie wolno logować do konsoli ani Sentry.
 5. Content script na Google Meet nie czyta ani nie wysyła treści spotkania; wykrywa tylko stan obecności w spotkaniu.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.7.5",
+    "version": "1.8.0",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/src/background.ts
+++ b/src/background.ts
@@ -25,6 +25,7 @@ let autoStopMeetTabId: number | null = null
 let recordingStartedAt: number | null = null
 const meetTabsInMeeting = new Set<number>()
 let recentRecordings: RecordingHistoryItem[] = []
+const RECORDER_CONTEXT_INTERRUPTED_MESSAGE = 'Upload was interrupted by an extension restart or refresh.'
 
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
 const DEFAULT_OFFSCREEN_RESPONSE_TIMEOUT_MS = 15_000
@@ -140,7 +141,7 @@ async function hasOffscreenContext(): Promise<boolean> {
 async function ensureOffscreen(): Promise<void> {
   const have = await hasOffscreenContext()
   if (!have) {
-    recentRecordings = (await markIncompleteRecordingsFailed('Upload data was lost when the recorder context was recreated.')).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+    recentRecordings = (await markIncompleteRecordingsFailed(RECORDER_CONTEXT_INTERRUPTED_MESSAGE)).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
     broadcastUploadQueueState()
     bglog('Creating offscreen document…')
     await chrome.offscreen.createDocument({
@@ -188,7 +189,7 @@ async function resetOffscreen(): Promise<void> {
     if (await hasOffscreenContext()) {
       await chrome.offscreen.closeDocument()
       await wait(250)
-      recentRecordings = (await markIncompleteRecordingsFailed('Upload data was lost when the recorder context was reset.')).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+      recentRecordings = (await markIncompleteRecordingsFailed(RECORDER_CONTEXT_INTERRUPTED_MESSAGE)).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
       broadcastUploadQueueState()
     }
   } catch (e) {
@@ -260,7 +261,7 @@ chrome.runtime.onConnect.addListener((port) => {
     void (async () => {
       try {
         if (await hasOffscreenContext()) return
-        recentRecordings = (await markIncompleteRecordingsFailed('Upload data was lost when the recorder context disconnected.')).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+        recentRecordings = (await markIncompleteRecordingsFailed(RECORDER_CONTEXT_INTERRUPTED_MESSAGE)).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
         broadcastUploadQueueState()
       } catch (e) {
         bglog('Failed to mark incomplete recordings after offscreen disconnect', e)

--- a/src/background.ts
+++ b/src/background.ts
@@ -256,6 +256,17 @@ chrome.runtime.onConnect.addListener((port) => {
     recordingStartedAt = null
     persistRecordingState(false, null)
     setBadge(false)
+
+    void (async () => {
+      try {
+        if (await hasOffscreenContext()) return
+        recentRecordings = (await markIncompleteRecordingsFailed('Upload data was lost when the recorder context disconnected.')).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+        broadcastUploadQueueState()
+      } catch (e) {
+        bglog('Failed to mark incomplete recordings after offscreen disconnect', e)
+        captureException(e, { operation: 'offscreen.onDisconnect.markIncompleteRecordingsFailed' })
+      }
+    })()
   })
 })
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,7 +1,7 @@
 // src/background.ts
 
 import { captureException, initDiagnostics } from './diagnostics'
-import { getMeet2NoteExtensionToken, MEET2NOTE_EXTENSION_TOKEN_KEY } from './extensionAuth'
+import { getMeet2NoteExtensionToken } from './extensionAuth'
 import { clearMicPreferences, getMicPreferences, type MicPreferences } from './micPreferences'
 import {
   markIncompleteRecordingsFailed,
@@ -564,17 +564,6 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   })
 
   return true
-})
-
-chrome.storage.onChanged.addListener((changes, areaName) => {
-  if (areaName !== 'local') return
-
-  const tokenChange = changes[MEET2NOTE_EXTENSION_TOKEN_KEY]
-  if (tokenChange && typeof tokenChange.newValue === 'string' && tokenChange.newValue.trim() && offscreenPort) {
-    postToOffscreen({ type: 'OFFSCREEN_RESUME_AUTH_UPLOADS' }).catch((e) => {
-      bglog('OFFSCREEN_RESUME_AUTH_UPLOADS failed', e)
-    })
-  }
 })
 
 chrome.runtime.onSuspend?.addListener(async () => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,8 +1,15 @@
 // src/background.ts
 
 import { captureException, initDiagnostics } from './diagnostics'
-import { getMeet2NoteExtensionToken } from './extensionAuth'
+import { getMeet2NoteExtensionToken, MEET2NOTE_EXTENSION_TOKEN_KEY } from './extensionAuth'
 import { clearMicPreferences, getMicPreferences, type MicPreferences } from './micPreferences'
+import {
+  markIncompleteRecordingsFailed,
+  normalizeRecordingHistory,
+  POPUP_RECORDING_HISTORY_LIMIT,
+  readRecordingHistory,
+  type RecordingHistoryItem
+} from './recordingHistory'
 
 initDiagnostics('background')
 
@@ -17,13 +24,7 @@ let currentRecordingTabId: number | null = null
 let autoStopMeetTabId: number | null = null
 let recordingStartedAt: number | null = null
 const meetTabsInMeeting = new Set<number>()
-
-type UploadStatus = 'idle' | 'uploading' | 'upload_retrying' | 'uploaded' | 'auth_required'
-
-let currentUploadStatus: UploadStatus = 'idle'
-let currentUploadError: string | null = null
-let currentUploadNextRetryAt: number | null = null
-let currentUploadedRecordingId: string | null = null
+let recentRecordings: RecordingHistoryItem[] = []
 
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
 const DEFAULT_OFFSCREEN_RESPONSE_TIMEOUT_MS = 15_000
@@ -95,66 +96,19 @@ function setRecordingStopping(stopping: boolean): void {
   broadcastRecordingState()
 }
 
-function persistUploadState(): void {
+async function hydrateRecentRecordings(): Promise<RecordingHistoryItem[]> {
   try {
-    void (chrome.storage as any)?.session?.set?.({
-      uploadStatus: currentUploadStatus,
-      uploadError: currentUploadError,
-      uploadNextRetryAt: currentUploadNextRetryAt,
-      uploadedRecordingId: currentUploadedRecordingId
-    })?.catch?.(() => {})
+    recentRecordings = (await readRecordingHistory()).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+    return recentRecordings
   } catch {}
+  return recentRecordings
 }
 
-function setUploadState(
-  status: UploadStatus,
-  extra?: {
-    error?: string | null
-    nextRetryAt?: number | null
-    recordingId?: string | null
-  }
-): void {
-  currentUploadStatus = status
-  currentUploadError = extra?.error ?? null
-  currentUploadNextRetryAt = extra?.nextRetryAt ?? null
-  currentUploadedRecordingId = extra?.recordingId ?? (status === 'uploaded' ? currentUploadedRecordingId : null)
-  persistUploadState()
+function broadcastUploadQueueState(items = recentRecordings): void {
   chrome.runtime.sendMessage({
-    type: 'UPLOAD_STATE',
-    status: currentUploadStatus,
-    error: currentUploadError,
-    nextRetryAt: currentUploadNextRetryAt,
-    recordingId: currentUploadedRecordingId
+    type: 'UPLOAD_QUEUE_STATE',
+    items
   }).catch(() => {})
-}
-
-function isUploadBlockingNewRecording(): boolean {
-  return currentUploadStatus === 'uploading' || currentUploadStatus === 'upload_retrying'
-}
-
-function isUploadStatus(value: unknown): value is UploadStatus {
-  return value === 'idle' ||
-    value === 'uploading' ||
-    value === 'upload_retrying' ||
-    value === 'uploaded' ||
-    value === 'auth_required'
-}
-
-async function hydrateUploadStateFromSession(): Promise<void> {
-  try {
-    const sessionState = await chrome.storage.session.get([
-      'uploadStatus',
-      'uploadError',
-      'uploadNextRetryAt',
-      'uploadedRecordingId'
-    ])
-    if (isUploadStatus(sessionState?.uploadStatus)) {
-      currentUploadStatus = sessionState.uploadStatus
-    }
-    currentUploadError = typeof sessionState?.uploadError === 'string' ? sessionState.uploadError : null
-    currentUploadNextRetryAt = typeof sessionState?.uploadNextRetryAt === 'number' ? sessionState.uploadNextRetryAt : null
-    currentUploadedRecordingId = typeof sessionState?.uploadedRecordingId === 'string' ? sessionState.uploadedRecordingId : null
-  } catch {}
 }
 
 async function getMicPreferencesForOffscreen(): Promise<MicPreferences> {
@@ -186,6 +140,8 @@ async function hasOffscreenContext(): Promise<boolean> {
 async function ensureOffscreen(): Promise<void> {
   const have = await hasOffscreenContext()
   if (!have) {
+    recentRecordings = (await markIncompleteRecordingsFailed('Upload data was lost when the recorder context was recreated.')).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+    broadcastUploadQueueState()
     bglog('Creating offscreen document…')
     await chrome.offscreen.createDocument({
       url: chrome.runtime.getURL('offscreen.html'),
@@ -226,13 +182,14 @@ async function resetOffscreen(): Promise<void> {
   autoStopMeetTabId = null
   recordingStartedAt = null
   persistRecordingState(false, null)
-  setUploadState('idle')
   setBadge(false)
 
   try {
     if (await hasOffscreenContext()) {
       await chrome.offscreen.closeDocument()
       await wait(250)
+      recentRecordings = (await markIncompleteRecordingsFailed('Upload data was lost when the recorder context was reset.')).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+      broadcastUploadQueueState()
     }
   } catch (e) {
     bglog('Offscreen reset failed', e)
@@ -279,15 +236,9 @@ chrome.runtime.onConnect.addListener((port) => {
       }
     }
 
-    if (msg?.type === 'UPLOAD_STATE') {
-      const status = typeof msg.status === 'string' ? msg.status as UploadStatus : 'idle'
-      if (isUploadStatus(status)) {
-        setUploadState(status, {
-          error: typeof msg.error === 'string' ? msg.error : null,
-          nextRetryAt: typeof msg.nextRetryAt === 'number' ? msg.nextRetryAt : null,
-          recordingId: typeof msg.recordingId === 'string' ? msg.recordingId : null
-        })
-      }
+    if (msg?.type === 'UPLOAD_QUEUE_STATE' && Array.isArray(msg.items)) {
+      recentRecordings = normalizeRecordingHistory(msg.items).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+      broadcastUploadQueueState()
     }
   })
 
@@ -304,9 +255,6 @@ chrome.runtime.onConnect.addListener((port) => {
     autoStopMeetTabId = null
     recordingStartedAt = null
     persistRecordingState(false, null)
-    if (currentUploadStatus !== 'uploading' && currentUploadStatus !== 'upload_retrying') {
-      setUploadState('idle')
-    }
     setBadge(false)
   })
 })
@@ -447,11 +395,6 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         sendResponse({ ok: true, recording: true, recordingStartedAt })
         return
       }
-      await hydrateUploadStateFromSession()
-      if (isUploadBlockingNewRecording()) {
-        sendResponse({ ok: false, error: 'Upload is still in progress' })
-        return
-      }
       bglog('Popup requested START_RECORDING for tabId', tabId)
       setRecordingStarting(true, tabId)
 
@@ -506,7 +449,6 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
             : null
           if (!recordingStartedAt) recordingStartedAt = Date.now()
           persistRecordingState(true, recordingStartedAt)
-          if (currentUploadStatus === 'uploaded') setUploadState('idle')
           setBadge(true, tabId)
           broadcastRecordingState({ warning: r.warning })
           sendResponse({ ok: true, micIncluded: r.micIncluded, warning: r.warning, recordingStartedAt })
@@ -550,11 +492,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           'recordingStarting',
           'recordingStartingTabId',
           'recordingStartRequestedAt',
-          'recordingStopping',
-          'uploadStatus',
-          'uploadError',
-          'uploadNextRetryAt',
-          'uploadedRecordingId'
+          'recordingStopping'
         ])
         lastKnownRecording = !!sessionState?.recording
         recordingStartedAt = typeof sessionState?.recordingStartedAt === 'number'
@@ -568,12 +506,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           ? sessionState.recordingStartRequestedAt
           : null
         recordingStopping = !!sessionState?.recordingStopping
-        if (isUploadStatus(sessionState?.uploadStatus)) {
-          currentUploadStatus = sessionState.uploadStatus
-        }
-        currentUploadError = typeof sessionState?.uploadError === 'string' ? sessionState.uploadError : null
-        currentUploadNextRetryAt = typeof sessionState?.uploadNextRetryAt === 'number' ? sessionState.uploadNextRetryAt : null
-        currentUploadedRecordingId = typeof sessionState?.uploadedRecordingId === 'string' ? sessionState.uploadedRecordingId : null
+        await hydrateRecentRecordings()
       } catch {}
       sendResponse({
         recording: lastKnownRecording,
@@ -582,10 +515,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         startingTabId: recordingStartingTabId,
         startRequestedAt: recordingStartRequestedAt,
         stopping: recordingStopping,
-        uploadStatus: currentUploadStatus,
-        uploadError: currentUploadError,
-        uploadNextRetryAt: currentUploadNextRetryAt,
-        uploadedRecordingId: currentUploadedRecordingId
+        recentRecordings
       })
       return
     }
@@ -624,7 +554,20 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   return true
 })
 
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName !== 'local') return
+
+  const tokenChange = changes[MEET2NOTE_EXTENSION_TOKEN_KEY]
+  if (tokenChange && typeof tokenChange.newValue === 'string' && tokenChange.newValue.trim() && offscreenPort) {
+    postToOffscreen({ type: 'OFFSCREEN_RESUME_AUTH_UPLOADS' }).catch((e) => {
+      bglog('OFFSCREEN_RESUME_AUTH_UPLOADS failed', e)
+    })
+  }
+})
+
 chrome.runtime.onSuspend?.addListener(async () => {
   try { if (offscreenPort) await postToOffscreen({ type: 'OFFSCREEN_STOP' }) } catch {}
   setBadge(false)
 })
+
+void hydrateRecentRecordings().catch(() => {})

--- a/src/background.ts
+++ b/src/background.ts
@@ -582,4 +582,17 @@ chrome.runtime.onSuspend?.addListener(async () => {
   setBadge(false)
 })
 
-void hydrateRecentRecordings().catch(() => {})
+async function initializeRecentRecordings(): Promise<void> {
+  if (!(await hasOffscreenContext())) {
+    recentRecordings = (await markIncompleteRecordingsFailed(RECORDER_CONTEXT_INTERRUPTED_MESSAGE)).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+    broadcastUploadQueueState()
+    return
+  }
+
+  await hydrateRecentRecordings()
+}
+
+void initializeRecentRecordings().catch((e) => {
+  bglog('Initial recording history hydration failed', e)
+  captureException(e, { operation: 'initializeRecentRecordings' })
+})

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1,9 +1,23 @@
 // src/offscreen.ts
 
 import { captureException, captureMessage, initDiagnostics } from './diagnostics'
-import { isMeet2NoteAuthError, markMeet2NoteReconnectRequired, Meet2NoteAuthError } from './extensionAuth'
+import {
+  isMeet2NoteAuthError,
+  markMeet2NoteReconnectRequired,
+  MEET2NOTE_EXTENSION_TOKEN_KEY,
+  Meet2NoteAuthError
+} from './extensionAuth'
 import type { MicPreferences } from './micPreferences'
 import { uploadRecordingOnce, type UploadRecordingInput } from './uploadClient'
+import {
+  generateRecordingLocalId,
+  POPUP_RECORDING_HISTORY_LIMIT,
+  readRecordingHistory,
+  type RecordingHistoryItem,
+  type RecordingUploadAsset,
+  type RecordingUploadStatus,
+  upsertRecordingHistoryItem
+} from './recordingHistory'
 
 initDiagnostics('offscreen')
 
@@ -56,13 +70,37 @@ function pushState(recording: boolean, extra?: Record<string, any>) {
   getPort().postMessage({ type: 'RECORDING_STATE', recording, recordingStartedAt, ...extra })
 }
 
-type UploadStatus = 'idle' | 'uploading' | 'upload_retrying' | 'uploaded' | 'auth_required'
+const sleep = (ms: number) => new Promise(res => setTimeout(res, ms))
 
-function pushUploadState(status: UploadStatus, extra?: Record<string, any>) {
-  getPort().postMessage({ type: 'UPLOAD_STATE', status, ...extra })
+interface UploadQueueEntry extends RecordingHistoryItem {
+  videoBlob: Blob
+  microphoneBlob: Blob | null
 }
 
-const sleep = (ms: number) => new Promise(res => setTimeout(res, ms))
+let uploadQueue: UploadQueueEntry[] = []
+let uploadWorkerRunning = false
+
+function toHistoryItem(entry: UploadQueueEntry): RecordingHistoryItem {
+  const {
+    videoBlob: _videoBlob,
+    microphoneBlob: _microphoneBlob,
+    ...historyItem
+  } = entry
+  return historyItem
+}
+
+async function publishUploadQueueState(items?: RecordingHistoryItem[]): Promise<void> {
+  const history = items ?? await readRecordingHistory().catch(() => [])
+  getPort().postMessage({
+    type: 'UPLOAD_QUEUE_STATE',
+    items: history.slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+  })
+}
+
+async function persistQueueEntry(entry: UploadQueueEntry): Promise<void> {
+  const items = await upsertRecordingHistoryItem(toHistoryItem(entry))
+  await publishUploadQueueState(items)
+}
 
 let activeStreams = new Set<MediaStream>()
 let activeAudioContexts = new Set<AudioContext>()
@@ -316,7 +354,6 @@ let microphoneRecorder: MediaRecorder | null = null
 let chunks: BlobPart[] = []
 let microphoneChunks: BlobPart[] = []
 let capturing = false
-let uploadInProgress = false
 let currentRecordingStartedAtMs: number | null = null
 let currentRecordingContext: RecordingContext | null = null
 let microphoneStoppedPromise: Promise<Blob | null> | null = null
@@ -372,68 +409,165 @@ function fallbackTitleFromUrl(url?: string | null): string {
   }
 }
 
-function buildUploadInput(videoBlob: Blob, microphoneBlob: Blob | null): UploadRecordingInput {
+function buildUploadQueueEntry(videoBlob: Blob, microphoneBlob: Blob | null): UploadQueueEntry {
   const now = Date.now()
   const startedAtMs = currentRecordingStartedAtMs || now
   const tabTitle = currentRecordingContext?.tabTitle?.trim()
   const tabUrl = currentRecordingContext?.tabUrl || null
   const meetingId = inferMeetingId(tabUrl)
   const title = tabTitle || fallbackTitleFromUrl(tabUrl)
+  const timestamp = new Date(now).toISOString()
 
   return {
+    localId: generateRecordingLocalId(),
+    status: 'queued',
     title,
     meetingId,
     meetingTitle: tabTitle || undefined,
+    tabUrl: tabUrl || undefined,
     startedAt: new Date(startedAtMs).toISOString(),
+    stoppedAt: timestamp,
     durationMs: Math.max(1, now - startedAtMs),
+    videoBytes: videoBlob.size,
+    microphoneBytes: microphoneBlob?.size || 0,
+    attempt: 0,
+    nextRetryAt: null,
+    backendRecordingId: null,
+    assets: microphoneBlob && microphoneBlob.size > 0 ? ['video_audio', 'microphone'] : ['video_audio'],
+    error: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
     videoBlob,
     microphoneBlob: microphoneBlob && microphoneBlob.size > 0 ? microphoneBlob : null
   }
 }
 
-async function uploadRecordingUntilSuccess(input: UploadRecordingInput, attempt = 1): Promise<void> {
-  uploadInProgress = true
-  let currentAttempt = attempt
+function uploadInputFromQueueEntry(entry: UploadQueueEntry): UploadRecordingInput {
+  return {
+    title: entry.title,
+    meetingId: entry.meetingId,
+    meetingTitle: entry.meetingTitle,
+    startedAt: entry.startedAt,
+    durationMs: entry.durationMs,
+    videoBlob: entry.videoBlob,
+    microphoneBlob: entry.microphoneBlob
+  }
+}
 
+async function updateQueueEntry(
+  entry: UploadQueueEntry,
+  status: RecordingUploadStatus,
+  patch: Partial<Pick<UploadQueueEntry,
+    'attempt' |
+    'nextRetryAt' |
+    'backendRecordingId' |
+    'assets' |
+    'error'
+  >> = {}
+): Promise<void> {
+  Object.assign(entry, {
+    status,
+    updatedAt: new Date().toISOString(),
+    ...patch
+  })
+  await persistQueueEntry(entry)
+}
+
+function removeQueueEntry(localId: string): void {
+  uploadQueue = uploadQueue.filter(entry => entry.localId !== localId)
+}
+
+async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'done' | 'auth_required'> {
   while (true) {
-    pushUploadState(currentAttempt === 1 ? 'uploading' : 'upload_retrying', { attempt: currentAttempt })
+    const attempt = entry.attempt + 1
+    await updateQueueEntry(entry, 'uploading', {
+      attempt,
+      nextRetryAt: null,
+      error: null
+    })
 
     try {
       const extensionToken = await requestMeet2NoteExtensionToken()
-      const result = await uploadRecordingOnce(input, extensionToken)
-      uploadInProgress = false
-      pushUploadState('uploaded', {
-        attempt: currentAttempt,
-        recordingId: result.recordingId,
-        assets: result.assets
+      const result = await uploadRecordingOnce(uploadInputFromQueueEntry(entry), extensionToken)
+      await updateQueueEntry(entry, 'uploaded', {
+        backendRecordingId: result.recordingId,
+        assets: result.assets as RecordingUploadAsset[],
+        nextRetryAt: null,
+        error: null
       })
-      log('Upload completed', { recordingId: result.recordingId, assets: result.assets, attempt: currentAttempt })
-      return
+      removeQueueEntry(entry.localId)
+      log('Upload completed', { localId: entry.localId, recordingId: result.recordingId, assets: result.assets, attempt })
+      return 'done'
     } catch (e) {
       if (isMeet2NoteAuthError(e)) {
-        uploadInProgress = false
         const message = e.message || 'Connect to Meet2Note before uploading.'
         await markMeet2NoteReconnectRequired(message).catch(() => {})
-        pushUploadState('auth_required', { error: message })
-        log('Upload requires Meet2Note connection', { attempt: currentAttempt })
-        return
+        await updateQueueEntry(entry, 'auth_required', {
+          error: message,
+          nextRetryAt: null
+        })
+        log('Upload requires Meet2Note connection', { localId: entry.localId, attempt })
+        return 'auth_required'
       }
 
       captureException(e, {
-        operation: 'uploadRecordingUntilSuccess',
-        attempt: currentAttempt,
+        operation: 'uploadQueueEntryUntilTerminal',
+        localId: entry.localId,
+        attempt,
         nextRetryMs: UPLOAD_RETRY_INTERVAL_MS
       })
       const nextRetryAt = Date.now() + UPLOAD_RETRY_INTERVAL_MS
-      log('Upload failed; retrying in 15 seconds', e)
-      pushUploadState('upload_retrying', {
-        attempt: currentAttempt,
+      log('Upload failed; retrying in 15 seconds', { localId: entry.localId, error: e })
+      await updateQueueEntry(entry, 'retrying', {
         error: e instanceof Error ? e.message : String(e),
         nextRetryAt
       })
       await sleep(UPLOAD_RETRY_INTERVAL_MS)
-      currentAttempt += 1
     }
+  }
+}
+
+async function runUploadQueueWorker(): Promise<void> {
+  if (uploadWorkerRunning) return
+  uploadWorkerRunning = true
+
+  try {
+    while (true) {
+      const nextEntry = uploadQueue.find(entry => entry.status === 'queued')
+      if (!nextEntry) return
+
+      const result = await uploadQueueEntryUntilTerminal(nextEntry)
+      if (result === 'auth_required') return
+    }
+  } finally {
+    uploadWorkerRunning = false
+  }
+}
+
+async function enqueueUpload(entry: UploadQueueEntry): Promise<void> {
+  uploadQueue.push(entry)
+  await persistQueueEntry(entry)
+  void runUploadQueueWorker().catch((e) => {
+    log('Unexpected upload queue worker failure', e)
+    captureException(e, { operation: 'runUploadQueueWorker.unhandled' })
+  })
+}
+
+async function requeueAuthRequiredUploads(): Promise<void> {
+  let changed = false
+  for (const entry of uploadQueue) {
+    if (entry.status !== 'auth_required') continue
+    changed = true
+    await updateQueueEntry(entry, 'queued', {
+      nextRetryAt: null,
+      error: null
+    })
+  }
+  if (changed) {
+    void runUploadQueueWorker().catch((e) => {
+      log('Unexpected upload queue resume failure', e)
+      captureException(e, { operation: 'requeueAuthRequiredUploads.unhandled' })
+    })
   }
 }
 
@@ -669,10 +803,10 @@ async function prepareAndRecord(
         const microphoneBlob = microphoneStoppedPromise ? await microphoneStoppedPromise : null
         log('Finalizing; video chunks =', chunks.length, 'video blob.size =', videoBlob.size, 'microphone blob.size =', microphoneBlob?.size || 0)
 
-        const uploadInput = buildUploadInput(videoBlob, microphoneBlob)
-        void uploadRecordingUntilSuccess(uploadInput).catch((e) => {
-          log('Unexpected upload retry loop failure', e)
-          captureException(e, { operation: 'uploadRecordingUntilSuccess.unhandled' })
+        const uploadEntry = buildUploadQueueEntry(videoBlob, microphoneBlob)
+        void enqueueUpload(uploadEntry).catch((e) => {
+          log('Unexpected upload queue enqueue failure', e)
+          captureException(e, { operation: 'enqueueUpload.unhandled' })
         })
       } catch (e) {
         log('Finalize/Upload failed', e)
@@ -725,12 +859,8 @@ async function startRecordingFromStreamId(
   micPreferences: MicPreferences,
   recordingContext: RecordingContext
 ): Promise<RecordingStartInfo> {
-  if (capturing) {
-    log('Already recording; ignoring start')
-    return { micIncluded: true }
-  }
-  if (uploadInProgress) {
-    throw new Error('Upload is still in progress')
+  if (capturing || stopRequested || mediaRecorder) {
+    throw new Error('Recording is still stopping. Try again in a moment.')
   }
   cleanupRecordingResources()
   try {
@@ -757,7 +887,6 @@ function stopRecording(reason = 'manual'): Record<string, unknown> {
 
   if (!mediaRecorder || !capturing) {
     console.warn('[offscreen] Stop called but not recording')
-    if (uploadInProgress) return { ok: true, alreadyStopping: true }
     pushState(false)
     return { ok: true, alreadyStopped: true }
   }
@@ -817,7 +946,26 @@ rpcPort.onMessage.addListener(async (msg: any) => {
         const res = await (chrome.storage as any)?.session?.get?.(['recording'])
         recording = !!res?.recording
       } catch {}
-      return respond(msg, { recording, uploadInProgress })
+      return respond(msg, {
+        recording,
+        uploadWorkerRunning,
+        queuedUploads: uploadQueue.length,
+        items: await readRecordingHistory().catch(() => [])
+      })
+    }
+
+    if (msg?.type === 'OFFSCREEN_UPLOAD_QUEUE_STATUS') {
+      return respond(msg, {
+        ok: true,
+        uploadWorkerRunning,
+        queuedUploads: uploadQueue.length,
+        items: await readRecordingHistory().catch(() => [])
+      })
+    }
+
+    if (msg?.type === 'OFFSCREEN_RESUME_AUTH_UPLOADS') {
+      await requeueAuthRequiredUploads()
+      return respond(msg, { ok: true })
     }
 
     if (msg?.type === 'DIAG_ECHO') {
@@ -839,3 +987,15 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   } catch (e) { sendResponse({ ok: false, error: String(e) }) }
   return false
 })
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName !== 'local') return
+  const tokenChange = changes[MEET2NOTE_EXTENSION_TOKEN_KEY]
+  if (!tokenChange || typeof tokenChange.newValue !== 'string' || !tokenChange.newValue.trim()) return
+  void requeueAuthRequiredUploads().catch((e) => {
+    log('resume auth-required uploads after token change failed', e)
+    captureException(e, { operation: 'storage.onChanged.resumeAuthUploads' })
+  })
+})
+
+void publishUploadQueueState().catch(() => {})

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -479,12 +479,14 @@ async function updateQueueEntry(
     'error'
   >> = {}
 ): Promise<void> {
-  Object.assign(entry, {
+  const nextEntry: UploadQueueEntry = {
+    ...entry,
     status,
     updatedAt: new Date().toISOString(),
     ...patch
-  })
-  await persistQueueEntry(entry)
+  }
+  await persistQueueEntry(nextEntry)
+  Object.assign(entry, nextEntry)
 }
 
 function removeQueueEntry(localId: string): void {
@@ -504,14 +506,16 @@ async function rejectQueueEntryForMemoryLimit(entry: UploadQueueEntry): Promise<
   const currentBytes = getUploadQueueBytes()
   const entryBytes = getQueueEntryBytes(entry)
   const message = 'Upload queue is full. Try again after pending uploads finish.'
-
-  Object.assign(entry, {
-    status: 'failed' as const,
+  const failedEntry: UploadQueueEntry = {
+    ...entry,
+    status: 'failed',
     error: message,
     nextRetryAt: null,
     updatedAt: now
-  })
-  await persistQueueEntry(entry)
+  }
+
+  await persistQueueEntry(failedEntry)
+  Object.assign(entry, failedEntry)
   captureMessage(
     'Upload queue rejected recording because memory limit was reached.',
     'warning',
@@ -524,6 +528,28 @@ async function rejectQueueEntryForMemoryLimit(entry: UploadQueueEntry): Promise<
       maxQueueBytes: MAX_UPLOAD_QUEUE_BYTES
     }
   )
+}
+
+function getNextReadyUploadQueueEntry(now: number): UploadQueueEntry | null {
+  return uploadQueue.find((entry) => {
+    if (entry.status === 'queued' || entry.status === 'uploading') return true
+    if (entry.status !== 'retrying') return false
+    return entry.nextRetryAt == null || entry.nextRetryAt <= now
+  }) ?? null
+}
+
+function getNextUploadRetryDelayMs(now: number): number | null {
+  let nextRetryDelayMs: number | null = null
+
+  for (const entry of uploadQueue) {
+    if (entry.status !== 'retrying' || entry.nextRetryAt == null || entry.nextRetryAt <= now) continue
+    const delayMs = entry.nextRetryAt - now
+    if (nextRetryDelayMs == null || delayMs < nextRetryDelayMs) {
+      nextRetryDelayMs = delayMs
+    }
+  }
+
+  return nextRetryDelayMs
 }
 
 async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'done' | 'auth_required'> {
@@ -582,11 +608,50 @@ async function runUploadQueueWorker(): Promise<void> {
 
   try {
     while (true) {
-      const nextEntry = uploadQueue.find(entry => entry.status === 'queued')
-      if (!nextEntry) return
+      const now = Date.now()
+      const nextEntry = getNextReadyUploadQueueEntry(now)
+      if (!nextEntry) {
+        const nextRetryDelayMs = getNextUploadRetryDelayMs(now)
+        if (nextRetryDelayMs == null) return
+        await sleep(nextRetryDelayMs)
+        continue
+      }
 
-      const result = await uploadQueueEntryUntilTerminal(nextEntry)
-      if (result === 'auth_required') return
+      try {
+        const result = await uploadQueueEntryUntilTerminal(nextEntry)
+        if (result === 'auth_required') return
+      } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : String(e)
+        captureException(e, {
+          operation: 'runUploadQueueWorker.entry',
+          localId: nextEntry.localId,
+          status: nextEntry.status
+        })
+        log('Upload queue entry crashed; re-queueing entry', {
+          localId: nextEntry.localId,
+          status: nextEntry.status,
+          error: e
+        })
+
+        try {
+          await updateQueueEntry(nextEntry, 'queued', {
+            error: errorMessage,
+            nextRetryAt: null
+          })
+        } catch (recoveryError) {
+          captureException(recoveryError, {
+            operation: 'runUploadQueueWorker.entry.recovery',
+            localId: nextEntry.localId,
+            status: nextEntry.status
+          })
+          Object.assign(nextEntry, {
+            status: 'queued' as const,
+            error: errorMessage,
+            nextRetryAt: null,
+            updatedAt: new Date().toISOString()
+          })
+        }
+      }
     }
   } finally {
     uploadWorkerRunning = false

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -29,6 +29,8 @@ const WANT_MIC_ASSET = true
 const MEDIA_CAPTURE_TIMEOUT_MS = 10_000
 const UPLOAD_RETRY_INTERVAL_MS = 15_000
 const STOP_FINALIZE_TIMEOUT_MS = 10_000
+const MAX_UPLOAD_QUEUE_ENTRIES = 3
+const MAX_UPLOAD_QUEUE_BYTES = 2 * 1024 * 1024 * 1024
 
 window.addEventListener('error', (e) => {
   console.error('[offscreen] window.onerror', e?.message, e?.error)
@@ -477,6 +479,41 @@ function removeQueueEntry(localId: string): void {
   uploadQueue = uploadQueue.filter(entry => entry.localId !== localId)
 }
 
+function getQueueEntryBytes(entry: UploadQueueEntry): number {
+  return entry.videoBlob.size + (entry.microphoneBlob?.size || 0)
+}
+
+function getUploadQueueBytes(entries = uploadQueue): number {
+  return entries.reduce((total, entry) => total + getQueueEntryBytes(entry), 0)
+}
+
+async function rejectQueueEntryForMemoryLimit(entry: UploadQueueEntry): Promise<void> {
+  const now = new Date().toISOString()
+  const currentBytes = getUploadQueueBytes()
+  const entryBytes = getQueueEntryBytes(entry)
+  const message = 'Upload queue is full. Try again after pending uploads finish.'
+
+  Object.assign(entry, {
+    status: 'failed' as const,
+    error: message,
+    nextRetryAt: null,
+    updatedAt: now
+  })
+  await persistQueueEntry(entry)
+  captureMessage(
+    'Upload queue rejected recording because memory limit was reached.',
+    'warning',
+    {
+      operation: 'enqueueUpload.memoryLimit',
+      queueEntries: uploadQueue.length,
+      queueBytes: currentBytes,
+      recordingBytes: entryBytes,
+      maxQueueEntries: MAX_UPLOAD_QUEUE_ENTRIES,
+      maxQueueBytes: MAX_UPLOAD_QUEUE_BYTES
+    }
+  )
+}
+
 async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'done' | 'auth_required'> {
   while (true) {
     const attempt = entry.attempt + 1
@@ -545,6 +582,16 @@ async function runUploadQueueWorker(): Promise<void> {
 }
 
 async function enqueueUpload(entry: UploadQueueEntry): Promise<void> {
+  const queuedBytes = getUploadQueueBytes()
+  const entryBytes = getQueueEntryBytes(entry)
+  if (
+    uploadQueue.length >= MAX_UPLOAD_QUEUE_ENTRIES ||
+    queuedBytes + entryBytes > MAX_UPLOAD_QUEUE_BYTES
+  ) {
+    await rejectQueueEntryForMemoryLimit(entry)
+    return
+  }
+
   uploadQueue.push(entry)
   await persistQueueEntry(entry)
   void runUploadQueueWorker().catch((e) => {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -81,15 +81,21 @@ function wakeUploadQueueWorker(): void {
 
 function sleepUntilUploadQueueWakeOrTimeout(ms: number): Promise<void> {
   let wake: (() => void) | null = null
-  const wakePromise = new Promise<void>((resolve) => {
-    wake = resolve
-    uploadQueueWake = resolve
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+  const wakePromise = new Promise<'wake'>((resolve) => {
+    wake = () => resolve('wake')
+    uploadQueueWake = wake
+  })
+  const timeoutPromise = new Promise<'timeout'>((resolve) => {
+    timeoutId = setTimeout(() => resolve('timeout'), ms)
   })
 
   return Promise.race([
-    sleep(ms),
+    timeoutPromise,
     wakePromise
-  ]).then(() => {
+  ]).then((result) => {
+    if (result === 'wake' && timeoutId) clearTimeout(timeoutId)
     if (wake && uploadQueueWake === wake) uploadQueueWake = null
   })
 }

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1011,7 +1011,10 @@ async function startRecordingFromStreamId(
   micPreferences: MicPreferences,
   recordingContext: RecordingContext
 ): Promise<RecordingStartInfo> {
-  if (capturing || stopRequested || mediaRecorder) {
+  if (capturing) {
+    throw new Error('Already recording.')
+  }
+  if (stopRequested || mediaRecorder) {
     throw new Error('Recording is still stopping. Try again in a moment.')
   }
   cleanupRecordingResources()

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -411,6 +411,17 @@ function fallbackTitleFromUrl(url?: string | null): string {
   }
 }
 
+function sanitizeTabUrlForHistory(url?: string | null): string | undefined {
+  try {
+    if (!url) return undefined
+    const u = new URL(url)
+    const path = u.pathname.replace(/\/+$/, '')
+    return `${u.origin}${path || '/'}`
+  } catch {
+    return undefined
+  }
+}
+
 function buildUploadQueueEntry(videoBlob: Blob, microphoneBlob: Blob | null): UploadQueueEntry {
   const now = Date.now()
   const startedAtMs = currentRecordingStartedAtMs || now
@@ -418,6 +429,7 @@ function buildUploadQueueEntry(videoBlob: Blob, microphoneBlob: Blob | null): Up
   const tabUrl = currentRecordingContext?.tabUrl || null
   const meetingId = inferMeetingId(tabUrl)
   const title = tabTitle || fallbackTitleFromUrl(tabUrl)
+  const sanitizedTabUrl = sanitizeTabUrlForHistory(tabUrl)
   const timestamp = new Date(now).toISOString()
 
   return {
@@ -426,7 +438,7 @@ function buildUploadQueueEntry(videoBlob: Blob, microphoneBlob: Blob | null): Up
     title,
     meetingId,
     meetingTitle: tabTitle || undefined,
-    tabUrl: tabUrl || undefined,
+    tabUrl: sanitizedTabUrl,
     startedAt: new Date(startedAtMs).toISOString(),
     stoppedAt: timestamp,
     durationMs: Math.max(1, now - startedAtMs),

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1109,11 +1109,6 @@ rpcPort.onMessage.addListener(async (msg: any) => {
       })
     }
 
-    if (msg?.type === 'OFFSCREEN_RESUME_AUTH_UPLOADS') {
-      await requeueAuthRequiredUploads()
-      return respond(msg, { ok: true })
-    }
-
     if (msg?.type === 'DIAG_ECHO') {
       return respond(msg, { ok: true, pong: 'offscreen-alive' })
     }

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1001,15 +1001,6 @@ rpcPort.onMessage.addListener(async (msg: any) => {
       })
     }
 
-    if (msg?.type === 'OFFSCREEN_UPLOAD_QUEUE_STATUS') {
-      return respond(msg, {
-        ok: true,
-        uploadWorkerRunning,
-        queuedUploads: uploadQueue.length,
-        items: await readRecordingHistory().catch(() => [])
-      })
-    }
-
     if (msg?.type === 'OFFSCREEN_RESUME_AUTH_UPLOADS') {
       await requeueAuthRequiredUploads()
       return respond(msg, { ok: true })

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -14,7 +14,6 @@ import {
   POPUP_RECORDING_HISTORY_LIMIT,
   readRecordingHistory,
   type RecordingHistoryItem,
-  type RecordingUploadAsset,
   type RecordingUploadStatus,
   upsertRecordingHistoryItem
 } from './recordingHistory'
@@ -74,6 +73,27 @@ function pushState(recording: boolean, extra?: Record<string, any>) {
 
 const sleep = (ms: number) => new Promise(res => setTimeout(res, ms))
 
+function wakeUploadQueueWorker(): void {
+  const wake = uploadQueueWake
+  uploadQueueWake = null
+  if (wake) wake()
+}
+
+function sleepUntilUploadQueueWakeOrTimeout(ms: number): Promise<void> {
+  let wake: (() => void) | null = null
+  const wakePromise = new Promise<void>((resolve) => {
+    wake = resolve
+    uploadQueueWake = resolve
+  })
+
+  return Promise.race([
+    sleep(ms),
+    wakePromise
+  ]).then(() => {
+    if (wake && uploadQueueWake === wake) uploadQueueWake = null
+  })
+}
+
 interface UploadQueueEntry extends RecordingHistoryItem {
   videoBlob: Blob
   microphoneBlob: Blob | null
@@ -81,6 +101,7 @@ interface UploadQueueEntry extends RecordingHistoryItem {
 
 let uploadQueue: UploadQueueEntry[] = []
 let uploadWorkerRunning = false
+let uploadQueueWake: (() => void) | null = null
 
 function toHistoryItem(entry: UploadQueueEntry): RecordingHistoryItem {
   const {
@@ -93,10 +114,15 @@ function toHistoryItem(entry: UploadQueueEntry): RecordingHistoryItem {
 
 async function publishUploadQueueState(items?: RecordingHistoryItem[]): Promise<void> {
   const history = items ?? await readRecordingHistory().catch(() => [])
-  getPort().postMessage({
-    type: 'UPLOAD_QUEUE_STATE',
-    items: history.slice(0, POPUP_RECORDING_HISTORY_LIMIT)
-  })
+  try {
+    getPort().postMessage({
+      type: 'UPLOAD_QUEUE_STATE',
+      items: history.slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+    })
+  } catch (e) {
+    log('Upload queue state broadcast failed', e)
+    captureException(e, { operation: 'publishUploadQueueState' })
+  }
 }
 
 async function persistQueueEntry(entry: UploadQueueEntry): Promise<void> {
@@ -566,7 +592,7 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
       const result = await uploadRecordingOnce(uploadInputFromQueueEntry(entry), extensionToken)
       await updateQueueEntry(entry, 'uploaded', {
         backendRecordingId: result.recordingId,
-        assets: result.assets as RecordingUploadAsset[],
+        assets: result.assets,
         nextRetryAt: null,
         error: null
       })
@@ -613,7 +639,7 @@ async function runUploadQueueWorker(): Promise<void> {
       if (!nextEntry) {
         const nextRetryDelayMs = getNextUploadRetryDelayMs(now)
         if (nextRetryDelayMs == null) return
-        await sleep(nextRetryDelayMs)
+        await sleepUntilUploadQueueWakeOrTimeout(nextRetryDelayMs)
         continue
       }
 
@@ -671,6 +697,7 @@ async function enqueueUpload(entry: UploadQueueEntry): Promise<void> {
 
   uploadQueue.push(entry)
   await persistQueueEntry(entry)
+  wakeUploadQueueWorker()
   void runUploadQueueWorker().catch((e) => {
     log('Unexpected upload queue worker failure', e)
     captureException(e, { operation: 'runUploadQueueWorker.unhandled' })
@@ -688,6 +715,7 @@ async function requeueAuthRequiredUploads(): Promise<void> {
     })
   }
   if (changed) {
+    wakeUploadQueueWorker()
     void runUploadQueueWorker().catch((e) => {
       log('Unexpected upload queue resume failure', e)
       captureException(e, { operation: 'requeueAuthRequiredUploads.unhandled' })

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -307,10 +307,7 @@ function App(): React.ReactElement {
   const connectionErrorMessage = meet2NoteConnection.authError ||
     authRequiredUpload?.error ||
     null
-  const showRecentRecordings = recordingControlsAvailable || recentRecordings.length > 0
-  const recentRecordingsEmptyText = recordingControlsAvailable
-    ? 'No recordings from this browser yet'
-    : 'Connect to Meet2Note to upload recordings'
+  const recentRecordingsEmptyText = 'No recordings from this browser yet'
 
   const openSettings = useCallback(async () => {
     try {
@@ -580,61 +577,59 @@ function App(): React.ReactElement {
             </Space>
           </>
         ) : null}
-        {showRecentRecordings ? (
-          <>
-            <Divider style={{ margin: '4px 0' }} />
-            <Flex vertical gap={6}>
-              <Text strong style={{ fontSize: 12, lineHeight: 1.2 }}>
-                Recent recordings
-              </Text>
-              {recentRecordings.length ? (
-                recentRecordings.map(item => (
-                  <Flex
-                    key={item.localId}
-                    vertical
-                    gap={3}
-                    style={{ borderTop: '1px solid #f0f0f0', paddingTop: 5 }}
-                  >
-                    <Flex align="center" justify="space-between" gap={6}>
-                      <Text
-                        title={item.title}
-                        style={{
-                          fontSize: 12,
-                          lineHeight: 1.2,
-                          maxWidth: 132,
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap'
-                        }}
-                      >
-                        {item.title}
-                      </Text>
-                      <Tag
-                        color={getHistoryTagColor(item.status)}
-                        style={{ marginInlineEnd: 0, fontSize: 10, lineHeight: '16px' }}
-                      >
-                        {item.status}
-                      </Tag>
-                    </Flex>
-                    <Text type="secondary" style={{ fontSize: 11, lineHeight: 1.2 }}>
-                      {formatTime(item.startedAt)} · {formatDuration(item.durationMs)}
-                    </Text>
+        <>
+          <Divider style={{ margin: '4px 0' }} />
+          <Flex vertical gap={6}>
+            <Text strong style={{ fontSize: 12, lineHeight: 1.2 }}>
+              Recent recordings
+            </Text>
+            {recentRecordings.length ? (
+              recentRecordings.map(item => (
+                <Flex
+                  key={item.localId}
+                  vertical
+                  gap={3}
+                  style={{ borderTop: '1px solid #f0f0f0', paddingTop: 5 }}
+                >
+                  <Flex align="center" justify="space-between" gap={6}>
                     <Text
-                      type={item.status === 'failed' || item.status === 'auth_required' ? 'danger' : 'secondary'}
-                      style={{ fontSize: 11, lineHeight: 1.2 }}
+                      title={item.title}
+                      style={{
+                        fontSize: 12,
+                        lineHeight: 1.2,
+                        maxWidth: 132,
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap'
+                      }}
                     >
-                      {getHistoryStatusText(item, now)}
+                      {item.title}
                     </Text>
+                    <Tag
+                      color={getHistoryTagColor(item.status)}
+                      style={{ marginInlineEnd: 0, fontSize: 10, lineHeight: '16px' }}
+                    >
+                      {item.status}
+                    </Tag>
                   </Flex>
-                ))
-              ) : (
-                <Text type="secondary" style={{ fontSize: 11, lineHeight: 1.2 }}>
-                  {recentRecordingsEmptyText}
-                </Text>
-              )}
-            </Flex>
-          </>
-        ) : null}
+                  <Text type="secondary" style={{ fontSize: 11, lineHeight: 1.2 }}>
+                    {formatTime(item.startedAt)} · {formatDuration(item.durationMs)}
+                  </Text>
+                  <Text
+                    type={item.status === 'failed' || item.status === 'auth_required' ? 'danger' : 'secondary'}
+                    style={{ fontSize: 11, lineHeight: 1.2 }}
+                  >
+                    {getHistoryStatusText(item, now)}
+                  </Text>
+                </Flex>
+              ))
+            ) : (
+              <Text type="secondary" style={{ fontSize: 11, lineHeight: 1.2 }}>
+                {recentRecordingsEmptyText}
+              </Text>
+            )}
+          </Flex>
+        </>
       </Flex>
     </ConfigProvider>
   )

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -25,6 +25,7 @@ import {
 } from './extensionAuth'
 import { getMicPreferences, MIC_DEVICE_ID_KEY, MIC_LABEL_KEY } from './micPreferences'
 import {
+  normalizeRecordingHistory,
   POPUP_RECORDING_HISTORY_LIMIT,
   type RecordingHistoryItem,
   type RecordingUploadStatus
@@ -114,52 +115,8 @@ function getRecordingButtonText(recordingState: RecordingStatus): string {
   return recordingState.recording ? 'Stop & Upload' : 'Start Recording'
 }
 
-function isRecordingUploadStatus(value: unknown): value is RecordingUploadStatus {
-  return value === 'queued' ||
-    value === 'uploading' ||
-    value === 'retrying' ||
-    value === 'uploaded' ||
-    value === 'auth_required' ||
-    value === 'failed'
-}
-
-function sanitizeRecordingHistoryItem(value: unknown): RecordingHistoryItem | null {
-  if (!value || typeof value !== 'object') return null
-  const record = value as Record<string, unknown>
-  if (typeof record.localId !== 'string' || !record.localId) return null
-  if (!isRecordingUploadStatus(record.status)) return null
-
-  const now = new Date().toISOString()
-  return {
-    localId: record.localId,
-    status: record.status,
-    title: typeof record.title === 'string' && record.title ? record.title : 'Browser recording',
-    meetingId: typeof record.meetingId === 'string' ? record.meetingId : undefined,
-    meetingTitle: typeof record.meetingTitle === 'string' ? record.meetingTitle : undefined,
-    tabUrl: typeof record.tabUrl === 'string' ? record.tabUrl : undefined,
-    startedAt: typeof record.startedAt === 'string' ? record.startedAt : now,
-    stoppedAt: typeof record.stoppedAt === 'string' ? record.stoppedAt : now,
-    durationMs: typeof record.durationMs === 'number' ? record.durationMs : 0,
-    videoBytes: typeof record.videoBytes === 'number' ? record.videoBytes : 0,
-    microphoneBytes: typeof record.microphoneBytes === 'number' ? record.microphoneBytes : 0,
-    attempt: typeof record.attempt === 'number' ? record.attempt : 0,
-    nextRetryAt: typeof record.nextRetryAt === 'number' ? record.nextRetryAt : null,
-    backendRecordingId: typeof record.backendRecordingId === 'string' ? record.backendRecordingId : null,
-    assets: Array.isArray(record.assets)
-      ? record.assets.filter((asset): asset is 'video_audio' | 'microphone' => asset === 'video_audio' || asset === 'microphone')
-      : [],
-    error: typeof record.error === 'string' ? record.error : null,
-    createdAt: typeof record.createdAt === 'string' ? record.createdAt : now,
-    updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : now
-  }
-}
-
 function sanitizeRecordingHistory(value: unknown): RecordingHistoryItem[] {
-  if (!Array.isArray(value)) return []
-  return value
-    .map(sanitizeRecordingHistoryItem)
-    .filter((item): item is RecordingHistoryItem => !!item)
-    .slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+  return normalizeRecordingHistory(value).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
 }
 
 function formatTime(value: string): string {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -9,7 +9,7 @@ import {
   SettingOutlined,
   VideoCameraOutlined
 } from '@ant-design/icons'
-import { Alert, Button, ConfigProvider, Divider, Flex, Space, Typography, theme } from 'antd'
+import { Alert, Button, ConfigProvider, Divider, Flex, Space, Tag, Typography, theme } from 'antd'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createRoot } from 'react-dom/client'
 import { captureException, initDiagnostics } from './diagnostics'
@@ -24,22 +24,19 @@ import {
   type Meet2NoteConnection
 } from './extensionAuth'
 import { getMicPreferences, MIC_DEVICE_ID_KEY, MIC_LABEL_KEY } from './micPreferences'
+import {
+  POPUP_RECORDING_HISTORY_LIMIT,
+  type RecordingHistoryItem,
+  type RecordingUploadStatus
+} from './recordingHistory'
 
 initDiagnostics('popup')
-
-type UploadStatus = 'idle' | 'uploading' | 'upload_retrying' | 'uploaded' | 'auth_required'
 
 interface RecordingStatus {
   recording: boolean
   starting: boolean
   stopping: boolean
   recordingStartedAt: number | null
-}
-
-interface UploadState {
-  status: UploadStatus
-  error: string | null
-  nextRetryAt: number | null
 }
 
 const { Text } = Typography
@@ -55,14 +52,6 @@ function formatDuration(ms: number): string {
   const ss = String(seconds).padStart(2, '0')
   if (!hours) return `${mm}:${ss}`
   return `${hours}:${mm}:${ss}`
-}
-
-function isUploadStatus(value: unknown): value is UploadStatus {
-  return value === 'idle' ||
-    value === 'uploading' ||
-    value === 'upload_retrying' ||
-    value === 'uploaded' ||
-    value === 'auth_required'
 }
 
 async function openMicSetupTab(): Promise<void> {
@@ -109,19 +98,7 @@ async function readMicButtonLabel(): Promise<{ label: string; title: string }> {
   }
 }
 
-function getRecordingText(recordingState: RecordingStatus, uploadState: UploadState, now: number): string {
-  if (uploadState.status === 'uploaded') return 'Uploaded'
-  if (uploadState.status === 'uploading') return 'Uploading...'
-  if (uploadState.status === 'auth_required') return 'Connect to Meet2Note to upload.'
-  if (uploadState.status === 'upload_retrying') {
-    const waitMs = typeof uploadState.nextRetryAt === 'number'
-      ? Math.max(0, uploadState.nextRetryAt - now)
-      : 0
-    const waitSeconds = Math.ceil(waitMs / 1000)
-    return uploadState.error
-      ? `Upload failed. Retrying in ${waitSeconds}s.`
-      : `Retrying upload in ${waitSeconds}s.`
-  }
+function getRecordingText(recordingState: RecordingStatus, now: number): string {
   if (recordingState.starting) return 'Starting recording...'
   if (recordingState.stopping) return 'Stopping recording...'
   if (recordingState.recording) {
@@ -131,13 +108,86 @@ function getRecordingText(recordingState: RecordingStatus, uploadState: UploadSt
   return 'Not recording'
 }
 
-function getRecordingButtonText(recordingState: RecordingStatus, uploadState: UploadState): string {
-  if (uploadState.status === 'uploading') return 'Uploading...'
-  if (uploadState.status === 'auth_required') return recordingState.recording ? 'Stop & Upload' : 'Start Recording'
-  if (uploadState.status === 'upload_retrying') return 'Retrying Upload...'
+function getRecordingButtonText(recordingState: RecordingStatus): string {
   if (recordingState.starting) return 'Starting...'
   if (recordingState.stopping) return 'Stopping...'
   return recordingState.recording ? 'Stop & Upload' : 'Start Recording'
+}
+
+function isRecordingUploadStatus(value: unknown): value is RecordingUploadStatus {
+  return value === 'queued' ||
+    value === 'uploading' ||
+    value === 'retrying' ||
+    value === 'uploaded' ||
+    value === 'auth_required' ||
+    value === 'failed'
+}
+
+function sanitizeRecordingHistoryItem(value: unknown): RecordingHistoryItem | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  if (typeof record.localId !== 'string' || !record.localId) return null
+  if (!isRecordingUploadStatus(record.status)) return null
+
+  const now = new Date().toISOString()
+  return {
+    localId: record.localId,
+    status: record.status,
+    title: typeof record.title === 'string' && record.title ? record.title : 'Browser recording',
+    meetingId: typeof record.meetingId === 'string' ? record.meetingId : undefined,
+    meetingTitle: typeof record.meetingTitle === 'string' ? record.meetingTitle : undefined,
+    tabUrl: typeof record.tabUrl === 'string' ? record.tabUrl : undefined,
+    startedAt: typeof record.startedAt === 'string' ? record.startedAt : now,
+    stoppedAt: typeof record.stoppedAt === 'string' ? record.stoppedAt : now,
+    durationMs: typeof record.durationMs === 'number' ? record.durationMs : 0,
+    videoBytes: typeof record.videoBytes === 'number' ? record.videoBytes : 0,
+    microphoneBytes: typeof record.microphoneBytes === 'number' ? record.microphoneBytes : 0,
+    attempt: typeof record.attempt === 'number' ? record.attempt : 0,
+    nextRetryAt: typeof record.nextRetryAt === 'number' ? record.nextRetryAt : null,
+    backendRecordingId: typeof record.backendRecordingId === 'string' ? record.backendRecordingId : null,
+    assets: Array.isArray(record.assets)
+      ? record.assets.filter((asset): asset is 'video_audio' | 'microphone' => asset === 'video_audio' || asset === 'microphone')
+      : [],
+    error: typeof record.error === 'string' ? record.error : null,
+    createdAt: typeof record.createdAt === 'string' ? record.createdAt : now,
+    updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : now
+  }
+}
+
+function sanitizeRecordingHistory(value: unknown): RecordingHistoryItem[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map(sanitizeRecordingHistoryItem)
+    .filter((item): item is RecordingHistoryItem => !!item)
+    .slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+}
+
+function formatTime(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+function getHistoryStatusText(item: RecordingHistoryItem, now: number): string {
+  if (item.status === 'queued') return 'Waiting to upload'
+  if (item.status === 'uploading') return item.attempt > 1 ? `Uploading, attempt ${item.attempt}` : 'Uploading...'
+  if (item.status === 'retrying') {
+    const waitMs = typeof item.nextRetryAt === 'number'
+      ? Math.max(0, item.nextRetryAt - now)
+      : 0
+    return `Retrying in ${Math.ceil(waitMs / 1000)}s`
+  }
+  if (item.status === 'uploaded') return item.backendRecordingId ? `Uploaded: ${item.backendRecordingId}` : 'Uploaded'
+  if (item.status === 'auth_required') return 'Reconnect to upload'
+  return item.error || 'Upload failed'
+}
+
+function getHistoryTagColor(status: RecordingUploadStatus): string {
+  if (status === 'uploaded') return 'success'
+  if (status === 'failed' || status === 'auth_required') return 'error'
+  if (status === 'retrying') return 'warning'
+  if (status === 'uploading') return 'processing'
+  return 'default'
 }
 
 function App(): React.ReactElement {
@@ -147,11 +197,7 @@ function App(): React.ReactElement {
     stopping: false,
     recordingStartedAt: null
   })
-  const [uploadState, setUploadState] = useState<UploadState>({
-    status: 'idle',
-    error: null,
-    nextRetryAt: null
-  })
+  const [recentRecordings, setRecentRecordings] = useState<RecordingHistoryItem[]>([])
   const [micStatus, setMicStatus] = useState('')
   const [micButton, setMicButton] = useState({
     label: 'Microphone Settings',
@@ -170,12 +216,12 @@ function App(): React.ReactElement {
   const inFlightRef = useRef(false)
 
   useEffect(() => {
-    if (!recordingState.recording && uploadState.status !== 'upload_retrying') return undefined
+    if (!recordingState.recording && !recentRecordings.some(item => item.status === 'retrying')) return undefined
 
     setNow(Date.now())
     const timerId = window.setInterval(() => setNow(Date.now()), 1000)
     return () => window.clearInterval(timerId)
-  }, [recordingState.recording, uploadState.status])
+  }, [recordingState.recording, recentRecordings])
 
   const refreshMic = useCallback(async () => {
     const [button, status] = await Promise.all([
@@ -202,11 +248,7 @@ function App(): React.ReactElement {
           stopping: !!status?.stopping,
           recordingStartedAt: typeof startedAt === 'number' ? startedAt : null
         })
-        setUploadState({
-          status: isUploadStatus(status?.uploadStatus) ? status.uploadStatus : 'idle',
-          error: typeof status?.uploadError === 'string' ? status.uploadError : null,
-          nextRetryAt: typeof status?.uploadNextRetryAt === 'number' ? status.uploadNextRetryAt : null
-        })
+        setRecentRecordings(sanitizeRecordingHistory(status?.recentRecordings))
       } catch {
         setRecordingState({
           recording: false,
@@ -260,12 +302,8 @@ function App(): React.ReactElement {
         })
       }
 
-      if (msg?.type === 'UPLOAD_STATE' && isUploadStatus(msg.status)) {
-        setUploadState({
-          status: msg.status,
-          error: typeof msg.error === 'string' ? msg.error : null,
-          nextRetryAt: typeof msg.nextRetryAt === 'number' ? msg.nextRetryAt : null
-        })
+      if (msg?.type === 'UPLOAD_QUEUE_STATE') {
+        setRecentRecordings(sanitizeRecordingHistory(msg.items))
       }
     }
 
@@ -296,23 +334,26 @@ function App(): React.ReactElement {
   }, [refreshMic, refreshMeet2NoteConnection])
 
   const recordingText = useMemo(
-    () => getRecordingText(recordingState, uploadState, now),
-    [recordingState, uploadState, now]
+    () => getRecordingText(recordingState, now),
+    [recordingState, now]
   )
-  const recordingButtonText = getRecordingButtonText(recordingState, uploadState)
+  const recordingButtonText = getRecordingButtonText(recordingState)
   const recordingControlsAvailable = meet2NoteConnection.connected
-  const uploadBlocksAction = uploadState.status === 'uploading' || uploadState.status === 'upload_retrying'
   const connectionActionDisabled = recordingState.recording ||
     recordingState.starting ||
-    recordingState.stopping ||
-    uploadBlocksAction
+    recordingState.stopping
   const actionDisabled = !recordingControlsAvailable ||
     inFlight ||
     recordingState.starting ||
-    recordingState.stopping ||
-    uploadBlocksAction
+    recordingState.stopping
+  const authRequiredUpload = recentRecordings.find(item => item.status === 'auth_required')
   const connectionErrorMessage = meet2NoteConnection.authError ||
-    (uploadState.status === 'auth_required' ? uploadState.error : null)
+    authRequiredUpload?.error ||
+    null
+  const showRecentRecordings = recordingControlsAvailable || recentRecordings.length > 0
+  const recentRecordingsEmptyText = recordingControlsAvailable
+    ? 'No recordings from this browser yet'
+    : 'Connect to Meet2Note to upload recordings'
 
   const openSettings = useCallback(async () => {
     try {
@@ -477,7 +518,7 @@ function App(): React.ReactElement {
     }
   }, [recordingState.recording, startRecording, stopRecording])
 
-  const actionIcon = uploadBlocksAction || recordingState.starting || recordingState.stopping || inFlight
+  const actionIcon = recordingState.starting || recordingState.stopping || inFlight
     ? <LoadingOutlined />
     : recordingState.recording
       ? <CloudUploadOutlined />
@@ -577,17 +618,64 @@ function App(): React.ReactElement {
               {recordingButtonText}
             </Button>
             <Space size={6} align="start">
-              {uploadState.status === 'uploaded' ? <CheckCircleOutlined style={{ color: '#389e0d' }} /> : null}
+              {recentRecordings.some(item => item.status === 'uploaded') ? <CheckCircleOutlined style={{ color: '#389e0d' }} /> : null}
               <Text style={{ fontSize: 12, lineHeight: 1.25 }}>{recordingText}</Text>
             </Space>
-            {(uploadState.status === 'upload_retrying' || uploadState.status === 'auth_required') && uploadState.error ? (
-              <Alert
-                type={uploadState.status === 'auth_required' ? 'error' : 'warning'}
-                showIcon={false}
-                message={uploadState.error}
-                style={{ fontSize: 12, padding: '4px 8px' }}
-              />
-            ) : null}
+          </>
+        ) : null}
+        {showRecentRecordings ? (
+          <>
+            <Divider style={{ margin: '4px 0' }} />
+            <Flex vertical gap={6}>
+              <Text strong style={{ fontSize: 12, lineHeight: 1.2 }}>
+                Recent recordings
+              </Text>
+              {recentRecordings.length ? (
+                recentRecordings.map(item => (
+                  <Flex
+                    key={item.localId}
+                    vertical
+                    gap={3}
+                    style={{ borderTop: '1px solid #f0f0f0', paddingTop: 5 }}
+                  >
+                    <Flex align="center" justify="space-between" gap={6}>
+                      <Text
+                        title={item.title}
+                        style={{
+                          fontSize: 12,
+                          lineHeight: 1.2,
+                          maxWidth: 132,
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap'
+                        }}
+                      >
+                        {item.title}
+                      </Text>
+                      <Tag
+                        color={getHistoryTagColor(item.status)}
+                        style={{ marginInlineEnd: 0, fontSize: 10, lineHeight: '16px' }}
+                      >
+                        {item.status}
+                      </Tag>
+                    </Flex>
+                    <Text type="secondary" style={{ fontSize: 11, lineHeight: 1.2 }}>
+                      {formatTime(item.startedAt)} · {formatDuration(item.durationMs)}
+                    </Text>
+                    <Text
+                      type={item.status === 'failed' || item.status === 'auth_required' ? 'danger' : 'secondary'}
+                      style={{ fontSize: 11, lineHeight: 1.2 }}
+                    >
+                      {getHistoryStatusText(item, now)}
+                    </Text>
+                  </Flex>
+                ))
+              ) : (
+                <Text type="secondary" style={{ fontSize: 11, lineHeight: 1.2 }}>
+                  {recentRecordingsEmptyText}
+                </Text>
+              )}
+            </Flex>
           </>
         ) : null}
       </Flex>

--- a/src/recordingHistory.ts
+++ b/src/recordingHistory.ts
@@ -29,13 +29,11 @@ export interface RecordingHistoryItem {
   updatedAt: string
 }
 
-interface StoredRecordingHistory {
-  meet2noteRecordingHistory?: unknown
-}
-
 export const RECORDING_HISTORY_KEY = 'meet2noteRecordingHistory'
 export const RECORDING_HISTORY_LIMIT = 10
 export const POPUP_RECORDING_HISTORY_LIMIT = 5
+
+type StoredRecordingHistory = Partial<Record<typeof RECORDING_HISTORY_KEY, unknown>>
 
 const NON_TERMINAL_STATUSES = new Set<RecordingUploadStatus>([
   'queued',
@@ -173,7 +171,7 @@ export function trimRecordingHistory(items: RecordingHistoryItem[]): RecordingHi
 
 export async function readRecordingHistory(): Promise<RecordingHistoryItem[]> {
   const items = await storageGet<StoredRecordingHistory>([RECORDING_HISTORY_KEY])
-  return normalizeRecordingHistory(items.meet2noteRecordingHistory)
+  return normalizeRecordingHistory(items[RECORDING_HISTORY_KEY])
 }
 
 export async function writeRecordingHistory(items: RecordingHistoryItem[]): Promise<RecordingHistoryItem[]> {

--- a/src/recordingHistory.ts
+++ b/src/recordingHistory.ts
@@ -1,0 +1,213 @@
+export type RecordingUploadStatus =
+  | 'queued'
+  | 'uploading'
+  | 'retrying'
+  | 'uploaded'
+  | 'auth_required'
+  | 'failed'
+
+export type RecordingUploadAsset = 'video_audio' | 'microphone'
+
+export interface RecordingHistoryItem {
+  localId: string
+  status: RecordingUploadStatus
+  title: string
+  meetingId?: string
+  meetingTitle?: string
+  tabUrl?: string
+  startedAt: string
+  stoppedAt: string
+  durationMs: number
+  videoBytes: number
+  microphoneBytes: number
+  attempt: number
+  nextRetryAt: number | null
+  backendRecordingId: string | null
+  assets: RecordingUploadAsset[]
+  error: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+interface StoredRecordingHistory {
+  meet2noteRecordingHistory?: unknown
+}
+
+export const RECORDING_HISTORY_KEY = 'meet2noteRecordingHistory'
+export const RECORDING_HISTORY_LIMIT = 10
+export const POPUP_RECORDING_HISTORY_LIMIT = 5
+
+const NON_TERMINAL_STATUSES = new Set<RecordingUploadStatus>([
+  'queued',
+  'uploading',
+  'retrying',
+  'auth_required'
+])
+
+export function isTerminalRecordingStatus(status: RecordingUploadStatus): boolean {
+  return status === 'uploaded' || status === 'failed'
+}
+
+export function generateRecordingLocalId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `rec_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`
+}
+
+function storageGet<T>(keys: string[]): Promise<T> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get(keys, (items) => {
+      const runtimeError = chrome.runtime.lastError
+      if (runtimeError) return reject(new Error(runtimeError.message))
+      resolve(items as T)
+    })
+  })
+}
+
+function storageSet(items: Record<string, unknown>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.set(items, () => {
+      const runtimeError = chrome.runtime.lastError
+      if (runtimeError) return reject(new Error(runtimeError.message))
+      resolve()
+    })
+  })
+}
+
+function isRecordingUploadStatus(value: unknown): value is RecordingUploadStatus {
+  return value === 'queued' ||
+    value === 'uploading' ||
+    value === 'retrying' ||
+    value === 'uploaded' ||
+    value === 'auth_required' ||
+    value === 'failed'
+}
+
+function sanitizeAssets(value: unknown): RecordingUploadAsset[] {
+  if (!Array.isArray(value)) return []
+  const assets: RecordingUploadAsset[] = []
+  for (const asset of value) {
+    if (asset === 'video_audio' || asset === 'microphone') assets.push(asset)
+  }
+  return assets
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0
+}
+
+function nullableNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function sanitizeHistoryItem(value: unknown): RecordingHistoryItem | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  const localId = optionalString(record.localId)
+  const status = record.status
+  if (!localId || !isRecordingUploadStatus(status)) return null
+
+  const now = new Date().toISOString()
+  const title = optionalString(record.title) || 'Browser recording'
+  const startedAt = optionalString(record.startedAt) || now
+  const stoppedAt = optionalString(record.stoppedAt) || startedAt
+  const createdAt = optionalString(record.createdAt) || startedAt
+  const updatedAt = optionalString(record.updatedAt) || createdAt
+
+  return {
+    localId,
+    status,
+    title,
+    meetingId: optionalString(record.meetingId),
+    meetingTitle: optionalString(record.meetingTitle),
+    tabUrl: optionalString(record.tabUrl),
+    startedAt,
+    stoppedAt,
+    durationMs: numberOrZero(record.durationMs),
+    videoBytes: numberOrZero(record.videoBytes),
+    microphoneBytes: numberOrZero(record.microphoneBytes),
+    attempt: Math.max(0, Math.floor(numberOrZero(record.attempt))),
+    nextRetryAt: nullableNumber(record.nextRetryAt),
+    backendRecordingId: nullableString(record.backendRecordingId),
+    assets: sanitizeAssets(record.assets),
+    error: nullableString(record.error),
+    createdAt,
+    updatedAt
+  }
+}
+
+export function normalizeRecordingHistory(value: unknown): RecordingHistoryItem[] {
+  if (!Array.isArray(value)) return []
+  const unique = new Map<string, RecordingHistoryItem>()
+  for (const item of value) {
+    const sanitized = sanitizeHistoryItem(item)
+    if (sanitized) unique.set(sanitized.localId, sanitized)
+  }
+  return trimRecordingHistory(Array.from(unique.values()))
+}
+
+export function trimRecordingHistory(items: RecordingHistoryItem[]): RecordingHistoryItem[] {
+  const sorted = [...items].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+  const kept: RecordingHistoryItem[] = []
+  let terminalCount = 0
+
+  for (const item of sorted) {
+    if (isTerminalRecordingStatus(item.status)) {
+      terminalCount += 1
+      if (terminalCount > RECORDING_HISTORY_LIMIT) continue
+    }
+    kept.push(item)
+  }
+
+  return kept
+}
+
+export async function readRecordingHistory(): Promise<RecordingHistoryItem[]> {
+  const items = await storageGet<StoredRecordingHistory>([RECORDING_HISTORY_KEY])
+  return normalizeRecordingHistory(items.meet2noteRecordingHistory)
+}
+
+export async function writeRecordingHistory(items: RecordingHistoryItem[]): Promise<RecordingHistoryItem[]> {
+  const normalized = normalizeRecordingHistory(items)
+  await storageSet({ [RECORDING_HISTORY_KEY]: normalized })
+  return normalized
+}
+
+export async function upsertRecordingHistoryItem(item: RecordingHistoryItem): Promise<RecordingHistoryItem[]> {
+  const history = await readRecordingHistory()
+  const index = history.findIndex(existing => existing.localId === item.localId)
+  const next = [...history]
+  if (index >= 0) {
+    next[index] = item
+  } else {
+    next.unshift(item)
+  }
+  return writeRecordingHistory(next)
+}
+
+export async function markIncompleteRecordingsFailed(message: string): Promise<RecordingHistoryItem[]> {
+  const history = await readRecordingHistory()
+  const now = new Date().toISOString()
+  let changed = false
+  const next = history.map((item) => {
+    if (!NON_TERMINAL_STATUSES.has(item.status)) return item
+    changed = true
+    return {
+      ...item,
+      status: 'failed' as const,
+      error: message,
+      nextRetryAt: null,
+      updatedAt: now
+    }
+  })
+  return changed ? writeRecordingHistory(next) : history
+}

--- a/src/recordingHistory.ts
+++ b/src/recordingHistory.ts
@@ -35,6 +35,8 @@ export const POPUP_RECORDING_HISTORY_LIMIT = 5
 
 type StoredRecordingHistory = Partial<Record<typeof RECORDING_HISTORY_KEY, unknown>>
 
+let recordingHistoryWriteQueue: Promise<unknown> = Promise.resolve()
+
 const NON_TERMINAL_STATUSES = new Set<RecordingUploadStatus>([
   'queued',
   'uploading',
@@ -169,43 +171,68 @@ export function trimRecordingHistory(items: RecordingHistoryItem[]): RecordingHi
   return kept
 }
 
+function enqueueRecordingHistoryWrite<T>(operation: () => Promise<T>): Promise<T> {
+  const run = recordingHistoryWriteQueue.catch(() => undefined).then(operation)
+  recordingHistoryWriteQueue = run.then(
+    () => undefined,
+    () => undefined
+  )
+  return run
+}
+
+async function writeRecordingHistoryInternal(items: RecordingHistoryItem[]): Promise<RecordingHistoryItem[]> {
+  const normalized = normalizeRecordingHistory(items)
+  await storageSet({ [RECORDING_HISTORY_KEY]: normalized })
+  return normalized
+}
+
 export async function readRecordingHistory(): Promise<RecordingHistoryItem[]> {
   const items = await storageGet<StoredRecordingHistory>([RECORDING_HISTORY_KEY])
   return normalizeRecordingHistory(items[RECORDING_HISTORY_KEY])
 }
 
 export async function writeRecordingHistory(items: RecordingHistoryItem[]): Promise<RecordingHistoryItem[]> {
-  const normalized = normalizeRecordingHistory(items)
-  await storageSet({ [RECORDING_HISTORY_KEY]: normalized })
-  return normalized
+  return enqueueRecordingHistoryWrite(() => writeRecordingHistoryInternal(items))
+}
+
+export async function updateRecordingHistory(
+  updater: (items: RecordingHistoryItem[]) => RecordingHistoryItem[] | Promise<RecordingHistoryItem[]>
+): Promise<RecordingHistoryItem[]> {
+  return enqueueRecordingHistoryWrite(async () => {
+    const history = await readRecordingHistory()
+    const next = await updater(history)
+    return writeRecordingHistoryInternal(next)
+  })
 }
 
 export async function upsertRecordingHistoryItem(item: RecordingHistoryItem): Promise<RecordingHistoryItem[]> {
-  const history = await readRecordingHistory()
-  const index = history.findIndex(existing => existing.localId === item.localId)
-  const next = [...history]
-  if (index >= 0) {
-    next[index] = item
-  } else {
-    next.unshift(item)
-  }
-  return writeRecordingHistory(next)
+  return updateRecordingHistory((history) => {
+    const index = history.findIndex(existing => existing.localId === item.localId)
+    const next = [...history]
+    if (index >= 0) {
+      next[index] = item
+    } else {
+      next.unshift(item)
+    }
+    return next
+  })
 }
 
 export async function markIncompleteRecordingsFailed(message: string): Promise<RecordingHistoryItem[]> {
-  const history = await readRecordingHistory()
-  const now = new Date().toISOString()
-  let changed = false
-  const next = history.map((item) => {
-    if (!NON_TERMINAL_STATUSES.has(item.status)) return item
-    changed = true
-    return {
-      ...item,
-      status: 'failed' as const,
-      error: message,
-      nextRetryAt: null,
-      updatedAt: now
-    }
+  return updateRecordingHistory((history) => {
+    const now = new Date().toISOString()
+    let changed = false
+    const next = history.map((item) => {
+      if (!NON_TERMINAL_STATUSES.has(item.status)) return item
+      changed = true
+      return {
+        ...item,
+        status: 'failed' as const,
+        error: message,
+        nextRetryAt: null,
+        updatedAt: now
+      }
+    })
+    return changed ? next : history
   })
-  return changed ? writeRecordingHistory(next) : history
 }

--- a/src/recordingHistory.ts
+++ b/src/recordingHistory.ts
@@ -1,3 +1,5 @@
+import type { UploadAsset } from './uploadClient'
+
 export type RecordingUploadStatus =
   | 'queued'
   | 'uploading'
@@ -6,7 +8,7 @@ export type RecordingUploadStatus =
   | 'auth_required'
   | 'failed'
 
-export type RecordingUploadAsset = 'video_audio' | 'microphone'
+export type RecordingUploadAsset = UploadAsset
 
 export interface RecordingHistoryItem {
   localId: string


### PR DESCRIPTION
## Zakres

- Zastepuje pojedynczy globalny stan uploadu sekwencyjna kolejka pozycji w offscreen.
- Dodaje trwala lokalna historie ostatnich uploadow w `chrome.storage.local` i sekcje `Recent recordings` w popupie.
- Odblokowuje start kolejnego nagrania, gdy poprzedni upload nadal trwa albo czeka na retry.
- Aktualizuje dokumentacje, smoke test i wersje manifestu do `1.8.0`.

## Weryfikacja

- `npm run typecheck`
- `make check`
- `scripts/smoke-test.sh`

## Ryzyka

- Reczny smoke test w Chrome/Meet nie zostal wykonany w tej rundzie.
- Popup pokazuje lokalna historie uploadow z tego profilu przegladarki; pelna lista z panelu Meet2Note wymaga backendowego kontraktu po `extensionToken`, opisanego w `recording-backend#22`.

## Uprawnienia Chrome

Bez zmian w `permissions` i `host_permissions`.