### PR TITLE
Add durable recording spool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,8 @@ Gdy czlowiek napisze `+PR`, uruchom lokalna procedure pracy z Pull Requestem.
       - `unclear` + pytanie doprecyzowujace
    b) Nie zostawiaj komentarzy Copilota bez odpowiedzi.
    c) Jesli uwaga jest trade-offem albo moze zmienic zalozenia funkcjonalne, zawsze pytaj czlowieka przed wdrozeniem.
+   d) Przed zakonczeniem pracy z CR sprawdz thread-aware stan review i upewnij sie, ze kazda uwaga Copilota ma odpowiedz w watku oraz jest resolved albo ma jawne wyjasnienie `not applying`/`unclear`.
+   e) Brak odpowiedzi przy uwadze Copilota jest traktowany jako blad procesu, bo czlowiek uzywa odpowiedzi jako sygnalu, czy i jak uwaga zostala uwzgledniona.
 
 4. Kolejne rundy
    a) Po wdrozeniu zatwierdzonych przez czlowieka poprawek zrob commit i push.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Jeśli wolisz wariant z botem albo aplikacją desktopową do nagrywania, zobacz 
 
 **Połączenie z kontem Meet2Note** - popup otwiera flow `Connect to Meet2Note`, zapisuje długotrwały token w `chrome.storage.local` i używa go przy uploadzie.
 
-**Kolejka i retry uploadu** - zakończone nagrania trafiają do lokalnej kolejki, a pojedynczy upload w retry nie blokuje kolejnego nagrania.
+**Trwała kolejka i retry uploadu** - nagrania są zapisywane lokalnie w IndexedDB i pozostają w kolejce, jeśli backend, sieć albo token wymagają ponowienia.
 
 **Ostatnie nagrania** - popup scala lokalne statusy kolejki z listą nagrań pobraną z Meet2Note.
 
@@ -33,7 +33,8 @@ Jeśli wolisz wariant z botem albo aplikacją desktopową do nagrywania, zobacz 
 
 3. Service worker w tle tworzy i koordynuje dokument offscreen oraz pobiera właściwy `streamId` przechwytywania dla aktywnej karty.
 
-4. Strona offscreen przechwytuje kartę, nagrywa osobny asset mikrofonu, finalizuje bloby i dodaje nagranie do sekwencyjnej kolejki uploadu.
+4. Strona offscreen przechwytuje kartę, nagrywa osobny asset mikrofonu i zapisuje chunki nagrania do trwałego lokalnego spoolu IndexedDB.
+5. Po zatrzymaniu nagrania worker składa assety ze spoolu i wykonuje sekwencyjny upload do backendu.
 
 ## Wymagania
 
@@ -161,9 +162,10 @@ Po każdym ponownym buildzie kliknij `Reload` przy rozszerzeniu w `chrome://exte
 │  ├─ background.ts     # service worker MV3: tworzy offscreen i koordynuje strumienie
 │  ├─ connectCallback.ts # callback flow połączenia Meet2Note
 │  ├─ extensionAuth.ts  # token użytkownika, state flow połączenia i storage
-│  ├─ offscreen.ts      # uruchamia nagrywarkę i wysyła assety do backendu
+│  ├─ offscreen.ts      # uruchamia nagrywarkę, zapisuje spool i wysyła assety do backendu
 │  ├─ popup.tsx         # UI popupu w React + Ant Design: mikrofon, start/stop
 │  ├─ micPreferences.ts # wspólne helpery zapisu wyboru mikrofonu
+│  ├─ recordingSpool.ts # trwały lokalny spool nagrań w IndexedDB
 │  ├─ recordingsClient.ts # klient listy nagrań Meet2Note
 │  ├─ uploadClient.ts   # klient kontraktu uploadu backendu
 │  └─ micsetup.tsx      # strona React + Ant Design do nadania uprawnienia i wyboru mikrofonu
@@ -290,7 +292,8 @@ Pytanie: `Stop & Upload` kończy nagrywanie, ale upload się ponawia. Co zrobić
 Odpowiedź:
 1. Sprawdź, czy `https://meet2note.com` działa i czy przeglądarka ma połączenie z siecią.
 2. Rozszerzenie ponawia pełną próbę uploadu tej pozycji co 15 sekund, a kolejne nagrania mogą w tym czasie trafiać do kolejki.
-3. Nie zamykaj przeglądarki ani nie przeładowuj rozszerzenia, bo gotowe bloby są trzymane w pamięci i mogą zostać oznaczone jako utracone.
+3. Zakończone nagranie zostaje w lokalnym spoolu IndexedDB do czasu potwierdzonego uploadu; po restarcie rozszerzenia upload powinien zostać wznowiony.
+4. Jeśli popup pokaże błąd lokalnego zapisu, sprawdź miejsce w profilu Chrome/dysku przed kolejnym nagraniem.
 
 Pytanie: Popup pokazuje `Connect to Meet2Note` albo `Reconnect to Meet2Note`. Co zrobić?
 Odpowiedź:

--- a/docs/runbooks/002-smoke-test-po-zmianach.md
+++ b/docs/runbooks/002-smoke-test-po-zmianach.md
@@ -28,7 +28,8 @@ Szybko potwierdzic, ze build oraz najwazniejsze sciezki rozszerzenia dzialaja po
 13. Jesli testujesz retry, czasowo odetnij backend albo siec, zatrzymaj nagranie i potwierdz, ze popup pokazuje ponawianie uploadu konkretnej pozycji co okolo 15 sekund.
 14. Jesli testujesz autoryzacje, usun albo uszkodz token w `chrome.storage.local` i potwierdz, ze popup wymaga ponownego polaczenia zamiast bez konca ponawiac upload.
 15. Przywroc backend albo siec i potwierdz, ze kolejna proba uploadu konczy sie sukcesem.
-16. Sprawdz konsole service workera, offscreen document i karty testowej pod katem nowych bledow.
+16. Jesli dotknieto lokalnego spoolu nagran, po zatrzymaniu nagrania przeladuj rozszerzenie albo service worker i potwierdz, ze pozycja nadal jest widoczna oraz upload wznawia sie ze spoolu.
+17. Sprawdz konsole service workera, offscreen document i karty testowej pod katem nowych bledow.
 
 ## Kryteria zaliczenia
 
@@ -40,6 +41,7 @@ Szybko potwierdzic, ze build oraz najwazniejsze sciezki rozszerzenia dzialaja po
 - Nagrywanie startuje, zatrzymuje sie i wysyla assety do backendu, jesli dotknieto kodu recording/offscreen/upload/permissions.
 - Po sukcesie Chrome nie pobiera lokalnego `.webm`.
 - Upload jednego nagrania nie blokuje rozpoczecia kolejnego nagrania.
+- Zakonczone nagranie pozostaje w lokalnym spoolu po restarcie service workera/offscreen do czasu udanego uploadu.
 - Na aktywnym spotkaniu Meet znacznik rozszerzenia pokazuje `RDY`, po starcie `REC`, a wyjscie ze spotkania zatrzymuje nagrywanie i uruchamia upload.
 - Przy bledzie uploadu popup pokazuje retry dla konkretnej pozycji, a kolejna proba nastepuje co okolo 15 sekund.
 - Przy bledzie autoryzacji `401`/`403` popup pokazuje koniecznosc ponownego polaczenia z Meet2Note.

--- a/docs/specs/004-kolejka-uploadu-i-historia-nagran.md
+++ b/docs/specs/004-kolejka-uploadu-i-historia-nagran.md
@@ -28,7 +28,7 @@ Użytkownik powinien widzieć oddzielnie:
 2. Poza zakresem:
    a) Backendowe zmiany API uploadu.
    b) Równoległy upload wielu nagrań.
-   c) Trwałe składowanie dużych blobów w IndexedDB albo na dysku.
+   c) Trwałe składowanie dużych blobów w IndexedDB albo na dysku było poza pierwotnym zakresem #10; zostało wydzielone do #13.
    d) Ręczny eksport lokalnego pliku `.webm`.
    e) Ręczne kasowanie pojedynczych pozycji historii z UI, o ile nie okaże się konieczne dla ergonomii.
    f) Migracja starszych, już utraconych uploadów zapisanych tylko jako globalny `uploadStatus`.
@@ -55,21 +55,21 @@ Użytkownik powinien widzieć oddzielnie:
    b) Kolejne zakończone nagrania czekają jako `queued`.
    c) Uzasadnienie: kontrakt backendu i zużycie pasma/pamięci są bezpieczniejsze przy jednym aktywnym uploadzie.
 
-3. Bloby pozostają w pamięci offscreen.
-   a) Gotowe `videoBlob` i opcjonalny `microphoneBlob` są trzymane w pamięci kolejki offscreen.
+3. Po realizacji #13 bloby nie pozostają wyłącznie w pamięci offscreen.
+   a) Chunks nagrania są zapisywane w IndexedDB podczas nagrywania.
    b) `chrome.storage.local` przechowuje tylko metadane historii, nie zawartość nagrań.
-   c) Uzasadnienie: trwałe składowanie dużych blobów wymaga osobnej decyzji o IndexedDB, limitach, czyszczeniu i prywatności.
+   c) Lokalny spool jest czyszczony dopiero po potwierdzonym uploadzie.
 
 4. Restart service workera ma być obsłużony przez metadane i ponowne spięcie z offscreen.
    a) Po restarcie service worker odczytuje historię z `chrome.storage.local`.
    b) Jeśli offscreen nadal żyje, background pobiera aktualny snapshot kolejki przez komunikat do offscreen.
