### PR TITLE
Fix popup recording history sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Jeśli wolisz wariant z botem albo aplikacją desktopową do nagrywania, zobacz 
 
 **Kolejka i retry uploadu** - zakończone nagrania trafiają do lokalnej kolejki, a pojedynczy upload w retry nie blokuje kolejnego nagrania.
 
+**Ostatnie nagrania** - popup scala lokalne statusy kolejki z listą nagrań pobraną z Meet2Note.
+
 **Architektura MV3/Offscreen** - nagrywanie działa w ukrytym dokumencie offscreen.
 
 ## Jak to działa
@@ -88,6 +90,7 @@ Otwórz Google Meet i kliknij ikonę rozszerzenia:
 1. **Connect to Meet2Note** - otwiera backendowy flow połączenia z kontem użytkownika.
 2. **Enable Microphone / Microphone Settings** - otwiera konfigurację mikrofonu i pozwala wybrać urządzenie wejściowe.
 3. **Start Recording / Stop & Upload** - nagrywa kartę i wysyła wynik do `https://meet2note.com`.
+4. **Recent recordings** - pokazuje lokalne uploady oraz ostatnie nagrania widoczne w Meet2Note.
 
 ## Instalacja i budowanie
 
@@ -161,6 +164,7 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
 │  ├─ offscreen.ts      # uruchamia nagrywarkę i wysyła assety do backendu
 │  ├─ popup.tsx         # UI popupu w React + Ant Design: mikrofon, start/stop
 │  ├─ micPreferences.ts # wspólne helpery zapisu wyboru mikrofonu
+│  ├─ recordingsClient.ts # klient listy nagrań Meet2Note
 │  ├─ uploadClient.ts   # klient kontraktu uploadu backendu
 │  └─ micsetup.tsx      # strona React + Ant Design do nadania uprawnienia i wyboru mikrofonu
 └─ dist/                # wygenerowany wynik builda

--- a/docs/specs/004-kolejka-uploadu-i-historia-nagran.md
+++ b/docs/specs/004-kolejka-uploadu-i-historia-nagran.md
@@ -32,7 +32,7 @@ Użytkownik powinien widzieć oddzielnie:
    d) Ręczny eksport lokalnego pliku `.webm`.
    e) Ręczne kasowanie pojedynczych pozycji historii z UI, o ile nie okaże się konieczne dla ergonomii.
    f) Migracja starszych, już utraconych uploadów zapisanych tylko jako globalny `uploadStatus`.
-   g) Pobieranie w popupie pełnej historii z panelu Meet2Note, dopóki backend nie udostępnia listy nagrań dla `extensionToken`.
+   g) Pełny ekran zarządzania nagraniami z panelu Meet2Note w popupie.
 
 ## Obecne zachowanie
 
@@ -180,9 +180,10 @@ interface UploadQueueEntry extends RecordingHistoryItem {
 2. `src/background.ts`:
    a) usuwa blokadę startu zależną od uploadu,
    b) nadal koordynuje aktywne nagrywanie, badge i offscreen,
-   c) hydratuje historię z `chrome.storage.local`,
+   c) hydratuje historię z `chrome.storage.local` i listy backendowej,
    d) przekazuje popupowi stan nagrywania i snapshot ostatnich nagrań,
-   e) po reconnect/token change prosi offscreen o wznowienie pozycji `auth_required`, jeśli ma bloby.
+   e) po reconnect/token change prosi offscreen o wznowienie pozycji `auth_required`, jeśli ma bloby,
+   f) wykonuje operacje `chrome.storage`, bo offscreen document nie ma pełnego dostępu do API Chrome.
 
 3. `src/popup.tsx`:
    a) przestaje używać pojedynczego `UploadState` jako źródła blokady startu,
@@ -218,14 +219,18 @@ interface UploadQueueSnapshotMessage {
    c) Dane pozycji: tytuł, status, czas/długość, `recordingId` po sukcesie albo błąd/retry.
    d) UI ma być gęsty i czytelny w obecnej szerokości popupu.
    e) Sekcja ma być widoczna także przy pustej lokalnej historii, żeby użytkownik widział, gdzie pojawią się statusy kolejki.
+   f) Jeśli konto jest połączone, lista scala lokalną kolejkę uploadu z ostatnimi nagraniami zwróconymi przez backendowe `GET /api/recordings`.
 
 3. Statusy użytkowe:
    a) `queued`: `Waiting to upload`.
    b) `uploading`: `Uploading...`.
    c) `retrying`: `Retrying in Ns`.
    d) `uploaded`: `Uploaded`.
