### PR TITLE
Fix offscreen onChanged diagnostics error

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.0",
+    "version": "1.9.1",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1,6 +1,6 @@
 // src/offscreen.ts
 
-import { captureException, captureMessage, initDiagnostics } from './diagnostics'
+import { captureException, captureMessage, initDiagnostics } from './offscreenDiagnostics'
 import {
   isMeet2NoteAuthError,
   Meet2NoteAuthError

--- a/src/offscreenDiagnostics.ts
+++ b/src/offscreenDiagnostics.ts
@@ -1,0 +1,24 @@
+let componentName = 'offscreen'
+
+export function initDiagnostics(component: string): void {
+  componentName = component
+}
+
+export function captureException(error: unknown, context?: Record<string, unknown>): void {
+  console.warn(`[${componentName}] captured exception`, error, context)
+}
+
+export function captureMessage(
+  message: string,
+  level: 'debug' | 'info' | 'warning' | 'error' = 'info',
+  context?: Record<string, unknown>
+): void {
+  const log = level === 'error'
+    ? console.error
+    : level === 'warning'
+      ? console.warn
+      : level === 'debug'
+        ? console.debug
+        : console.info
+  log(`[${componentName}] ${message}`, context)
+}

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -1,4 +1,3 @@
-import { captureException } from './diagnostics'
 import {
   makeAuthorizationHeader,
   Meet2NoteAuthError
@@ -168,31 +167,21 @@ export async function uploadRecordingOnce(
   input: UploadRecordingInput,
   extensionToken: string
 ): Promise<UploadRecordingResult> {
-  try {
-    const authHeaders = await uploadAuthHeaders(extensionToken)
-    const session = await initUpload(input, authHeaders)
-    const assets: UploadAsset[] = ['video_audio']
+  const authHeaders = await uploadAuthHeaders(extensionToken)
+  const session = await initUpload(input, authHeaders)
+  const assets: UploadAsset[] = ['video_audio']
 
-    await uploadAsset(session.recordingId, session.uploadToken, 'video', input.videoBlob, authHeaders)
+  await uploadAsset(session.recordingId, session.uploadToken, 'video', input.videoBlob, authHeaders)
 
-    if (input.microphoneBlob && input.microphoneBlob.size > 0) {
-      await uploadAsset(session.recordingId, session.uploadToken, 'microphone', input.microphoneBlob, authHeaders)
-      assets.push('microphone')
-    }
+  if (input.microphoneBlob && input.microphoneBlob.size > 0) {
+    await uploadAsset(session.recordingId, session.uploadToken, 'microphone', input.microphoneBlob, authHeaders)
+    assets.push('microphone')
+  }
 
-    await completeUpload(session.recordingId, session.uploadToken, assets, authHeaders)
+  await completeUpload(session.recordingId, session.uploadToken, assets, authHeaders)
 
-    return {
-      recordingId: session.recordingId,
-      assets
-    }
-  } catch (error) {
-    captureException(error, {
-      operation: 'uploadRecordingOnce',
-      hasMicrophoneAsset: !!input.microphoneBlob,
-      videoBytes: input.videoBlob.size,
-      microphoneBytes: input.microphoneBlob?.size || 0
-    })
-    throw error
+  return {
+    recordingId: session.recordingId,
+    assets
   }
 }


### PR DESCRIPTION
## Zakres
- rozdziela diagnostyke offscreen od ogolnego adaptera Sentry/browser
- usuwa posredni import `./diagnostics` z `uploadClient`, zeby offscreen bundle nie zaciagal `@sentry/browser`
- zostawia obsluge bledow uploadu w wyzszym flow offscreen, gdzie jest juz kontekst kolejki
- podbija wersje rozszerzenia do `1.9.1`

## Przyczyna
`offscreen.html` ladowal bundle zawierajacy browser SDK Sentry przez importy diagnostyki. W kontekscie Chrome offscreen taki kod jest zbyt szeroki i mogl dotykac API niedostepnych w tym runtime, co objawialo sie bledami `Cannot read properties of undefined (reading 'onChanged')`.

## Weryfikacja
- `npm run typecheck`
- `make check`
- `scripts/smoke-test.sh`
- `rg -n "__SENTRY|Sentry|onChanged|Cannot read properties" dist/offscreen.js || true` zwraca brak wynikow
- `dist/manifest.json` ma wersje `1.9.1`

## Uprawnienia Chrome
Bez zmian w `permissions` i `host_permissions`.

Closes #15