-   c) Jeśli offscreen został utracony razem z blobami, pozycje nieukończone są oznaczane jako `failed` z komunikatem o utracie danych nagrania.
+   c) Jeśli offscreen został utracony, zakończone pozycje uploadu są odtwarzane z IndexedDB; aktywne, niefinalizowane nagrania mogą zostać oznaczone jako `failed_unrecoverable`.
 
 5. `401` i `403` nie uruchamiają zwykłego retry.
    a) Pozycja przechodzi w `auth_required`.
    b) Token Meet2Note jest czyszczony przez istniejący mechanizm reconnect.
-   c) Po ponownym połączeniu pozycja może wrócić do `queued`, jeśli jej bloby nadal istnieją w pamięci offscreen.
-   d) Jeśli bloby zostały utracone, pozycja pozostaje `failed`.
+   c) Po ponownym połączeniu pozycja może wrócić do `queued`, jeśli jej chunks nadal istnieją w lokalnym spoolu.
+   d) Jeśli chunks zostały utracone albo storage jest uszkodzony, pozycja pozostaje `failed_unrecoverable`.
 
 6. Historia ma ograniczony rozmiar.
    a) Domyślny limit: 10 ostatnich pozycji.
@@ -304,11 +304,11 @@ make check
 
 ## Ryzyka
 
-1. Pamięć offscreen może rosnąć przy wielu dużych nagraniach czekających na upload.
-   a) Mitigacja: sekwencyjny upload, limit historii i brak równoległości; w przyszłości rozważyć IndexedDB albo upload chunkowany.
+1. Lokalny spool IndexedDB może rosnąć przy wielu dużych nagraniach czekających na upload.
+   a) Mitigacja: sekwencyjny upload, limit pozycji i łącznego rozmiaru spoolu.
 
 2. Chrome może zamknąć offscreen albo przeglądarkę przed zakończeniem uploadu.
-   a) Mitigacja: metadane historii zostają, ale po utracie blobów pozycja przechodzi w `failed`.
+   a) Mitigacja: zakończone nagrania zostają w IndexedDB i upload jest odtwarzany po restarcie.
 
 3. Długi upload może konkurować o zasoby z kolejnym nagrywaniem.
    a) Mitigacja: jeden aktywny upload naraz i obserwacja realnego zachowania w smoke teście.
@@ -325,4 +325,4 @@ make check
 
 ## Otwarte Pytania
 
-Brak pytań blokujących na etapie specyfikacji. Trwałe składowanie blobów w IndexedDB jest świadomie poza zakresem tej iteracji i powinno dostać osobne issue, jeśli okaże się wymagane.
+Brak pytań blokujących na etapie specyfikacji #10. Trwałe składowanie blobów w IndexedDB zostało później wydzielone do #13 i zaimplementowane jako lokalny spool.

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -23,7 +23,8 @@ Docelowy backend dla uploadu i przetwarzania nagrań będzie rozwijany w powiąz
 | Callback Meet2Note | `connect-callback.html`, `src/connectCallback.ts` | Kończy flow połączenia z backendu, waliduje `state`, wymienia jednorazowy `code` na token i zapisuje go lokalnie. |
 | Watcher Google Meet | `src/meetWatcher.ts`, `manifest.json` | Content script na `meet.google.com`, który wykrywa aktywne spotkanie i opuszczenie spotkania. |
 | Service worker tła | `src/background.ts` | Koordynuje przechwytywanie karty, cykl życia dokumentu offscreen, stan nagrywania/uploadu i znaczniki. |
-| Nagrywarka offscreen | `offscreen.html`, `src/offscreen.ts` | Przechwytuje media z karty, nagrywa osobny asset mikrofonu, finalizuje bloby i wysyła je do backendu. |
+| Nagrywarka offscreen | `offscreen.html`, `src/offscreen.ts` | Przechwytuje media z karty, nagrywa osobny asset mikrofonu, zapisuje chunki do spoolu i wysyła je do backendu. |
+| Lokalny spool nagrań | `src/recordingSpool.ts` | Trwały IndexedDB dla manifestów i chunków nagrań do czasu potwierdzonego uploadu. |
 | Klient uploadu | `src/uploadClient.ts` | Wykonuje kontrakt uploadu backendu: `/init`, upload assetów, `/complete`. |
 | Klient nagrań | `src/recordingsClient.ts` | Pobiera listę nagrań z backendu przez `GET /api/recordings` z `extensionToken`. |
 | Historia nagrań | `src/recordingHistory.ts` | Definiuje model lokalnej historii uploadów i helpery `chrome.storage.local`. |
@@ -47,7 +48,7 @@ Ten opis dokumentuje aktualne ustalenia integracyjne między wtyczką i backende
 6. Jeśli mikrofon jest dostępny, rozszerzenie wysyła osobny asset `microphone` przez `PUT /api/upload/{recordingId}/microphone`.
 7. Każdy upload assetu używa nagłówków `Authorization` oraz `X-Upload-Token`.
 8. Rozszerzenie kończy upload przez `POST /api/upload/{recordingId}/complete`.
-9. Zakończone nagrania trafiają do sekwencyjnej kolejki uploadu w offscreen; jeden aktywny upload nie blokuje startu kolejnego nagrania.
+9. Chunks nagrania trafiają do trwałego spoolu IndexedDB już podczas nagrywania, a zakończone nagrania są uploadowane sekwencyjnie.
 10. Jeśli upload się nie powiedzie, offscreen ponawia pełny upload konkretnej pozycji co 15 sekund, bez lokalnego zapisu pliku.
 11. Jeśli backend zwróci `401` albo `403`, zwykły retry tej pozycji jest przerywany, token jest czyszczony i popup wymaga ponownego połączenia z Meet2Note.
 12. Popup scala lokalną historię kolejki z listą nagrań z backendu, jeśli konto jest połączone z Meet2Note.
@@ -55,7 +56,7 @@ Ten opis dokumentuje aktualne ustalenia integracyjne między wtyczką i backende
 ## Granice uruchomieniowe
 
 1. Pliki wynikowe trafiają bezpośrednio do `https://meet2note.com`, bez automatycznego pobierania lokalnego `.webm`.
-2. Gotowe bloby są trzymane tylko w pamięci offscreen na czas kolejki, uploadu i retry; trwała historia w `chrome.storage.local` zawiera tylko metadane.
+2. Chunks nagrań są trzymane w IndexedDB do czasu potwierdzonego uploadu; trwała historia w `chrome.storage.local` zawiera tylko metadane.
 3. Wybór mikrofonu i token Meet2Note są zapisywane lokalnie w `chrome.storage.local`.
 4. Tokenów, kodów wymiany, nagłówka `Authorization`, `X-Upload-Token` ani blobów nagrań nie wolno logować do konsoli ani Sentry.
 5. Content script na Google Meet nie czyta ani nie wysyła treści spotkania; wykrywa tylko stan obecności w spotkaniu.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.8.1",
+    "version": "1.9.0",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/src/background.ts
+++ b/src/background.ts
@@ -236,10 +236,20 @@ function hasPendingLocalUpload(items = recentRecordings): boolean {
   )
 }
 