-   e) `auth_required`: `Reconnect to upload`.
-   f) `failed`: krótki komunikat błędu.
+   e) `pending`: `Waiting for processing`.
+   f) `processing`: `Processing in Meet2Note`.
+   g) `ready`: `Ready in Meet2Note`.
+   h) `auth_required`: `Reconnect to upload`.
+   i) `failed`: krótki komunikat błędu.
 
 4. Reconnect:
    a) Jeśli istnieje pozycja `auth_required`, popup pokazuje błąd przy sekcji połączenia.
@@ -314,11 +319,9 @@ make check
 5. Wznowienie `auth_required` po reconnect wymaga koordynacji storage i offscreen.
    a) Mitigacja: po zmianie tokenu background wysyła do offscreen komunikat wznowienia kolejki.
 
-6. Popup nie może jeszcze pobrać tej samej listy, którą pokazuje panel `/recordings`.
-   a) Obecny endpoint `GET /api/recordings` jest oparty o sesję webowego panelu.
-   b) Wtyczka ma trwały `extensionToken`, więc backend powinien udostępnić listę ostatnich nagrań po `Authorization: Bearer <extensionToken>`.
-   c) Backendowe rozszerzenie kontraktu jest opisane w issue [recording-backend#22](https://github.com/pawel-walaszek/recording-backend/issues/22).
-   d) Do czasu zmiany backendu popup pokazuje lokalną historię uploadów z tego profilu przeglądarki.
+6. Popup pobiera tę samą listę, którą pokazuje panel `/recordings`, przez `GET /api/recordings` z `Authorization: Bearer <extensionToken>`.
+   a) Lokalna historia nadal jest potrzebna dla stanów kolejki przed zakończeniem uploadu.
+   b) Po sukcesie wpis lokalny jest scalany z backendowym `recordingId` i statusem przetwarzania.
 
 ## Otwarte Pytania
 

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -19,12 +19,13 @@ Docelowy backend dla uploadu i przetwarzania nagrań będzie rozwijany w powiąz
 | Komponent | Ścieżka | Rola |
 | --- | --- | --- |
 | Manifest | `manifest.json` | Deklaruje metadane MV3, uprawnienia, worker tła i dostępne zasoby. |
-| Popup | `popup.html`, `src/popup.tsx` | Interfejs React + Ant Design do otwierania ustawień mikrofonu, startu/stopu nagrywania oraz podglądu historii uploadów. |
+| Popup | `popup.html`, `src/popup.tsx` | Interfejs React + Ant Design do otwierania ustawień mikrofonu, startu/stopu nagrywania oraz podglądu historii uploadów i nagrań z Meet2Note. |
 | Callback Meet2Note | `connect-callback.html`, `src/connectCallback.ts` | Kończy flow połączenia z backendu, waliduje `state`, wymienia jednorazowy `code` na token i zapisuje go lokalnie. |
 | Watcher Google Meet | `src/meetWatcher.ts`, `manifest.json` | Content script na `meet.google.com`, który wykrywa aktywne spotkanie i opuszczenie spotkania. |
 | Service worker tła | `src/background.ts` | Koordynuje przechwytywanie karty, cykl życia dokumentu offscreen, stan nagrywania/uploadu i znaczniki. |
 | Nagrywarka offscreen | `offscreen.html`, `src/offscreen.ts` | Przechwytuje media z karty, nagrywa osobny asset mikrofonu, finalizuje bloby i wysyła je do backendu. |
 | Klient uploadu | `src/uploadClient.ts` | Wykonuje kontrakt uploadu backendu: `/init`, upload assetów, `/complete`. |
+| Klient nagrań | `src/recordingsClient.ts` | Pobiera listę nagrań z backendu przez `GET /api/recordings` z `extensionToken`. |
 | Historia nagrań | `src/recordingHistory.ts` | Definiuje model lokalnej historii uploadów i helpery `chrome.storage.local`. |
 | Strona konfiguracji mikrofonu | `micsetup.html`, `src/micsetup.tsx` | Widoczna strona React + Ant Design używana do nadania uprawnienia mikrofonu, wyboru urządzenia i zapisu konfiguracji w `chrome.storage.local`. |
 | Preferencje mikrofonu | `src/micPreferences.ts` | Wspólne klucze i helpery `chrome.storage.local` dla zapisanego wyboru mikrofonu. |
@@ -49,6 +50,7 @@ Ten opis dokumentuje aktualne ustalenia integracyjne między wtyczką i backende
 9. Zakończone nagrania trafiają do sekwencyjnej kolejki uploadu w offscreen; jeden aktywny upload nie blokuje startu kolejnego nagrania.
 10. Jeśli upload się nie powiedzie, offscreen ponawia pełny upload konkretnej pozycji co 15 sekund, bez lokalnego zapisu pliku.
 11. Jeśli backend zwróci `401` albo `403`, zwykły retry tej pozycji jest przerywany, token jest czyszczony i popup wymaga ponownego połączenia z Meet2Note.
+12. Popup scala lokalną historię kolejki z listą nagrań z backendu, jeśli konto jest połączone z Meet2Note.
 
 ## Granice uruchomieniowe
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/src/background.ts
+++ b/src/background.ts
@@ -32,7 +32,10 @@ let autoStopMeetTabId: number | null = null
 let recordingStartedAt: number | null = null
 const meetTabsInMeeting = new Set<number>()
 let recentRecordings: RecordingHistoryItem[] = []
+let backendRecordingsRefreshPromise: Promise<void> | null = null
+let backendRecordingsLastRefreshedAt = 0
 const RECORDER_CONTEXT_INTERRUPTED_MESSAGE = 'Upload was interrupted by an extension restart or refresh.'
+const BACKEND_RECORDINGS_REFRESH_THROTTLE_MS = 15_000
 
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
 const DEFAULT_OFFSCREEN_RESPONSE_TIMEOUT_MS = 15_000
@@ -185,6 +188,24 @@ function mergeRecordingHistory(
   }
 
   return normalizeRecordingHistory(Array.from(byLocalId.values()))
+}
+
+function scheduleBackendRecordingsRefresh(): void {
+  const now = Date.now()
+  if (backendRecordingsRefreshPromise) return
+  if (now - backendRecordingsLastRefreshedAt < BACKEND_RECORDINGS_REFRESH_THROTTLE_MS) return
+
+  backendRecordingsRefreshPromise = hydrateRecentRecordings()
+    .then(() => {
+      backendRecordingsLastRefreshedAt = Date.now()
+      broadcastUploadQueueState()
+    })
+    .catch((e: any) => {
+      captureException(e, { operation: 'scheduleBackendRecordingsRefresh' })
+    })
+    .finally(() => {
+      backendRecordingsRefreshPromise = null
+    })
 }
 
 function broadcastUploadQueueState(items = recentRecordings): void {
@@ -653,13 +674,9 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         broadcastUploadQueueState()
         sendResponse({ ok: true, items: recentRecordings })
 
-        void hydrateRecentRecordings()
-          .then(() => {
-            broadcastUploadQueueState()
-          })
-          .catch((e: any) => {
-            captureException(e, { operation: 'UPSERT_RECORDING_HISTORY_ITEM_REFRESH' })
-          })
+        if (item.status === 'uploaded' && item.backendRecordingId) {
+          scheduleBackendRecordingsRefresh()
+        }
       } catch (e: any) {
         captureException(e, { operation: 'UPSERT_RECORDING_HISTORY_ITEM' })
         sendResponse({ ok: false, error: e?.message || String(e) })

--- a/src/background.ts
+++ b/src/background.ts
@@ -181,7 +181,7 @@ function mergeRecordingHistory(
           ...existing,
           status: backendItem.status,
           title: mergedRecordingTitle(existing, backendItem),
-          durationMs: backendItem.durationMs || existing.durationMs,
+          durationMs: backendItem.durationMs > 0 ? backendItem.durationMs : existing.durationMs,
           backendRecordingId: backendId,
           error: backendItem.error,
           updatedAt: backendItem.updatedAt

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,15 +1,22 @@
 // src/background.ts
 
 import { captureException, initDiagnostics } from './diagnostics'
-import { getMeet2NoteExtensionToken } from './extensionAuth'
+import {
+  getMeet2NoteExtensionToken,
+  isMeet2NoteAuthError,
+  markMeet2NoteReconnectRequired,
+  MEET2NOTE_EXTENSION_TOKEN_KEY
+} from './extensionAuth'
 import { clearMicPreferences, getMicPreferences, type MicPreferences } from './micPreferences'
 import {
   markIncompleteRecordingsFailed,
   normalizeRecordingHistory,
   POPUP_RECORDING_HISTORY_LIMIT,
   readRecordingHistory,
+  upsertRecordingHistoryItem,
   type RecordingHistoryItem
 } from './recordingHistory'
+import { listMeet2NoteRecordings, type BackendRecordingListItem } from './recordingsClient'
 
 initDiagnostics('background')
 
@@ -99,10 +106,85 @@ function setRecordingStopping(stopping: boolean): void {
 
 async function hydrateRecentRecordings(): Promise<RecordingHistoryItem[]> {
   try {
-    recentRecordings = (await readRecordingHistory()).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+    const localHistory = await readRecordingHistory()
+    const backendHistory = await readBackendRecordingHistory()
+    recentRecordings = mergeRecordingHistory(localHistory, backendHistory).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
     return recentRecordings
   } catch {}
   return recentRecordings
+}
+
+function backendRecordingToHistoryItem(recording: BackendRecordingListItem): RecordingHistoryItem {
+  return {
+    localId: `backend:${recording.id}`,
+    status: recording.status,
+    title: recording.title,
+    startedAt: recording.createdAt,
+    stoppedAt: recording.updatedAt || recording.createdAt,
+    durationMs: recording.durationMs ?? 0,
+    videoBytes: 0,
+    microphoneBytes: 0,
+    attempt: 0,
+    nextRetryAt: null,
+    backendRecordingId: recording.id,
+    assets: [],
+    error: recording.status === 'failed' ? 'Processing failed in Meet2Note.' : null,
+    createdAt: recording.createdAt,
+    updatedAt: recording.updatedAt || recording.createdAt
+  }
+}
+
+async function readBackendRecordingHistory(): Promise<RecordingHistoryItem[]> {
+  const token = await getMeet2NoteExtensionToken().catch(() => null)
+  if (!token) return []
+
+  try {
+    const recordings = await listMeet2NoteRecordings(token)
+    return recordings.map(backendRecordingToHistoryItem)
+  } catch (e) {
+    if (isMeet2NoteAuthError(e)) {
+      await markMeet2NoteReconnectRequired(e.message).catch(() => {})
+    }
+    bglog('Backend recordings list failed', e)
+    captureException(e, { operation: 'readBackendRecordingHistory' })
+    return []
+  }
+}
+
+function mergeRecordingHistory(
+  localHistory: RecordingHistoryItem[],
+  backendHistory: RecordingHistoryItem[]
+): RecordingHistoryItem[] {
+  const byLocalId = new Map<string, RecordingHistoryItem>()
+  const byBackendId = new Map<string, string>()
+
+  for (const item of normalizeRecordingHistory(localHistory)) {
+    byLocalId.set(item.localId, item)
+    if (item.backendRecordingId) byBackendId.set(item.backendRecordingId, item.localId)
+  }
+
+  for (const backendItem of normalizeRecordingHistory(backendHistory)) {
+    const backendId = backendItem.backendRecordingId
+    const existingLocalId = backendId ? byBackendId.get(backendId) : undefined
+    if (existingLocalId) {
+      const existing = byLocalId.get(existingLocalId)
+      if (existing) {
+        byLocalId.set(existingLocalId, {
+          ...existing,
+          status: backendItem.status,
+          title: existing.title || backendItem.title,
+          durationMs: backendItem.durationMs || existing.durationMs,
+          backendRecordingId: backendId,
+          error: backendItem.error,
+          updatedAt: backendItem.updatedAt
+        })
+        continue
+      }
+    }
+    byLocalId.set(backendItem.localId, backendItem)
+  }
+
+  return normalizeRecordingHistory(Array.from(byLocalId.values()))
 }
 
 function broadcastUploadQueueState(items = recentRecordings): void {
@@ -557,6 +639,51 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       }
       return
     }
+
+    if (msg?.type === 'UPSERT_RECORDING_HISTORY_ITEM') {
+      const [item] = normalizeRecordingHistory([msg.item])
+      if (!item) {
+        sendResponse({ ok: false, error: 'Invalid recording history item' })
+        return
+      }
+
+      try {
+        const localHistory = await upsertRecordingHistoryItem(item)
+        const backendHistory = await readBackendRecordingHistory()
+        recentRecordings = mergeRecordingHistory(localHistory, backendHistory).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+        broadcastUploadQueueState()
+        sendResponse({ ok: true, items: recentRecordings })
+      } catch (e: any) {
+        captureException(e, { operation: 'UPSERT_RECORDING_HISTORY_ITEM' })
+        sendResponse({ ok: false, error: e?.message || String(e) })
+      }
+      return
+    }
+
+    if (msg?.type === 'READ_RECORDING_HISTORY') {
+      try {
+        await hydrateRecentRecordings()
+        sendResponse({ ok: true, items: recentRecordings })
+      } catch (e: any) {
+        captureException(e, { operation: 'READ_RECORDING_HISTORY' })
+        sendResponse({ ok: false, error: e?.message || String(e), items: recentRecordings })
+      }
+      return
+    }
+
+    if (msg?.type === 'MARK_MEET2NOTE_RECONNECT_REQUIRED') {
+      const message = typeof msg.message === 'string' && msg.message.trim()
+        ? msg.message
+        : 'Connect to Meet2Note before uploading.'
+      try {
+        await markMeet2NoteReconnectRequired(message)
+        sendResponse({ ok: true })
+      } catch (e: any) {
+        captureException(e, { operation: 'MARK_MEET2NOTE_RECONNECT_REQUIRED' })
+        sendResponse({ ok: false, error: e?.message || String(e) })
+      }
+      return
+    }
   })().catch((err) => {
     console.error('[background] top-level error', err)
     captureException(err, { operation: 'runtime.onMessage' })
@@ -564,6 +691,17 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   })
 
   return true