+async function hasPendingLocalUploadInHistory(): Promise<boolean> {
+  try {
+    return hasPendingLocalUpload(await readRecordingHistory())
+  } catch (e) {
+    captureException(e, { operation: 'hasPendingLocalUploadInHistory' })
+    return hasPendingLocalUpload()
+  }
+}
+
 function wakeOffscreenForPendingUploads(): void {
-  if (!hasPendingLocalUpload()) return
-  void ensureOffscreen()
-    .then(() => {
+  void hasPendingLocalUploadInHistory()
+    .then(async (hasPendingUploads) => {
+      if (!hasPendingUploads) return undefined
+      await ensureOffscreen()
       if (offscreenPort) {
         return postToOffscreen({ type: 'OFFSCREEN_RESTORE_UPLOAD_QUEUE' }).catch(() => undefined)
       }

--- a/src/background.ts
+++ b/src/background.ts
@@ -230,7 +230,9 @@ function hasPendingLocalUpload(items = recentRecordings): boolean {
     item.status === 'queued' ||
     item.status === 'uploading' ||
     item.status === 'retrying' ||
-    item.status === 'auth_required'
+    item.status === 'auth_required' ||
+    item.status === 'recording' ||
+    item.status === 'finalizing'
   )
 }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -9,7 +9,6 @@ import {
 } from './extensionAuth'
 import { clearMicPreferences, getMicPreferences, type MicPreferences } from './micPreferences'
 import {
-  markIncompleteRecordingsFailed,
   normalizeRecordingHistory,
   POPUP_RECORDING_HISTORY_LIMIT,
   readRecordingHistory,
@@ -34,7 +33,6 @@ const meetTabsInMeeting = new Set<number>()
 let recentRecordings: RecordingHistoryItem[] = []
 let backendRecordingsRefreshPromise: Promise<void> | null = null
 let backendRecordingsLastRefreshedAt = 0
-const RECORDER_CONTEXT_INTERRUPTED_MESSAGE = 'Upload was interrupted by an extension restart or refresh.'
 const BACKEND_RECORDINGS_REFRESH_THROTTLE_MS = 15_000
 
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
@@ -227,6 +225,30 @@ function broadcastUploadQueueState(items = recentRecordings): void {
   }).catch(() => {})
 }
 
+function hasPendingLocalUpload(items = recentRecordings): boolean {
+  return items.some(item =>
+    item.status === 'queued' ||
+    item.status === 'uploading' ||
+    item.status === 'retrying' ||
+    item.status === 'auth_required'
+  )
+}
+
+function wakeOffscreenForPendingUploads(): void {
+  if (!hasPendingLocalUpload()) return
+  void ensureOffscreen()
+    .then(() => {
+      if (offscreenPort) {
+        return postToOffscreen({ type: 'OFFSCREEN_RESTORE_UPLOAD_QUEUE' }).catch(() => undefined)
+      }
+      return undefined
+    })
+    .catch((e) => {
+      bglog('Failed to wake offscreen for pending uploads', e)
+      captureException(e, { operation: 'wakeOffscreenForPendingUploads' })
+    })
+}
+
 async function getMicPreferencesForOffscreen(): Promise<MicPreferences> {
   try {
     return await getMicPreferences()
@@ -256,8 +278,6 @@ async function hasOffscreenContext(): Promise<boolean> {
 async function ensureOffscreen(): Promise<void> {
   const have = await hasOffscreenContext()
   if (!have) {
-    recentRecordings = (await markIncompleteRecordingsFailed(RECORDER_CONTEXT_INTERRUPTED_MESSAGE)).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
-    broadcastUploadQueueState()
     bglog('Creating offscreen document…')
     await chrome.offscreen.createDocument({
       url: chrome.runtime.getURL('offscreen.html'),
@@ -304,8 +324,6 @@ async function resetOffscreen(): Promise<void> {
     if (await hasOffscreenContext()) {
       await chrome.offscreen.closeDocument()
       await wait(250)
-      recentRecordings = (await markIncompleteRecordingsFailed(RECORDER_CONTEXT_INTERRUPTED_MESSAGE)).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
-      broadcastUploadQueueState()
     }
   } catch (e) {
     bglog('Offscreen reset failed', e)
@@ -373,16 +391,6 @@ chrome.runtime.onConnect.addListener((port) => {
     persistRecordingState(false, null)
     setBadge(false)
 
-    void (async () => {
-      try {
-        if (await hasOffscreenContext()) return
-        recentRecordings = (await markIncompleteRecordingsFailed(RECORDER_CONTEXT_INTERRUPTED_MESSAGE)).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
-        broadcastUploadQueueState()
-      } catch (e) {
-        bglog('Failed to mark incomplete recordings after offscreen disconnect', e)
-        captureException(e, { operation: 'offscreen.onDisconnect.markIncompleteRecordingsFailed' })
-      }
-    })()
   })
 })
 
@@ -636,6 +644,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         await hydrateRecentRecordings()
       } catch {}
       scheduleBackendRecordingsRefresh()
+      wakeOffscreenForPendingUploads()
       sendResponse({
         recording: lastKnownRecording,
         recordingStartedAt,
@@ -701,6 +710,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       try {
         await hydrateRecentRecordings()
         scheduleBackendRecordingsRefresh()
+        wakeOffscreenForPendingUploads()
         sendResponse({ ok: true, items: recentRecordings })
       } catch (e: any) {
         captureException(e, { operation: 'READ_RECORDING_HISTORY' })
@@ -748,14 +758,9 @@ chrome.runtime.onSuspend?.addListener(async () => {
 })
 
 async function initializeRecentRecordings(): Promise<void> {
-  if (!(await hasOffscreenContext())) {
-    recentRecordings = (await markIncompleteRecordingsFailed(RECORDER_CONTEXT_INTERRUPTED_MESSAGE)).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
-    broadcastUploadQueueState()
-    return
-  }
-
   await hydrateRecentRecordings()
   scheduleBackendRecordingsRefresh()
+  wakeOffscreenForPendingUploads()
 }
 
 void initializeRecentRecordings().catch((e) => {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -16,6 +16,7 @@ import {
   appendSpoolChunk,
   createSpoolRecording,
   deleteSpoolChunks,
+  deleteSpoolRecording,
   getSpoolChunkCounts,
   getSpoolUsage,
   listInterruptedSpoolRecordings,
@@ -124,6 +125,7 @@ interface UploadQueueEntry extends RecordingHistoryItem {
 let uploadQueue: UploadQueueEntry[] = []
 let uploadWorkerRunning = false
 let uploadQueueWake: (() => void) | null = null
+let restoreUploadQueuePromise: Promise<void> | null = null
 
 function toHistoryItem(entry: UploadQueueEntry): RecordingHistoryItem {
   const {
@@ -543,8 +545,17 @@ async function markSpoolRecordFailedUnrecoverable(
   }
   await updateSpoolRecording(failedRecord)
   await persistHistoryItem(failedRecord)
-  if (cleanupChunks) await deleteSpoolChunks(record.localId)
+  if (cleanupChunks) await cleanupTerminalSpoolEntry(record.localId, 'markSpoolRecordFailedUnrecoverable.cleanup')
   return failedRecord
+}
+
+async function cleanupTerminalSpoolEntry(localId: string, operation: string): Promise<void> {
+  try {
+    await deleteSpoolChunks(localId)
+    await deleteSpoolRecording(localId)
+  } catch (e) {
+    captureException(e, { operation, localId })
+  }
 }
 
 async function markCurrentSpoolLocalError(message: string): Promise<void> {
@@ -559,12 +570,7 @@ async function markCurrentSpoolLocalError(message: string): Promise<void> {
   }
   await updateSpoolRecording(currentSpoolRecord)
   await persistHistoryItem(currentSpoolRecord)
-  await deleteSpoolChunks(localId).catch((e) => {
-    captureException(e, {
-      operation: 'markCurrentSpoolLocalError.deleteSpoolChunks',
-      localId
-    })
-  })
+  await cleanupTerminalSpoolEntry(localId, 'markCurrentSpoolLocalError.cleanup')
 }
 
 function uploadInputFromQueueEntry(entry: UploadQueueEntry): UploadRecordingInput {
@@ -727,7 +733,7 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
         nextRetryAt: null,
         error: null
       })
-      await deleteSpoolChunks(entry.localId)
+      await cleanupTerminalSpoolEntry(entry.localId, 'uploadQueueEntryUntilTerminal.cleanupUploaded')
       removeQueueEntry(entry.localId)
       log('Upload completed', { localId: entry.localId, recordingId: result.recordingId, assets: result.assets, attempt })
       return 'done'
@@ -896,6 +902,15 @@ async function markOrphanedPendingHistoryItems(uploadableSpoolLocalIds: Set<stri
 }
 
 async function restoreUploadQueueFromSpool(): Promise<void> {
+  if (restoreUploadQueuePromise) return restoreUploadQueuePromise
+  restoreUploadQueuePromise = restoreUploadQueueFromSpoolOnce()
+    .finally(() => {
+      restoreUploadQueuePromise = null
+    })
+  return restoreUploadQueuePromise
+}
+
+async function restoreUploadQueueFromSpoolOnce(): Promise<void> {
   await markInterruptedSpoolRecordings()
   const records = await listUploadableSpoolRecordings()
   await markOrphanedPendingHistoryItems(new Set(records.map(record => record.localId)))
@@ -1018,12 +1033,7 @@ function markCurrentSpoolFailedUnrecoverable(message: string): void {
   currentSpoolRecord = nextRecord
   void updateSpoolRecording(nextRecord).catch(() => {})
   void persistHistoryItem(nextRecord).catch(() => {})
-  void deleteSpoolChunks(nextRecord.localId).catch((e) => {
-    captureException(e, {
-      operation: 'markCurrentSpoolFailedUnrecoverable.deleteSpoolChunks',
-      localId: nextRecord.localId
-    })
-  })
+  void cleanupTerminalSpoolEntry(nextRecord.localId, 'markCurrentSpoolFailedUnrecoverable.cleanup')
 }
 
 function forceClearStuckRecording(recordingId: number, reason: string, error?: unknown): void {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -12,6 +12,19 @@ import {
   type RecordingHistoryItem,
   type RecordingUploadStatus
 } from './recordingHistory'
+import {
+  appendSpoolChunk,
+  createSpoolRecording,
+  deleteSpoolChunks,
+  getSpoolChunkCounts,
+  getSpoolUsage,
+  listInterruptedSpoolRecordings,
+  listUploadableSpoolRecordings,
+  readSpoolAssetBlob,
+  SPOOL_SCHEMA_VERSION,
+  updateSpoolRecording,
+  type RecordingSpoolRecord
+} from './recordingSpool'
 
 initDiagnostics('offscreen')
 
@@ -25,6 +38,8 @@ const UPLOAD_RETRY_INTERVAL_MS = 15_000
 const STOP_FINALIZE_TIMEOUT_MS = 10_000
 const MAX_UPLOAD_QUEUE_ENTRIES = 3
 const MAX_UPLOAD_QUEUE_BYTES = 2 * 1024 * 1024 * 1024
+const MEDIA_RECORDER_TIMESLICE_MS = 5_000
+const INTERRUPTED_RECORDING_MESSAGE = 'Recording was interrupted before it could be finalized.'
 
 window.addEventListener('error', (e) => {
   console.error('[offscreen] window.onerror', e?.message, e?.error)
@@ -114,13 +129,13 @@ function toHistoryItem(entry: UploadQueueEntry): RecordingHistoryItem {
 }
 
 async function persistQueueEntry(entry: UploadQueueEntry): Promise<void> {
-  const response = await chrome.runtime.sendMessage({
-    type: 'UPSERT_RECORDING_HISTORY_ITEM',
-    item: toHistoryItem(entry)
+  await updateSpoolRecording({
+    ...toHistoryItem(entry),
+    schemaVersion: SPOOL_SCHEMA_VERSION,
+    videoMimeType: entry.videoBlob.type || 'video/webm',
+    microphoneMimeType: entry.microphoneBlob?.type || null
   })
-  if (response?.ok === false) {
-    throw new Error(response.error || 'Recording history update failed')
-  }
+  await persistHistoryItem(toHistoryItem(entry))
 }
 
 let activeStreams = new Set<MediaStream>()
@@ -372,11 +387,16 @@ async function captureWithStreamId(streamId: string): Promise<MediaStream> {
 
 let mediaRecorder: MediaRecorder | null = null
 let microphoneRecorder: MediaRecorder | null = null
-let chunks: BlobPart[] = []
-let microphoneChunks: BlobPart[] = []
 let capturing = false
 let currentRecordingStartedAtMs: number | null = null
 let currentRecordingContext: RecordingContext | null = null
+let currentSpoolRecord: RecordingSpoolRecord | null = null
+let currentVideoChunkSequence = 0
+let currentMicrophoneChunkSequence = 0
+let currentVideoBytes = 0
+let currentMicrophoneBytes = 0
+let currentSpoolWriteQueue: Promise<unknown> = Promise.resolve()
+let currentSpoolError: Error | null = null
 let microphoneStoppedPromise: Promise<Blob | null> | null = null
 let resolveMicrophoneStopped: ((blob: Blob | null) => void) | null = null
 let stopRequested = false
@@ -441,7 +461,13 @@ function sanitizeTabUrlForHistory(url?: string | null): string | undefined {
   }
 }
 
-function buildUploadQueueEntry(videoBlob: Blob, microphoneBlob: Blob | null): UploadQueueEntry {
+function buildSpoolRecording(
+  localId: string,
+  status: RecordingUploadStatus,
+  videoMimeType: string,
+  microphoneMimeType: string | null,
+  microphoneEnabled: boolean
+): RecordingSpoolRecord {
   const now = Date.now()
   const startedAtMs = currentRecordingStartedAtMs || now
   const tabTitle = currentRecordingContext?.tabTitle?.trim()
@@ -452,8 +478,8 @@ function buildUploadQueueEntry(videoBlob: Blob, microphoneBlob: Blob | null): Up
   const timestamp = new Date(now).toISOString()
 
   return {
-    localId: generateRecordingLocalId(),
-    status: 'queued',
+    localId,
+    status,
     title,
     meetingId,
     meetingTitle: tabTitle || undefined,
@@ -461,18 +487,40 @@ function buildUploadQueueEntry(videoBlob: Blob, microphoneBlob: Blob | null): Up
     startedAt: new Date(startedAtMs).toISOString(),
     stoppedAt: timestamp,
     durationMs: Math.max(1, now - startedAtMs),
-    videoBytes: videoBlob.size,
-    microphoneBytes: microphoneBlob?.size || 0,
+    videoBytes: currentVideoBytes,
+    microphoneBytes: currentMicrophoneBytes,
     attempt: 0,
     nextRetryAt: null,
     backendRecordingId: null,
-    assets: microphoneBlob && microphoneBlob.size > 0 ? ['video_audio', 'microphone'] : ['video_audio'],
+    assets: microphoneEnabled ? ['video_audio', 'microphone'] : ['video_audio'],
     error: null,
     createdAt: timestamp,
     updatedAt: timestamp,
+    schemaVersion: SPOOL_SCHEMA_VERSION,
+    videoMimeType,
+    microphoneMimeType
+  }
+}
+
+function spoolRecordToQueueEntry(
+  record: RecordingSpoolRecord,
+  videoBlob: Blob,
+  microphoneBlob: Blob | null
+): UploadQueueEntry {
+  return {
+    ...record,
     videoBlob,
     microphoneBlob: microphoneBlob && microphoneBlob.size > 0 ? microphoneBlob : null
   }
+}
+
+async function buildUploadQueueEntryFromSpool(record: RecordingSpoolRecord): Promise<UploadQueueEntry | null> {
+  const videoBlob = await readSpoolAssetBlob(record.localId, 'video_audio', record.videoMimeType)
+  if (!videoBlob || videoBlob.size === 0) return null
+  const microphoneBlob = record.assets.includes('microphone')
+    ? await readSpoolAssetBlob(record.localId, 'microphone', record.microphoneMimeType || 'audio/webm')
+    : null
+  return spoolRecordToQueueEntry(record, videoBlob, microphoneBlob)
 }
 
 function uploadInputFromQueueEntry(entry: UploadQueueEntry): UploadRecordingInput {
@@ -485,6 +533,61 @@ function uploadInputFromQueueEntry(entry: UploadQueueEntry): UploadRecordingInpu
     videoBlob: entry.videoBlob,
     microphoneBlob: entry.microphoneBlob
   }
+}
+
+function enqueueCurrentSpoolWrite(operation: () => Promise<void>): void {
+  currentSpoolWriteQueue = currentSpoolWriteQueue
+    .then(operation)
+    .catch((error) => {
+      const err = error instanceof Error ? error : new Error(String(error))
+      currentSpoolError = err
+      log('Recording spool write failed', err)
+      captureException(err, { operation: 'recordingSpool.write' })
+      if (currentSpoolRecord) {
+        currentSpoolRecord = {
+          ...currentSpoolRecord,
+          status: 'local_error',
+          error: err.message,
+          updatedAt: new Date().toISOString()
+        }
+        void updateSpoolRecording(currentSpoolRecord).catch(() => {})
+        void persistHistoryItem(currentSpoolRecord).catch(() => {})
+      }
+      try { stopActiveRecorders() } catch {}
+    })
+}
+
+function saveRecorderChunk(asset: 'video_audio' | 'microphone', blob: Blob, mimeType: string): void {
+  const record = currentSpoolRecord
+  if (!record || !blob.size) return
+  const sequence = asset === 'video_audio'
+    ? currentVideoChunkSequence++
+    : currentMicrophoneChunkSequence++
+
+  enqueueCurrentSpoolWrite(async () => {
+    const sizeBytes = await appendSpoolChunk({
+      localId: record.localId,
+      asset,
+      sequence,
+      blob,
+      mimeType
+    })
+    if (asset === 'video_audio') currentVideoBytes += sizeBytes
+    else currentMicrophoneBytes += sizeBytes
+  })
+}
+
+async function persistHistoryItem(item: RecordingHistoryItem): Promise<RecordingHistoryItem[]> {
+  const response = await chrome.runtime.sendMessage({
+    type: 'UPSERT_RECORDING_HISTORY_ITEM',
+    item
+  })
+  if (response?.ok === false) {
+    throw new Error(response.error || 'Recording history update failed')
+  }
+  return Array.isArray(response?.items)
+    ? response.items as RecordingHistoryItem[]
+    : [item]
 }
 
 async function updateQueueEntry(
@@ -589,6 +692,7 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
         nextRetryAt: null,
         error: null
       })
+      await deleteSpoolChunks(entry.localId)
       removeQueueEntry(entry.localId)
       log('Upload completed', { localId: entry.localId, recordingId: result.recordingId, assets: result.assets, attempt })
       return 'done'
@@ -700,6 +804,92 @@ async function enqueueUpload(entry: UploadQueueEntry): Promise<void> {
   })
 }
 
+async function assertSpoolCapacityBeforeRecording(): Promise<void> {
+  const usage = await getSpoolUsage().catch(() => ({ recordings: 0, bytes: 0 }))
+  if (usage.recordings >= MAX_UPLOAD_QUEUE_ENTRIES || usage.bytes >= MAX_UPLOAD_QUEUE_BYTES) {
+    throw new Error('Local recording storage is full. Wait for pending uploads to finish before starting another recording.')
+  }
+
+  try {
+    const estimate = await navigator.storage?.estimate?.()
+    if (estimate?.quota && estimate.usage && estimate.usage / estimate.quota > 0.9) {
+      throw new Error('Browser storage is almost full. Free space before starting another recording.')
+    }
+  } catch (e) {
+    if (e instanceof Error) throw e
+  }
+}
+
+async function markInterruptedSpoolRecordings(): Promise<void> {
+  const interrupted = await listInterruptedSpoolRecordings()
+  for (const record of interrupted) {
+    const counts = await getSpoolChunkCounts(record.localId).catch(() => ({ video_audio: 0, microphone: 0 }))
+    const message = counts.video_audio > 0
+      ? 'Recording was interrupted before finalization; saved chunks cannot be safely uploaded as a complete recording.'
+      : INTERRUPTED_RECORDING_MESSAGE
+    const nextRecord: RecordingSpoolRecord = {
+      ...record,
+      status: 'failed_unrecoverable',
+      error: message,
+      nextRetryAt: null,
+      updatedAt: new Date().toISOString()
+    }
+    await updateSpoolRecording(nextRecord)
+    await persistHistoryItem(nextRecord)
+  }
+}
+
+async function restoreUploadQueueFromSpool(): Promise<void> {
+  await markInterruptedSpoolRecordings()
+  const records = await listUploadableSpoolRecordings()
+  let restored = 0
+  const canResumeAuthRequired = await requestMeet2NoteExtensionToken()
+    .then(() => true)
+    .catch(() => false)
+
+  for (const record of records) {
+    if (uploadQueue.some(entry => entry.localId === record.localId)) continue
+    const restoredStatus = record.status === 'uploading' ||
+      (record.status === 'auth_required' && canResumeAuthRequired)
+      ? 'queued'
+      : record.status
+    const entry = await buildUploadQueueEntryFromSpool({
+      ...record,
+      status: restoredStatus,
+      error: record.status === 'uploading'
+        ? 'Upload was interrupted and will be retried.'
+        : record.status === 'auth_required' && canResumeAuthRequired
+          ? null
+        : record.error,
+      updatedAt: new Date().toISOString()
+    })
+    if (!entry) {
+      const failedRecord: RecordingSpoolRecord = {
+        ...record,
+        status: 'failed_unrecoverable',
+        error: 'Recording data is missing from the local spool.',
+        nextRetryAt: null,
+        updatedAt: new Date().toISOString()
+      }
+      await updateSpoolRecording(failedRecord)
+      await persistHistoryItem(failedRecord)
+      continue
+    }
+    uploadQueue.push(entry)
+    await persistQueueEntry(entry)
+    restored += 1
+  }
+
+  if (restored) {
+    log('Restored upload queue entries from spool', restored)
+    wakeUploadQueueWorker()
+    void runUploadQueueWorker().catch((e) => {
+      log('Unexpected restored upload queue worker failure', e)
+      captureException(e, { operation: 'restoreUploadQueueFromSpool.runUploadQueueWorker' })
+    })
+  }
+}
+
 async function requeueAuthRequiredUploads(): Promise<void> {
   let changed = false
   for (const entry of uploadQueue) {
@@ -757,18 +947,42 @@ function markStopComplete(): void {
   stopRequested = false
 }
 
+function resetCurrentSpoolRuntime(): void {
+  currentSpoolRecord = null
+  currentVideoBytes = 0
+  currentMicrophoneBytes = 0
+  currentVideoChunkSequence = 0
+  currentMicrophoneChunkSequence = 0
+  currentSpoolWriteQueue = Promise.resolve()
+  currentSpoolError = null
+}
+
+function markCurrentSpoolFailedUnrecoverable(message: string): void {
+  if (!currentSpoolRecord) return
+  const nextRecord: RecordingSpoolRecord = {
+    ...currentSpoolRecord,
+    status: 'failed_unrecoverable',
+    error: message,
+    nextRetryAt: null,
+    updatedAt: new Date().toISOString()
+  }
+  currentSpoolRecord = nextRecord
+  void updateSpoolRecording(nextRecord).catch(() => {})
+  void persistHistoryItem(nextRecord).catch(() => {})
+}
+
 function forceClearStuckRecording(recordingId: number, reason: string, error?: unknown): void {
   abandonedRecordingIds.add(recordingId)
+  markCurrentSpoolFailedUnrecoverable(INTERRUPTED_RECORDING_MESSAGE)
   markStopComplete()
   resolveMicrophoneStop(null)
   cleanupRecordingResources()
   mediaRecorder = null
   microphoneRecorder = null
-  chunks = []
-  microphoneChunks = []
   capturing = false
   currentRecordingStartedAtMs = null
   currentRecordingContext = null
+  resetCurrentSpoolRuntime()
   microphoneStoppedPromise = Promise.resolve(null)
   resolveMicrophoneStopped = null
   pushState(false, { warning: reason })
@@ -864,10 +1078,19 @@ async function prepareAndRecord(
     } catch {}
   }
 
-  chunks = []
-  microphoneChunks = []
   const mime = chooseVideoMime()
   const microphoneMime = chooseMicrophoneMime()
+  const localId = generateRecordingLocalId()
+  currentVideoChunkSequence = 0
+  currentMicrophoneChunkSequence = 0
+  currentVideoBytes = 0
+  currentMicrophoneBytes = 0
+  currentSpoolWriteQueue = Promise.resolve()
+  currentSpoolError = null
+  currentSpoolRecord = buildSpoolRecording(localId, 'recording', mime, micTrack ? microphoneMime : null, !!micTrack)
+  await assertSpoolCapacityBeforeRecording()
+  await createSpoolRecording(currentSpoolRecord)
+  await persistHistoryItem(currentSpoolRecord)
 
   microphoneStoppedPromise = Promise.resolve(null)
   resolveMicrophoneStopped = null
@@ -884,7 +1107,7 @@ async function prepareAndRecord(
       })
 
       microphoneRecorder.ondataavailable = (e: BlobEvent) => {
-        if (e.data && e.data.size) microphoneChunks.push(e.data)
+        if (e.data && e.data.size) saveRecorderChunk('microphone', e.data, microphoneMime)
       }
 
       microphoneRecorder.onerror = (e: any) => {
@@ -894,9 +1117,7 @@ async function prepareAndRecord(
       }
 
       microphoneRecorder.onstop = () => {
-        const microphoneBlob = new Blob(microphoneChunks, { type: microphoneMime })
-        log('Microphone finalized; chunks =', microphoneChunks.length, 'blob.size =', microphoneBlob.size)
-        resolveMicrophoneStop(microphoneBlob.size > 0 ? microphoneBlob : null)
+        resolveMicrophoneStop(null)
       }
     } catch (e) {
       log('microphone recorder setup failed; continuing with video_audio only', e)
@@ -938,7 +1159,7 @@ async function prepareAndRecord(
     }
 
     mediaRecorder!.ondataavailable = (e: BlobEvent) => {
-      if (e.data && e.data.size) chunks.push(e.data)
+      if (e.data && e.data.size) saveRecorderChunk('video_audio', e.data, mime)
     }
 
     mediaRecorder!.onstop = async () => {
@@ -947,11 +1168,37 @@ async function prepareAndRecord(
           log('Skipping upload for abandoned recording', recordingId)
           return
         }
-        const videoBlob = new Blob(chunks, { type: mime })
-        const microphoneBlob = microphoneStoppedPromise ? await microphoneStoppedPromise : null
-        log('Finalizing; video chunks =', chunks.length, 'video blob.size =', videoBlob.size, 'microphone blob.size =', microphoneBlob?.size || 0)
+        if (currentSpoolRecord) {
+          currentSpoolRecord = {
+            ...currentSpoolRecord,
+            status: 'finalizing',
+            updatedAt: new Date().toISOString()
+          }
+          await updateSpoolRecording(currentSpoolRecord)
+          await persistHistoryItem(currentSpoolRecord)
+        }
+        if (microphoneStoppedPromise) await microphoneStoppedPromise.catch(() => null)
+        await currentSpoolWriteQueue
+        if (currentSpoolError) throw currentSpoolError
+        if (!currentSpoolRecord) throw new Error('Missing local recording spool record.')
 
-        const uploadEntry = buildUploadQueueEntry(videoBlob, microphoneBlob)
+        const stoppedAt = new Date().toISOString()
+        currentSpoolRecord = {
+          ...currentSpoolRecord,
+          status: 'queued',
+          stoppedAt,
+          durationMs: Math.max(1, Date.now() - (currentRecordingStartedAtMs || Date.now())),
+          videoBytes: currentVideoBytes,
+          microphoneBytes: currentMicrophoneBytes,
+          assets: currentMicrophoneBytes > 0 ? ['video_audio', 'microphone'] : ['video_audio'],
+          updatedAt: stoppedAt
+        }
+        await updateSpoolRecording(currentSpoolRecord)
+        await persistHistoryItem(currentSpoolRecord)
+
+        const uploadEntry = await buildUploadQueueEntryFromSpool(currentSpoolRecord)
+        if (!uploadEntry) throw new Error('Recording was finalized without video data in local spool.')
+        log('Finalizing; video blob.size =', uploadEntry.videoBlob.size, 'microphone blob.size =', uploadEntry.microphoneBlob?.size || 0)
         void enqueueUpload(uploadEntry).catch((e) => {
           log('Unexpected upload queue enqueue failure', e)
           captureException(e, { operation: 'enqueueUpload.unhandled' })
@@ -963,11 +1210,10 @@ async function prepareAndRecord(
         cleanupRecordingResources()
         mediaRecorder = null
         microphoneRecorder = null
-        chunks = []
-        microphoneChunks = []
         capturing = false
         currentRecordingStartedAtMs = null
         currentRecordingContext = null
+        resetCurrentSpoolRuntime()
         resolveMicrophoneStopped = null
         microphoneStoppedPromise = null
         abandonedRecordingIds.delete(recordingId)
@@ -1022,9 +1268,8 @@ async function startRecordingFromStreamId(
     captureException(e, { operation: 'startRecordingFromStreamId' })
     mediaRecorder = null
     microphoneRecorder = null
-    chunks = []
-    microphoneChunks = []
     capturing = false
+    resetCurrentSpoolRuntime()
     pushState(false)
     throw e
   }
@@ -1111,6 +1356,11 @@ rpcPort.onMessage.addListener(async (msg: any) => {
       return respond(msg, { ok: true })
     }
 
+    if (msg?.type === 'OFFSCREEN_RESTORE_UPLOAD_QUEUE') {
+      await restoreUploadQueueFromSpool()
+      return respond(msg, { ok: true })
+    }
+
     if (msg?.type === 'DIAG_ECHO') {
       return respond(msg, { ok: true, pong: 'offscreen-alive' })
     }
@@ -1129,4 +1379,9 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
     if (msg?.type === 'OFFSCREEN_CONNECT') { connectPort(); sendResponse({ ok: true }); return true }
   } catch (e) { sendResponse({ ok: false, error: String(e) }) }
   return false
+})
+
+void restoreUploadQueueFromSpool().catch((e) => {
+  log('restore upload queue from spool failed', e)
+  captureException(e, { operation: 'restoreUploadQueueFromSpool.initial' })
 })

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -40,6 +40,12 @@ const MAX_UPLOAD_QUEUE_ENTRIES = 3
 const MAX_UPLOAD_QUEUE_BYTES = 2 * 1024 * 1024 * 1024
 const MEDIA_RECORDER_TIMESLICE_MS = 5_000
 const INTERRUPTED_RECORDING_MESSAGE = 'Recording was interrupted before it could be finalized.'
+const ORPHANED_PENDING_UPLOAD_STATUSES: RecordingUploadStatus[] = [
+  'queued',
+  'uploading',
+  'retrying',
+  'auth_required'
+]
 
 window.addEventListener('error', (e) => {
   console.error('[offscreen] window.onerror', e?.message, e?.error)
@@ -523,6 +529,37 @@ async function buildUploadQueueEntryFromSpool(record: RecordingSpoolRecord): Pro
   return spoolRecordToQueueEntry(record, videoBlob, microphoneBlob)
 }
 
+async function markSpoolRecordFailedUnrecoverable(
+  record: RecordingSpoolRecord,
+  message: string,
+  cleanupChunks = true
+): Promise<RecordingSpoolRecord> {
+  const failedRecord: RecordingSpoolRecord = {
+    ...record,
+    status: 'failed_unrecoverable',
+    error: message,
+    nextRetryAt: null,
+    updatedAt: new Date().toISOString()
+  }
+  await updateSpoolRecording(failedRecord)
+  await persistHistoryItem(failedRecord)
+  if (cleanupChunks) await deleteSpoolChunks(record.localId)
+  return failedRecord
+}
+
+async function markCurrentSpoolLocalError(message: string): Promise<void> {
+  if (!currentSpoolRecord) return
+  currentSpoolRecord = {
+    ...currentSpoolRecord,
+    status: 'local_error',
+    error: message,
+    nextRetryAt: null,
+    updatedAt: new Date().toISOString()
+  }
+  await updateSpoolRecording(currentSpoolRecord)
+  await persistHistoryItem(currentSpoolRecord)
+}
+
 function uploadInputFromQueueEntry(entry: UploadQueueEntry): UploadRecordingInput {
   return {
     title: entry.title,
@@ -543,16 +580,7 @@ function enqueueCurrentSpoolWrite(operation: () => Promise<void>): void {
       currentSpoolError = err
       log('Recording spool write failed', err)
       captureException(err, { operation: 'recordingSpool.write' })
-      if (currentSpoolRecord) {
-        currentSpoolRecord = {
-          ...currentSpoolRecord,
-          status: 'local_error',
-          error: err.message,
-          updatedAt: new Date().toISOString()
-        }
-        void updateSpoolRecording(currentSpoolRecord).catch(() => {})
-        void persistHistoryItem(currentSpoolRecord).catch(() => {})
-      }
+      void markCurrentSpoolLocalError(err.message).catch(() => {})
       try { stopActiveRecorders() } catch {}
     })
 }
@@ -805,7 +833,13 @@ async function enqueueUpload(entry: UploadQueueEntry): Promise<void> {
 }
 
 async function assertSpoolCapacityBeforeRecording(): Promise<void> {
-  const usage = await getSpoolUsage().catch(() => ({ recordings: 0, bytes: 0 }))
+  let usage: Awaited<ReturnType<typeof getSpoolUsage>>
+  try {
+    usage = await getSpoolUsage()
+  } catch (e) {
+    captureException(e, { operation: 'assertSpoolCapacityBeforeRecording.getSpoolUsage' })
+    throw new Error('Local recording storage is unavailable. Refresh the extension or free browser storage before starting another recording.')
+  }
   if (usage.recordings >= MAX_UPLOAD_QUEUE_ENTRIES || usage.bytes >= MAX_UPLOAD_QUEUE_BYTES) {
     throw new Error('Local recording storage is full. Wait for pending uploads to finish before starting another recording.')
   }
@@ -827,21 +861,37 @@ async function markInterruptedSpoolRecordings(): Promise<void> {
     const message = counts.video_audio > 0
       ? 'Recording was interrupted before finalization; saved chunks cannot be safely uploaded as a complete recording.'
       : INTERRUPTED_RECORDING_MESSAGE
-    const nextRecord: RecordingSpoolRecord = {
-      ...record,
-      status: 'failed_unrecoverable',
-      error: message,
-      nextRetryAt: null,
-      updatedAt: new Date().toISOString()
+    await markSpoolRecordFailedUnrecoverable(record, message)
+  }
+}
+
+async function readLocalRecordingHistory(): Promise<RecordingHistoryItem[]> {
+  const response = await chrome.runtime.sendMessage({ type: 'READ_RECORDING_HISTORY' }).catch(() => null)
+  return Array.isArray(response?.items) ? response.items as RecordingHistoryItem[] : []
+}
+
+async function markOrphanedPendingHistoryItems(uploadableSpoolLocalIds: Set<string>): Promise<void> {
+  const history = await readLocalRecordingHistory()
+  for (const item of history) {
+    if (
+      ORPHANED_PENDING_UPLOAD_STATUSES.includes(item.status) &&
+      !uploadableSpoolLocalIds.has(item.localId)
+    ) {
+      await persistHistoryItem({
+        ...item,
+        status: 'failed_unrecoverable',
+        error: 'Recording data is missing from the local spool. Start a new recording to retry.',
+        nextRetryAt: null,
+        updatedAt: new Date().toISOString()
+      })
     }
-    await updateSpoolRecording(nextRecord)
-    await persistHistoryItem(nextRecord)
   }
 }
 
 async function restoreUploadQueueFromSpool(): Promise<void> {
   await markInterruptedSpoolRecordings()
   const records = await listUploadableSpoolRecordings()
+  await markOrphanedPendingHistoryItems(new Set(records.map(record => record.localId)))
   let restored = 0
   const canResumeAuthRequired = await requestMeet2NoteExtensionToken()
     .then(() => true)
@@ -864,15 +914,7 @@ async function restoreUploadQueueFromSpool(): Promise<void> {
       updatedAt: new Date().toISOString()
     })
     if (!entry) {
-      const failedRecord: RecordingSpoolRecord = {
-        ...record,
-        status: 'failed_unrecoverable',
-        error: 'Recording data is missing from the local spool.',
-        nextRetryAt: null,
-        updatedAt: new Date().toISOString()
-      }
-      await updateSpoolRecording(failedRecord)
-      await persistHistoryItem(failedRecord)
+      await markSpoolRecordFailedUnrecoverable(record, 'Recording data is missing from the local spool.')
       continue
     }
     uploadQueue.push(entry)
@@ -1168,6 +1210,11 @@ async function prepareAndRecord(
           log('Skipping upload for abandoned recording', recordingId)
           return
         }
+        if (microphoneStoppedPromise) await microphoneStoppedPromise.catch(() => null)
+        await currentSpoolWriteQueue
+        if (currentSpoolError) throw currentSpoolError
+        if (!currentSpoolRecord) throw new Error('Missing local recording spool record.')
+
         if (currentSpoolRecord) {
           currentSpoolRecord = {
             ...currentSpoolRecord,
@@ -1177,10 +1224,6 @@ async function prepareAndRecord(
           await updateSpoolRecording(currentSpoolRecord)
           await persistHistoryItem(currentSpoolRecord)
         }
-        if (microphoneStoppedPromise) await microphoneStoppedPromise.catch(() => null)
-        await currentSpoolWriteQueue
-        if (currentSpoolError) throw currentSpoolError
-        if (!currentSpoolRecord) throw new Error('Missing local recording spool record.')
 
         const stoppedAt = new Date().toISOString()
         currentSpoolRecord = {
@@ -1206,6 +1249,7 @@ async function prepareAndRecord(
       } catch (e) {
         log('Finalize/Upload failed', e)
         captureException(e, { operation: 'finalizeRecording' })
+        await markCurrentSpoolLocalError(e instanceof Error ? e.message : String(e)).catch(() => {})
       } finally {
         cleanupRecordingResources()
         mediaRecorder = null
@@ -1225,7 +1269,7 @@ async function prepareAndRecord(
 
   if (microphoneRecorder) {
     try {
-      microphoneRecorder.start(1000)
+      microphoneRecorder.start(MEDIA_RECORDER_TIMESLICE_MS)
     } catch (e) {
       log('microphone recorder start failed; continuing with video_audio only', e)
       captureException(e, { operation: 'startMicrophoneRecorder' })
@@ -1233,7 +1277,7 @@ async function prepareAndRecord(
       microphoneRecorder = null
     }
   }
-  mediaRecorder.start(1000)
+  mediaRecorder.start(MEDIA_RECORDER_TIMESLICE_MS)
 
   // Jeśli karta nawiguje albo kończy się ścieżka wideo, zatrzymaj automatycznie.
   baseStream.getVideoTracks()[0]?.addEventListener('ended', () => {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -549,6 +549,7 @@ async function markSpoolRecordFailedUnrecoverable(
 
 async function markCurrentSpoolLocalError(message: string): Promise<void> {
   if (!currentSpoolRecord) return
+  const localId = currentSpoolRecord.localId
   currentSpoolRecord = {
     ...currentSpoolRecord,
     status: 'local_error',
@@ -558,6 +559,12 @@ async function markCurrentSpoolLocalError(message: string): Promise<void> {
   }
   await updateSpoolRecording(currentSpoolRecord)
   await persistHistoryItem(currentSpoolRecord)
+  await deleteSpoolChunks(localId).catch((e) => {
+    captureException(e, {
+      operation: 'markCurrentSpoolLocalError.deleteSpoolChunks',
+      localId
+    })
+  })
 }
 
 function uploadInputFromQueueEntry(entry: UploadQueueEntry): UploadRecordingInput {
@@ -1011,6 +1018,12 @@ function markCurrentSpoolFailedUnrecoverable(message: string): void {
   currentSpoolRecord = nextRecord
   void updateSpoolRecording(nextRecord).catch(() => {})
   void persistHistoryItem(nextRecord).catch(() => {})
+  void deleteSpoolChunks(nextRecord.localId).catch((e) => {
+    captureException(e, {
+      operation: 'markCurrentSpoolFailedUnrecoverable.deleteSpoolChunks',
+      localId: nextRecord.localId
+    })
+  })
 }
 
 function forceClearStuckRecording(recordingId: number, reason: string, error?: unknown): void {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -126,6 +126,8 @@ function formatTime(value: string): string {
 }
 
 function getHistoryStatusText(item: RecordingHistoryItem, now: number): string {
+  if (item.status === 'recording') return 'Recording - saved locally'
+  if (item.status === 'finalizing') return 'Saving local recording'
   if (item.status === 'queued') return 'Waiting to upload'
   if (item.status === 'uploading') return item.attempt > 1 ? `Uploading, attempt ${item.attempt}` : 'Uploading...'
   if (item.status === 'retrying') {
@@ -139,14 +141,16 @@ function getHistoryStatusText(item: RecordingHistoryItem, now: number): string {
   if (item.status === 'ready') return 'Ready in Meet2Note'
   if (item.status === 'uploaded') return item.backendRecordingId ? `Uploaded: ${item.backendRecordingId}` : 'Uploaded'
   if (item.status === 'auth_required') return 'Reconnect to upload'
+  if (item.status === 'local_error') return item.error || 'Local save failed'
+  if (item.status === 'failed_unrecoverable') return item.error || 'Recording could not be recovered'
   return item.error || 'Upload failed'
 }
 
 function getHistoryTagColor(status: RecordingUploadStatus): string {
   if (status === 'uploaded' || status === 'ready') return 'success'
-  if (status === 'failed' || status === 'auth_required') return 'error'
+  if (status === 'failed' || status === 'auth_required' || status === 'local_error' || status === 'failed_unrecoverable') return 'error'
   if (status === 'retrying') return 'warning'
-  if (status === 'uploading' || status === 'processing' || status === 'pending') return 'processing'
+  if (status === 'recording' || status === 'finalizing' || status === 'uploading' || status === 'processing' || status === 'pending') return 'processing'
   return 'default'
 }
 

--- a/src/recordingHistory.ts
+++ b/src/recordingHistory.ts
@@ -1,6 +1,8 @@
 import type { UploadAsset } from './uploadClient'
 
 export type RecordingUploadStatus =
+  | 'recording'
+  | 'finalizing'
   | 'queued'
   | 'uploading'
   | 'retrying'
@@ -9,6 +11,8 @@ export type RecordingUploadStatus =
   | 'processing'
   | 'ready'
   | 'auth_required'
+  | 'local_error'
+  | 'failed_unrecoverable'
   | 'failed'
 
 export type RecordingUploadAsset = UploadAsset
@@ -43,6 +47,8 @@ type StoredRecordingHistory = Partial<Record<typeof RECORDING_HISTORY_KEY, unkno
 let recordingHistoryWriteQueue: Promise<unknown> = Promise.resolve()
 
 const NON_TERMINAL_STATUSES = new Set<RecordingUploadStatus>([
+  'recording',
+  'finalizing',
   'queued',
   'uploading',
   'retrying',
@@ -54,6 +60,8 @@ export function isTerminalRecordingStatus(status: RecordingUploadStatus): boolea
     status === 'pending' ||
     status === 'processing' ||
     status === 'ready' ||
+    status === 'local_error' ||
+    status === 'failed_unrecoverable' ||
     status === 'failed'
 }
 
@@ -88,11 +96,15 @@ function isRecordingUploadStatus(value: unknown): value is RecordingUploadStatus
   return value === 'queued' ||
     value === 'uploading' ||
     value === 'retrying' ||
+    value === 'recording' ||
+    value === 'finalizing' ||
     value === 'uploaded' ||
     value === 'pending' ||
     value === 'processing' ||
     value === 'ready' ||
     value === 'auth_required' ||
+    value === 'local_error' ||
+    value === 'failed_unrecoverable' ||
     value === 'failed'
 }
 

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -222,18 +222,50 @@ export async function deleteSpoolChunks(localId: string): Promise<void> {
   })
 }
 
+export async function deleteSpoolRecording(localId: string): Promise<void> {
+  await enqueueSpoolWrite(async () => {
+    const db = await openSpoolDb()
+    const tx = db.transaction(RECORDINGS_STORE, 'readwrite')
+    tx.objectStore(RECORDINGS_STORE).delete(localId)
+    await transactionComplete(tx)
+  })
+}
+
+async function sumChunkSizes(): Promise<number> {
+  const db = await openSpoolDb()
+  const tx = db.transaction(CHUNKS_STORE, 'readonly')
+  const store = tx.objectStore(CHUNKS_STORE)
+  const complete = transactionComplete(tx)
+  let totalBytes = 0
+
+  await new Promise<void>((resolve, reject) => {
+    const request = store.openCursor()
+    request.onerror = () => reject(request.error || new Error('Recording spool cursor failed.'))
+    request.onsuccess = () => {
+      const cursor = request.result
+      if (!cursor) {
+        resolve()
+        return
+      }
+      const chunk = cursor.value as RecordingSpoolChunk
+      totalBytes += chunk.sizeBytes
+      cursor.continue()
+    }
+  })
+  await complete
+  return totalBytes
+}
+
 export async function getSpoolUsage(): Promise<{ recordings: number; bytes: number }> {
   const db = await openSpoolDb()
-  const [records, chunks] = await Promise.all([
+  const [records, bytes] = await Promise.all([
     requestResult<RecordingSpoolRecord[]>(
       db.transaction(RECORDINGS_STORE, 'readonly').objectStore(RECORDINGS_STORE).getAll()
     ),
-    requestResult<RecordingSpoolChunk[]>(
-      db.transaction(CHUNKS_STORE, 'readonly').objectStore(CHUNKS_STORE).getAll()
-    )
+    sumChunkSizes()
   ])
   return {
     recordings: records.filter(record => countsAgainstSpoolCapacity(record.status)).length,
-    bytes: chunks.reduce((total, chunk) => total + chunk.sizeBytes, 0)
+    bytes
   }
 }

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -92,6 +92,15 @@ function isUploadableStatus(status: RecordingUploadStatus): boolean {
     status === 'auth_required'
 }
 
+function countsAgainstSpoolCapacity(status: RecordingUploadStatus): boolean {
+  return status === 'recording' ||
+    status === 'finalizing' ||
+    status === 'queued' ||
+    status === 'uploading' ||
+    status === 'retrying' ||
+    status === 'auth_required'
+}
+
 export async function createSpoolRecording(record: RecordingSpoolRecord): Promise<void> {
   await enqueueSpoolWrite(async () => {
     const db = await openSpoolDb()
@@ -217,7 +226,7 @@ export async function getSpoolUsage(): Promise<{ recordings: number; bytes: numb
     )
   ])
   return {
-    recordings: records.filter(record => record.status !== 'uploaded').length,
+    recordings: records.filter(record => countsAgainstSpoolCapacity(record.status)).length,
     bytes: chunks.reduce((total, chunk) => total + chunk.sizeBytes, 0)
   }
 }

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -1,0 +1,223 @@
+import type {
+  RecordingHistoryItem,
+  RecordingUploadAsset,
+  RecordingUploadStatus
+} from './recordingHistory'
+
+const DB_NAME = 'meet2noteRecordingSpool'
+const DB_VERSION = 1
+const RECORDINGS_STORE = 'recordings'
+const CHUNKS_STORE = 'chunks'
+const LOCAL_ID_INDEX = 'localId'
+const ASSET_INDEX = 'localIdAsset'
+
+export const SPOOL_SCHEMA_VERSION = 1
+
+export interface RecordingSpoolRecord extends RecordingHistoryItem {
+  schemaVersion: number
+  videoMimeType: string
+  microphoneMimeType: string | null
+}
+
+export interface RecordingSpoolChunk {
+  id: string
+  localId: string
+  asset: RecordingUploadAsset
+  localIdAsset: string
+  sequence: number
+  blob: Blob
+  sizeBytes: number
+  mimeType: string
+  createdAt: string
+}
+
+let dbPromise: Promise<IDBDatabase> | null = null
+let spoolWriteQueue: Promise<unknown> = Promise.resolve()
+
+function openSpoolDb(): Promise<IDBDatabase> {
+  if (dbPromise) return dbPromise
+
+  dbPromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    request.onerror = () => reject(request.error || new Error('Could not open recording spool.'))
+    request.onupgradeneeded = () => {
+      const db = request.result
+      if (!db.objectStoreNames.contains(RECORDINGS_STORE)) {
+        db.createObjectStore(RECORDINGS_STORE, { keyPath: 'localId' })
+      }
+      if (!db.objectStoreNames.contains(CHUNKS_STORE)) {
+        const chunks = db.createObjectStore(CHUNKS_STORE, { keyPath: 'id' })
+        chunks.createIndex(LOCAL_ID_INDEX, 'localId', { unique: false })
+        chunks.createIndex(ASSET_INDEX, 'localIdAsset', { unique: false })
+      }
+    }
+    request.onsuccess = () => resolve(request.result)
+  })
+
+  return dbPromise
+}
+
+function transactionComplete(tx: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error || new Error('Recording spool transaction failed.'))
+    tx.onabort = () => reject(tx.error || new Error('Recording spool transaction aborted.'))
+  })
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error || new Error('Recording spool request failed.'))
+  })
+}
+
+function enqueueSpoolWrite<T>(operation: () => Promise<T>): Promise<T> {
+  const run = spoolWriteQueue.catch(() => undefined).then(operation)
+  spoolWriteQueue = run.then(
+    () => undefined,
+    () => undefined
+  )
+  return run
+}
+
+function localIdAsset(localId: string, asset: RecordingUploadAsset): string {
+  return `${localId}:${asset}`
+}
+
+function isUploadableStatus(status: RecordingUploadStatus): boolean {
+  return status === 'queued' ||
+    status === 'uploading' ||
+    status === 'retrying' ||
+    status === 'auth_required'
+}
+
+export async function createSpoolRecording(record: RecordingSpoolRecord): Promise<void> {
+  await enqueueSpoolWrite(async () => {
+    const db = await openSpoolDb()
+    const tx = db.transaction(RECORDINGS_STORE, 'readwrite')
+    tx.objectStore(RECORDINGS_STORE).put(record)
+    await transactionComplete(tx)
+  })
+}
+
+export async function updateSpoolRecording(record: RecordingSpoolRecord): Promise<void> {
+  await createSpoolRecording(record)
+}
+
+export async function getSpoolRecording(localId: string): Promise<RecordingSpoolRecord | null> {
+  const db = await openSpoolDb()
+  const tx = db.transaction(RECORDINGS_STORE, 'readonly')
+  const result = await requestResult<RecordingSpoolRecord | undefined>(
+    tx.objectStore(RECORDINGS_STORE).get(localId)
+  )
+  return result || null
+}
+
+export async function appendSpoolChunk(params: {
+  localId: string
+  asset: RecordingUploadAsset
+  sequence: number
+  blob: Blob
+  mimeType: string
+}): Promise<number> {
+  return enqueueSpoolWrite(async () => {
+    const db = await openSpoolDb()
+    const tx = db.transaction(CHUNKS_STORE, 'readwrite')
+    const chunk: RecordingSpoolChunk = {
+      id: `${params.localId}:${params.asset}:${params.sequence}`,
+      localId: params.localId,
+      asset: params.asset,
+      localIdAsset: localIdAsset(params.localId, params.asset),
+      sequence: params.sequence,
+      blob: params.blob,
+      sizeBytes: params.blob.size,
+      mimeType: params.mimeType,
+      createdAt: new Date().toISOString()
+    }
+    tx.objectStore(CHUNKS_STORE).put(chunk)
+    await transactionComplete(tx)
+    return chunk.sizeBytes
+  })
+}
+
+export async function listSpoolRecordings(): Promise<RecordingSpoolRecord[]> {
+  const db = await openSpoolDb()
+  const tx = db.transaction(RECORDINGS_STORE, 'readonly')
+  const result = await requestResult<RecordingSpoolRecord[]>(
+    tx.objectStore(RECORDINGS_STORE).getAll()
+  )
+  return result
+}
+
+export async function listUploadableSpoolRecordings(): Promise<RecordingSpoolRecord[]> {
+  const records = await listSpoolRecordings()
+  return records
+    .filter(record => isUploadableStatus(record.status))
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+}
+
+export async function listInterruptedSpoolRecordings(): Promise<RecordingSpoolRecord[]> {
+  const records = await listSpoolRecordings()
+  return records.filter(record => record.status === 'recording' || record.status === 'finalizing')
+}
+
+async function getChunksByIndex(localId: string, asset: RecordingUploadAsset): Promise<RecordingSpoolChunk[]> {
+  const db = await openSpoolDb()
+  const tx = db.transaction(CHUNKS_STORE, 'readonly')
+  const index = tx.objectStore(CHUNKS_STORE).index(ASSET_INDEX)
+  const chunks = await requestResult<RecordingSpoolChunk[]>(
+    index.getAll(localIdAsset(localId, asset))
+  )
+  return chunks.sort((a, b) => a.sequence - b.sequence)
+}
+
+export async function readSpoolAssetBlob(
+  localId: string,
+  asset: RecordingUploadAsset,
+  fallbackMimeType: string
+): Promise<Blob | null> {
+  const chunks = await getChunksByIndex(localId, asset)
+  if (!chunks.length) return null
+  const mimeType = chunks.find(chunk => chunk.mimeType)?.mimeType || fallbackMimeType
+  return new Blob(chunks.map(chunk => chunk.blob), { type: mimeType })
+}
+
+export async function getSpoolChunkCounts(localId: string): Promise<Record<RecordingUploadAsset, number>> {
+  const [videoChunks, microphoneChunks] = await Promise.all([
+    getChunksByIndex(localId, 'video_audio'),
+    getChunksByIndex(localId, 'microphone')
+  ])
+  return {
+    video_audio: videoChunks.length,
+    microphone: microphoneChunks.length
+  }
+}
+
+export async function deleteSpoolChunks(localId: string): Promise<void> {
+  await enqueueSpoolWrite(async () => {
+    const db = await openSpoolDb()
+    const tx = db.transaction(CHUNKS_STORE, 'readwrite')
+    const store = tx.objectStore(CHUNKS_STORE)
+    const index = store.index(LOCAL_ID_INDEX)
+    const keys = await requestResult<IDBValidKey[]>(index.getAllKeys(localId))
+    for (const key of keys) store.delete(key)
+    await transactionComplete(tx)
+  })
+}
+
+export async function getSpoolUsage(): Promise<{ recordings: number; bytes: number }> {
+  const db = await openSpoolDb()
+  const [records, chunks] = await Promise.all([
+    requestResult<RecordingSpoolRecord[]>(
+      db.transaction(RECORDINGS_STORE, 'readonly').objectStore(RECORDINGS_STORE).getAll()
+    ),
+    requestResult<RecordingSpoolChunk[]>(
+      db.transaction(CHUNKS_STORE, 'readonly').objectStore(CHUNKS_STORE).getAll()
+    )
+  ])
+  return {
+    recordings: records.filter(record => record.status !== 'uploaded').length,
+    bytes: chunks.reduce((total, chunk) => total + chunk.sizeBytes, 0)
+  }
+}

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -39,7 +39,14 @@ function openSpoolDb(): Promise<IDBDatabase> {
 
   dbPromise = new Promise((resolve, reject) => {
     const request = indexedDB.open(DB_NAME, DB_VERSION)
-    request.onerror = () => reject(request.error || new Error('Could not open recording spool.'))
+    request.onerror = () => {
+      dbPromise = null
+      reject(request.error || new Error('Could not open recording spool.'))
+    }
+    request.onblocked = () => {
+      dbPromise = null
+      reject(new Error('Recording spool upgrade is blocked by another extension context.'))
+    }
     request.onupgradeneeded = () => {
       const db = request.result
       if (!db.objectStoreNames.contains(RECORDINGS_STORE)) {


### PR DESCRIPTION
## Zakres
- dodaje trwaly spool nagran w IndexedDB z zapisem chunkow w trakcie nagrywania
- odtwarza kolejke uploadu po restarcie service workera/offscreen i nie kasuje lokalnych pozycji przy chwilowej niedostepnosci wtyczki
- pokazuje nowe statusy lokalnego zapisu/odzyskiwania w popupie
- aktualizuje dokumentacje, smoke test i wersje rozszerzenia do 1.9.0
- dopisuje procesowa zasade odpowiadania na kazdy komentarz Copilota w CR

## Weryfikacja
- npm run typecheck
- make check
- scripts/smoke-test.sh

## Ryzyka i limity
- nie odzyskujemy danych, ktorych MediaRecorder nie zdazyl wyemitowac jako chunk przed awaria
- nie da sie odzyskac nagran po usunieciu profilu Chrome albo danych rozszerzenia
- przy braku miejsca w storage nagranie jest blokowane albo oznaczane jako blad lokalny
- bez zmian w uprawnieniach Chrome i bez zmian backend API

Closes #13