+})
+
+chrome.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName !== 'local') return
+  const tokenChange = changes[MEET2NOTE_EXTENSION_TOKEN_KEY]
+  if (!tokenChange || typeof tokenChange.newValue !== 'string' || !tokenChange.newValue.trim() || !offscreenPort) return
+
+  postToOffscreen({ type: 'OFFSCREEN_REQUEUE_AUTH_REQUIRED_UPLOADS' }).catch((e) => {
+    bglog('OFFSCREEN_REQUEUE_AUTH_REQUIRED_UPLOADS failed', e)
+    captureException(e, { operation: 'OFFSCREEN_REQUEUE_AUTH_REQUIRED_UPLOADS' })
+  })
 })
 
 chrome.runtime.onSuspend?.addListener(async () => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -649,10 +649,17 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
       try {
         const localHistory = await upsertRecordingHistoryItem(item)
-        const backendHistory = await readBackendRecordingHistory()
-        recentRecordings = mergeRecordingHistory(localHistory, backendHistory).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+        recentRecordings = localHistory.slice(0, POPUP_RECORDING_HISTORY_LIMIT)
         broadcastUploadQueueState()
         sendResponse({ ok: true, items: recentRecordings })
+
+        void hydrateRecentRecordings()
+          .then(() => {
+            broadcastUploadQueueState()
+          })
+          .catch((e: any) => {
+            captureException(e, { operation: 'UPSERT_RECORDING_HISTORY_ITEM_REFRESH' })
+          })
       } catch (e: any) {
         captureException(e, { operation: 'UPSERT_RECORDING_HISTORY_ITEM' })
         sendResponse({ ok: false, error: e?.message || String(e) })

--- a/src/background.ts
+++ b/src/background.ts
@@ -109,11 +109,16 @@ function setRecordingStopping(stopping: boolean): void {
 
 async function hydrateRecentRecordings(): Promise<RecordingHistoryItem[]> {
   try {
-    const localHistory = await readRecordingHistory()
-    const backendHistory = await readBackendRecordingHistory()
-    recentRecordings = mergeRecordingHistory(localHistory, backendHistory).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+    recentRecordings = (await readRecordingHistory()).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
     return recentRecordings
   } catch {}
+  return recentRecordings
+}
+
+async function refreshRecentRecordingsFromBackend(): Promise<RecordingHistoryItem[]> {
+  const localHistory = await readRecordingHistory()
+  const backendHistory = await readBackendRecordingHistory()
+  recentRecordings = mergeRecordingHistory(localHistory, backendHistory).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
   return recentRecordings
 }
 
@@ -175,7 +180,7 @@ function mergeRecordingHistory(
         byLocalId.set(existingLocalId, {
           ...existing,
           status: backendItem.status,
-          title: existing.title || backendItem.title,
+          title: mergedRecordingTitle(existing, backendItem),
           durationMs: backendItem.durationMs || existing.durationMs,
           backendRecordingId: backendId,
           error: backendItem.error,
@@ -190,12 +195,19 @@ function mergeRecordingHistory(
   return normalizeRecordingHistory(Array.from(byLocalId.values()))
 }
 
+function mergedRecordingTitle(existing: RecordingHistoryItem, backendItem: RecordingHistoryItem): string {
+  if (backendItem.title && (!existing.title || existing.title === 'Browser recording')) {
+    return backendItem.title
+  }
+  return existing.title || backendItem.title
+}
+
 function scheduleBackendRecordingsRefresh(): void {
   const now = Date.now()
   if (backendRecordingsRefreshPromise) return
   if (now - backendRecordingsLastRefreshedAt < BACKEND_RECORDINGS_REFRESH_THROTTLE_MS) return
 
-  backendRecordingsRefreshPromise = hydrateRecentRecordings()
+  backendRecordingsRefreshPromise = refreshRecentRecordingsFromBackend()
     .then(() => {
       backendRecordingsLastRefreshedAt = Date.now()
       broadcastUploadQueueState()
@@ -623,6 +635,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         recordingStopping = !!sessionState?.recordingStopping
         await hydrateRecentRecordings()
       } catch {}
+      scheduleBackendRecordingsRefresh()
       sendResponse({
         recording: lastKnownRecording,
         recordingStartedAt,
@@ -687,6 +700,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     if (msg?.type === 'READ_RECORDING_HISTORY') {
       try {
         await hydrateRecentRecordings()
+        scheduleBackendRecordingsRefresh()
         sendResponse({ ok: true, items: recentRecordings })
       } catch (e: any) {
         captureException(e, { operation: 'READ_RECORDING_HISTORY' })
@@ -741,6 +755,7 @@ async function initializeRecentRecordings(): Promise<void> {
   }
 
   await hydrateRecentRecordings()
+  scheduleBackendRecordingsRefresh()
 }
 
 void initializeRecentRecordings().catch((e) => {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -9,7 +9,6 @@ import type { MicPreferences } from './micPreferences'
 import { uploadRecordingOnce, type UploadRecordingInput } from './uploadClient'
 import {
   generateRecordingLocalId,
-  POPUP_RECORDING_HISTORY_LIMIT,
   type RecordingHistoryItem,
   type RecordingUploadStatus
 } from './recordingHistory'
@@ -114,19 +113,6 @@ function toHistoryItem(entry: UploadQueueEntry): RecordingHistoryItem {
   return historyItem
 }
 
-async function publishUploadQueueState(items?: RecordingHistoryItem[]): Promise<void> {
-  const history = items ?? uploadQueue.map(toHistoryItem)
-  try {
-    getPort().postMessage({
-      type: 'UPLOAD_QUEUE_STATE',
-      items: history.slice(0, POPUP_RECORDING_HISTORY_LIMIT)
-    })
-  } catch (e) {
-    log('Upload queue state broadcast failed', e)
-    captureException(e, { operation: 'publishUploadQueueState' })
-  }
-}
-
 async function persistQueueEntry(entry: UploadQueueEntry): Promise<void> {
   const response = await chrome.runtime.sendMessage({
     type: 'UPSERT_RECORDING_HISTORY_ITEM',
@@ -135,10 +121,6 @@ async function persistQueueEntry(entry: UploadQueueEntry): Promise<void> {
   if (response?.ok === false) {
     throw new Error(response.error || 'Recording history update failed')
   }
-  const items = Array.isArray(response?.items)
-    ? response.items as RecordingHistoryItem[]
-    : [toHistoryItem(entry)]
-  await publishUploadQueueState(items)
 }
 
 let activeStreams = new Set<MediaStream>()

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -3,8 +3,6 @@
 import { captureException, captureMessage, initDiagnostics } from './diagnostics'
 import {
   isMeet2NoteAuthError,
-  markMeet2NoteReconnectRequired,
-  MEET2NOTE_EXTENSION_TOKEN_KEY,
   Meet2NoteAuthError
 } from './extensionAuth'
 import type { MicPreferences } from './micPreferences'
@@ -12,10 +10,8 @@ import { uploadRecordingOnce, type UploadRecordingInput } from './uploadClient'
 import {
   generateRecordingLocalId,
   POPUP_RECORDING_HISTORY_LIMIT,
-  readRecordingHistory,
   type RecordingHistoryItem,
-  type RecordingUploadStatus,
-  upsertRecordingHistoryItem
+  type RecordingUploadStatus
 } from './recordingHistory'
 
 initDiagnostics('offscreen')
@@ -119,7 +115,7 @@ function toHistoryItem(entry: UploadQueueEntry): RecordingHistoryItem {
 }
 
 async function publishUploadQueueState(items?: RecordingHistoryItem[]): Promise<void> {
-  const history = items ?? await readRecordingHistory().catch(() => [])
+  const history = items ?? uploadQueue.map(toHistoryItem)
   try {
     getPort().postMessage({
       type: 'UPLOAD_QUEUE_STATE',
@@ -132,7 +128,16 @@ async function publishUploadQueueState(items?: RecordingHistoryItem[]): Promise<
 }
 
 async function persistQueueEntry(entry: UploadQueueEntry): Promise<void> {
-  const items = await upsertRecordingHistoryItem(toHistoryItem(entry))
+  const response = await chrome.runtime.sendMessage({
+    type: 'UPSERT_RECORDING_HISTORY_ITEM',
+    item: toHistoryItem(entry)
+  })
+  if (response?.ok === false) {
+    throw new Error(response.error || 'Recording history update failed')
+  }
+  const items = Array.isArray(response?.items)
+    ? response.items as RecordingHistoryItem[]
+    : [toHistoryItem(entry)]
   await publishUploadQueueState(items)
 }
 
@@ -608,7 +613,10 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
     } catch (e) {
       if (isMeet2NoteAuthError(e)) {
         const message = e.message || 'Connect to Meet2Note before uploading.'
-        await markMeet2NoteReconnectRequired(message).catch(() => {})
+        await chrome.runtime.sendMessage({
+          type: 'MARK_MEET2NOTE_RECONNECT_REQUIRED',
+          message
+        }).catch(() => {})
         await updateQueueEntry(entry, 'auth_required', {
           error: message,
           nextRetryAt: null
@@ -1107,12 +1115,18 @@ rpcPort.onMessage.addListener(async (msg: any) => {
         const res = await (chrome.storage as any)?.session?.get?.(['recording'])
         recording = !!res?.recording
       } catch {}
+      const historyResponse = await chrome.runtime.sendMessage({ type: 'READ_RECORDING_HISTORY' }).catch(() => null)
       return respond(msg, {
         recording,
         uploadWorkerRunning,
         queuedUploads: uploadQueue.length,
-        items: await readRecordingHistory().catch(() => [])
+        items: Array.isArray(historyResponse?.items) ? historyResponse.items : uploadQueue.map(toHistoryItem)
       })
+    }
+
+    if (msg?.type === 'OFFSCREEN_REQUEUE_AUTH_REQUIRED_UPLOADS') {
+      await requeueAuthRequiredUploads()
+      return respond(msg, { ok: true })
     }
 
     if (msg?.type === 'DIAG_ECHO') {
@@ -1134,15 +1148,3 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
   } catch (e) { sendResponse({ ok: false, error: String(e) }) }
   return false
 })
-
-chrome.storage.onChanged.addListener((changes, areaName) => {
-  if (areaName !== 'local') return
-  const tokenChange = changes[MEET2NOTE_EXTENSION_TOKEN_KEY]
-  if (!tokenChange || typeof tokenChange.newValue !== 'string' || !tokenChange.newValue.trim()) return
-  void requeueAuthRequiredUploads().catch((e) => {
-    log('resume auth-required uploads after token change failed', e)
-    captureException(e, { operation: 'storage.onChanged.resumeAuthUploads' })
-  })
-})
-
-void publishUploadQueueState().catch(() => {})

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -134,16 +134,19 @@ function getHistoryStatusText(item: RecordingHistoryItem, now: number): string {
       : 0
     return `Retrying in ${Math.ceil(waitMs / 1000)}s`
   }
+  if (item.status === 'pending') return 'Waiting for processing'
+  if (item.status === 'processing') return 'Processing in Meet2Note'
+  if (item.status === 'ready') return 'Ready in Meet2Note'
   if (item.status === 'uploaded') return item.backendRecordingId ? `Uploaded: ${item.backendRecordingId}` : 'Uploaded'
   if (item.status === 'auth_required') return 'Reconnect to upload'
   return item.error || 'Upload failed'
 }
 
 function getHistoryTagColor(status: RecordingUploadStatus): string {
-  if (status === 'uploaded') return 'success'
+  if (status === 'uploaded' || status === 'ready') return 'success'
   if (status === 'failed' || status === 'auth_required') return 'error'
   if (status === 'retrying') return 'warning'
-  if (status === 'uploading') return 'processing'
+  if (status === 'uploading' || status === 'processing' || status === 'pending') return 'processing'
   return 'default'
 }
 

--- a/src/recordingHistory.ts
+++ b/src/recordingHistory.ts
@@ -5,6 +5,9 @@ export type RecordingUploadStatus =
   | 'uploading'
   | 'retrying'
   | 'uploaded'
+  | 'pending'
+  | 'processing'
+  | 'ready'
   | 'auth_required'
   | 'failed'
 
@@ -47,7 +50,11 @@ const NON_TERMINAL_STATUSES = new Set<RecordingUploadStatus>([
 ])
 
 export function isTerminalRecordingStatus(status: RecordingUploadStatus): boolean {
-  return status === 'uploaded' || status === 'failed'
+  return status === 'uploaded' ||
+    status === 'pending' ||
+    status === 'processing' ||
+    status === 'ready' ||
+    status === 'failed'
 }
 
 export function generateRecordingLocalId(): string {
@@ -82,6 +89,9 @@ function isRecordingUploadStatus(value: unknown): value is RecordingUploadStatus
     value === 'uploading' ||
     value === 'retrying' ||
     value === 'uploaded' ||
+    value === 'pending' ||
+    value === 'processing' ||
+    value === 'ready' ||
     value === 'auth_required' ||
     value === 'failed'
 }

--- a/src/recordingsClient.ts
+++ b/src/recordingsClient.ts
@@ -47,8 +47,9 @@ function parseBackendRecording(value: unknown): BackendRecordingListItem | null 
   const id = typeof record.id === 'string' ? record.id.trim() : ''
   const title = typeof record.title === 'string' ? record.title.trim() : ''
   const status = record.status
-  const createdAt = typeof record.createdAt === 'string' ? record.createdAt : ''
-  const updatedAt = typeof record.updatedAt === 'string' ? record.updatedAt : createdAt
+  const createdAt = typeof record.createdAt === 'string' ? record.createdAt.trim() : ''
+  const updatedAtRaw = typeof record.updatedAt === 'string' ? record.updatedAt.trim() : ''
+  const updatedAt = updatedAtRaw || createdAt
 
   if (!id || !isBackendRecordingStatus(status) || !createdAt) return null
 

--- a/src/recordingsClient.ts
+++ b/src/recordingsClient.ts
@@ -1,0 +1,93 @@
+import {
+  makeAuthorizationHeader,
+  Meet2NoteAuthError
+} from './extensionAuth'
+import { makeMeet2NoteUrl } from './meet2noteConfig'
+
+export type BackendRecordingStatus = 'pending' | 'processing' | 'ready' | 'failed'
+
+export interface BackendRecordingListItem {
+  id: string
+  title: string
+  status: BackendRecordingStatus
+  durationMs: number | null
+  createdAt: string
+  updatedAt: string
+}
+
+const LIST_RECORDINGS_TIMEOUT_MS = 30_000
+
+function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+  return fetch(url, {
+    ...init,
+    signal: controller.signal
+  }).catch((error) => {
+    if (controller.signal.aborted) {
+      throw new Error(`recordings list timed out after ${Math.round(timeoutMs / 1000)} seconds`)
+    }
+    throw error
+  }).finally(() => {
+    clearTimeout(timeoutId)
+  })
+}
+
+function isBackendRecordingStatus(value: unknown): value is BackendRecordingStatus {
+  return value === 'pending' ||
+    value === 'processing' ||
+    value === 'ready' ||
+    value === 'failed'
+}
+
+function parseBackendRecording(value: unknown): BackendRecordingListItem | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  const id = typeof record.id === 'string' ? record.id.trim() : ''
+  const title = typeof record.title === 'string' ? record.title.trim() : ''
+  const status = record.status
+  const createdAt = typeof record.createdAt === 'string' ? record.createdAt : ''
+  const updatedAt = typeof record.updatedAt === 'string' ? record.updatedAt : createdAt
+
+  if (!id || !isBackendRecordingStatus(status) || !createdAt) return null
+
+  return {
+    id,
+    title: title || 'Meet2Note recording',
+    status,
+    durationMs: typeof record.durationMs === 'number' && Number.isFinite(record.durationMs)
+      ? record.durationMs
+      : null,
+    createdAt,
+    updatedAt
+  }
+}
+
+export async function listMeet2NoteRecordings(extensionToken: string): Promise<BackendRecordingListItem[]> {
+  const token = extensionToken.trim()
+  if (!token) throw new Meet2NoteAuthError('Connect to Meet2Note before loading recordings.')
+
+  const response = await fetchWithTimeout(
+    makeMeet2NoteUrl('/api/recordings'),
+    {
+      method: 'GET',
+      headers: {
+        Authorization: makeAuthorizationHeader(token)
+      }
+    },
+    LIST_RECORDINGS_TIMEOUT_MS
+  )
+
+  if (response.status === 401 || response.status === 403) {
+    throw new Meet2NoteAuthError('Meet2Note connection required for recordings list.', response.status)
+  }
+  if (!response.ok) throw new Error(`recordings list failed with HTTP ${response.status}`)
+
+  const data = await response.json().catch(() => null)
+  if (!Array.isArray(data)) throw new Error('recordings list returned invalid JSON')
+
+  return data
+    .map(parseBackendRecording)
+    .filter((item): item is BackendRecordingListItem => item !== null)
+}


### PR DESCRIPTION
## Zakres
- przenosi zapis/odczyt historii z offscreen do background, bo offscreen document nie ma pelnego dostepu do chrome.storage
- pobiera ostatnie nagrania z Meet2Note przez GET /api/recordings z extensionToken i scala je z lokalna kolejka
- podbija wersje rozszerzenia do 1.8.1 oraz aktualizuje dokumentacje

## Weryfikacja
- npm run typecheck
- make check
- scripts/smoke-test.sh

## Ryzyka
- lista backendowa zalezy od poprawnego extensionToken; przy 401/403 popup wymusi ponowne polaczenie

## Uprawnienia Chrome
- bez zmian w permissions i host_permissions