### PR TITLE
[codex] Show upload progress in popup history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,11 +119,13 @@ Gdy czlowiek napisze `+PR`, uruchom lokalna procedure pracy z Pull Requestem.
 
 2. Review Copilota
    a) Popros o review Copilota, jesli repozytorium to obsluguje.
-   b) Poczekaj na wynik review.
-   c) Do odwolania wykonuj tylko jedna runde PR/CR z Copilotem.
-   d) Jesli Copilot zglosi techniczne uwagi, wdrazaj je wedlug wlasnej rekomendacji bez pytania czlowieka o kazda z nich.
-   e) Pytaj czlowieka tylko wtedy, gdy uwaga jest trade-offem, moze zmienic zalozenia funkcjonalne albo wymaga decyzji produktowej.
-   f) Jesli pytasz o uwage CR, podaj licznik w formacie `Pytanie X z Y` i wyjasnij kontekst szerzej niz jednym zdaniem.
+   b) Jesli Copilot Code review jest wlaczony przez ruleset repozytorium, traktuj wypchniecie PR-a jako podstawowy trigger review; nie probuj dodawac `copilot-pull-request-reviewer` przez zwykle API review request, bo GitHub moze odrzucic to jako zwyklego collaboratora.
+   c) Jesli review nie startuje automatycznie, uzyj dostepnego w UI GitHuba triggera Copilot review albo komentarza `@copilot review`, a potem sprawdz `gh pr view`/review threads.
+   d) Poczekaj na wynik review Copilota, ale po jego otrzymaniu od razu przystap do analizy i poprawek; nie czekaj na zakonczenie CI, jesli review juz jest dostepne.
+   e) Do odwolania wykonuj tylko jedna runde PR/CR z Copilotem.
+   f) Jesli Copilot zglosi techniczne uwagi, wdrazaj je wedlug wlasnej rekomendacji bez pytania czlowieka o kazda z nich.
+   g) Pytaj czlowieka tylko wtedy, gdy uwaga jest trade-offem, moze zmienic zalozenia funkcjonalne albo wymaga decyzji produktowej.
+   h) Jesli pytasz o uwage CR, podaj licznik w formacie `Pytanie X z Y` i wyjasnij kontekst szerzej niz jednym zdaniem.
 
 3. Odpowiedzi do review
    a) Na kazda uwage Copilota odpowiedz w watku:
@@ -144,6 +146,7 @@ Gdy czlowiek napisze `+PR`, uruchom lokalna procedure pracy z Pull Requestem.
    a) Copilot jest reviewerem pomocniczym, nie decydentem.
    b) Decyzje techniczne podejmuj samodzielnie wedlug najlepszej rekomendacji, respektujac architekture projektu.
    c) Decyzje produktowe, trade-offy i zmiany zalozen funkcjonalnych nadal eskaluj do czlowieka.
+   d) Jesli czlowiek koryguje sposob pracy agenta i wskazuje, ze zasada ma obowiazywac na przyszlosc, zapisz ja od razu w `AGENTS.md` albo odpowiedniej dokumentacji procesu, o ile nie jest jednorazowa ani sprzeczna z nadrzednymi instrukcjami.
 
 ## Chrome Extension
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.12",
+    "version": "1.9.16",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/src/background.ts
+++ b/src/background.ts
@@ -785,12 +785,12 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
       try {
         const localHistory = await upsertRecordingHistoryItem(item)
-        recentRecordings = localHistory.slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+        recentRecordings = mergeRecordingHistory(localHistory, backendRecordings).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
         broadcastUploadQueueState()
         sendResponse({ ok: true, items: recentRecordings })
 
         if (item.status === 'processing_queued' && item.backendRecordingId) {
-          scheduleBackendRecordingsRefresh()
+          scheduleBackendRecordingsRefresh(true)
         }
       } catch (e: any) {
         captureException(e, { operation: 'UPSERT_RECORDING_HISTORY_ITEM' })

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -753,7 +753,7 @@ function getNextUploadRetryDelayMs(now: number): number | null {
 async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'done' | 'auth_required'> {
   while (true) {
     const attempt = entry.attempt + 1
-    let lastPersistedProgressPercent = -1
+    let lastPersistedProgressPercent = 0
     let lastProgressPersistedAt = 0
     let acceptingProgressUpdates = true
     let progressPersistQueue: Promise<unknown> = Promise.resolve()
@@ -771,12 +771,7 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
           ? Math.max(0, Math.min(100, Math.floor((progress.loadedBytes / progress.totalBytes) * 100)))
           : 0
         const now = Date.now()
-        if (
-          percent === lastPersistedProgressPercent ||
-          (percent < 100 && percent - lastPersistedProgressPercent < 1 && now - lastProgressPersistedAt < 1000)
-        ) {
-          return
-        }
+        if (percent === lastPersistedProgressPercent && now - lastProgressPersistedAt < 1000) return
         lastPersistedProgressPercent = percent
         lastProgressPersistedAt = now
         progressPersistQueue = progressPersistQueue

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -65,7 +65,11 @@ function log(...a: any[]) { console.log('[offscreen]', ...a) }
 function connectPort(): chrome.runtime.Port {
   try { portRef?.disconnect() } catch {}
   const p: chrome.runtime.Port = chrome.runtime.connect({ name: 'offscreen' })
-  p.onDisconnect.addListener(() => { log('Port disconnected'); portRef = null })
+  p.onMessage.addListener(handleOffscreenPortMessage)
+  p.onDisconnect.addListener(() => {
+    log('Port disconnected')
+    if (portRef === p) portRef = null
+  })
   // Poinformuj tło, że offscreen działa.
   p.postMessage({ type: 'OFFSCREEN_READY' })
   log('READY signaled via Port')
@@ -668,7 +672,8 @@ async function updateQueueEntry(
     'backendRecordingId' |
     'assets' |
     'error' |
-    'failureReason'
+    'failureReason' |
+    'uploadProgressPercent'
   >> = {}
 ): Promise<void> {
   const nextEntry: UploadQueueEntry = {
@@ -748,20 +753,56 @@ function getNextUploadRetryDelayMs(now: number): number | null {
 async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'done' | 'auth_required'> {
   while (true) {
     const attempt = entry.attempt + 1
+    let lastPersistedProgressPercent = -1
+    let lastProgressPersistedAt = 0
+    let acceptingProgressUpdates = true
+    let progressPersistQueue: Promise<unknown> = Promise.resolve()
     await updateQueueEntry(entry, 'uploading', {
       attempt,
       nextRetryAt: null,
-      error: null
+      error: null,
+      uploadProgressPercent: 0
     })
 
     try {
       const extensionToken = await requestMeet2NoteExtensionToken()
-      const result = await uploadRecordingOnce(uploadInputFromQueueEntry(entry), extensionToken)
+      const result = await uploadRecordingOnce(uploadInputFromQueueEntry(entry), extensionToken, (progress) => {
+        const percent = progress.totalBytes > 0
+          ? Math.max(0, Math.min(100, Math.floor((progress.loadedBytes / progress.totalBytes) * 100)))
+          : 0
+        const now = Date.now()
+        if (
+          percent === lastPersistedProgressPercent ||
+          (percent < 100 && percent - lastPersistedProgressPercent < 1 && now - lastProgressPersistedAt < 1000)
+        ) {
+          return
+        }
+        lastPersistedProgressPercent = percent
+        lastProgressPersistedAt = now
+        progressPersistQueue = progressPersistQueue
+          .catch(() => undefined)
+          .then(async () => {
+            if (!acceptingProgressUpdates || entry.status !== 'uploading') return
+            await updateQueueEntry(entry, 'uploading', {
+              uploadProgressPercent: percent
+            })
+          })
+          .catch((e) => {
+            captureException(e, {
+              operation: 'uploadQueueEntryUntilTerminal.progress',
+              localId: entry.localId,
+              percent
+            })
+          })
+      })
+      acceptingProgressUpdates = false
+      await progressPersistQueue.catch(() => undefined)
       await updateQueueEntry(entry, 'processing_queued', {
         backendRecordingId: result.recordingId,
         assets: result.assets,
         nextRetryAt: null,
-        error: null
+        error: null,
+        uploadProgressPercent: null
       })
       await cleanupTerminalSpoolEntry(entry.localId, 'uploadQueueEntryUntilTerminal.cleanupUploaded')
       removeQueueEntry(entry.localId)
@@ -769,6 +810,8 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
       return 'done'
     } catch (e) {
       if (isMeet2NoteAuthError(e)) {
+        acceptingProgressUpdates = false
+        await progressPersistQueue.catch(() => undefined)
         const message = e.message || 'Connect to Meet2Note before uploading.'
         await chrome.runtime.sendMessage({
           type: 'MARK_MEET2NOTE_RECONNECT_REQUIRED',
@@ -777,7 +820,8 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
         await updateQueueEntry(entry, 'failed', {
           error: message,
           failureReason: 'auth_required',
-          nextRetryAt: null
+          nextRetryAt: null,
+          uploadProgressPercent: null
         })
         log('Upload requires Meet2Note connection', { localId: entry.localId, attempt })
         return 'auth_required'
@@ -791,10 +835,13 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
       })
       const nextRetryAt = Date.now() + UPLOAD_RETRY_INTERVAL_MS
       log('Upload failed; retrying in 15 seconds', { localId: entry.localId, error: e })
+      acceptingProgressUpdates = false
+      await progressPersistQueue.catch(() => undefined)
       await updateQueueEntry(entry, 'upload_queued', {
         error: e instanceof Error ? e.message : String(e),
         failureReason: 'upload_error',
-        nextRetryAt
+        nextRetryAt,
+        uploadProgressPercent: null
       })
       await sleep(UPLOAD_RETRY_INTERVAL_MS)
     }
@@ -1439,8 +1486,7 @@ function stopRecording(reason = 'manual'): Record<string, unknown> {
 }
 
 // RPC przez port.
-const rpcPort = getPort()
-rpcPort.onMessage.addListener(async (msg: any) => {
+async function handleOffscreenPortMessage(msg: any): Promise<void> {
   try {
     if (msg?.type === 'OFFSCREEN_START') {
       const streamId = msg.streamId as string | undefined
@@ -1504,7 +1550,9 @@ rpcPort.onMessage.addListener(async (msg: any) => {
     captureException(e, { operation: 'rpcPort.onMessage' })
     respond(msg, { ok: false, error: String(e) })
   }
-})
+}
+
+getPort()
 
 // Pozwala tłu sprawdzić stan, zanim port będzie gotowy.
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -143,9 +143,25 @@ function getHistoryTimelineText(item: RecordingHistoryItem): string {
 function getHistoryTagColor(status: RecordingUploadStatus): string {
   if (status === 'ready') return 'success'
   if (status === 'failed') return 'error'
-  if (status === 'upload_queued' || status === 'processing_queued') return 'warning'
-  if (status === 'finalizing' || status === 'uploading' || status === 'processing') return 'processing'
+  if (status === 'upload_queued') return 'warning'
+  if (status === 'finalizing' ||
+    status === 'uploading' ||
+    status === 'processing_queued' ||
+    status === 'processing') return 'processing'
   return 'default'
+}
+
+function getHistoryTagText(item: RecordingHistoryItem): string {
+  if (item.status === 'uploading') {
+    return typeof item.uploadProgressPercent === 'number'
+      ? `uploading (${item.uploadProgressPercent}%)`
+      : 'uploading'
+  }
+
+  if (item.status === 'upload_queued') return 'queued'
+  if (item.status === 'processing_queued') return item.localId.startsWith('backend:') ? 'processing' : 'uploaded'
+  if (item.status === 'finalizing') return 'saving'
+  return item.status
 }
 
 function readPopupUiCache(): PopupUiCache {
@@ -706,7 +722,7 @@ function App(): React.ReactElement {
                         color={getHistoryTagColor(item.status)}
                         style={{ marginInlineEnd: 0, fontSize: 10, lineHeight: '16px' }}
                       >
-                        {item.status}
+                        {getHistoryTagText(item)}
                       </Tag>
                     </Flex>
                     <Text type="secondary" style={{ fontSize: 11, lineHeight: 1.2 }}>

--- a/src/recordingHistory.ts
+++ b/src/recordingHistory.ts
@@ -38,6 +38,7 @@ export interface RecordingHistoryItem {
   assets: RecordingUploadAsset[]
   error: string | null
   failureReason: RecordingFailureReason | null
+  uploadProgressPercent?: number | null
   displayTimeline?: string
   createdAt: string
   updatedAt: string
@@ -148,6 +149,11 @@ function nullableNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
 
+function nullablePercent(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  return Math.max(0, Math.min(100, Math.floor(value)))
+}
+
 function sanitizeHistoryItem(value: unknown): RecordingHistoryItem | null {
   if (!value || typeof value !== 'object') return null
   const record = value as Record<string, unknown>
@@ -181,6 +187,7 @@ function sanitizeHistoryItem(value: unknown): RecordingHistoryItem | null {
     assets: sanitizeAssets(record.assets),
     error: nullableString(record.error),
     failureReason: status === 'failed' ? normalizeFailureReason(rawStatus, record.failureReason) : null,
+    uploadProgressPercent: status === 'uploading' ? nullablePercent(record.uploadProgressPercent) : null,
     displayTimeline: optionalString(record.displayTimeline),
     createdAt,
     updatedAt

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -21,6 +21,14 @@ export interface UploadRecordingResult {
   assets: UploadAsset[]
 }
 
+export interface UploadProgress {
+  asset: UploadAsset
+  loadedBytes: number
+  totalBytes: number
+  assetLoadedBytes: number
+  assetTotalBytes: number
+}
+
 interface InitUploadResponse {
   recordingId: string
   uploadToken: string
@@ -119,24 +127,57 @@ async function uploadAsset(
   uploadToken: string,
   path: 'video' | 'microphone',
   blob: Blob,
-  authHeaders: { Authorization: string }
+  authHeaders: { Authorization: string },
+  onAssetProgress?: (loadedBytes: number) => void
 ): Promise<void> {
-  const response = await fetchWithTimeout(
-    `upload ${path}`,
-    makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(recordingId)}/${path}`),
-    {
-      method: 'PUT',
-      headers: {
-        'Content-Type': 'application/octet-stream',
-        'X-Upload-Token': uploadToken,
-        ...authHeaders
-      },
-      body: blob
-    },
-    ASSET_UPLOAD_TIMEOUT_MS
-  )
+  await new Promise<void>((resolve, reject) => {
+    const operation = `upload ${path}`
+    const xhr = new XMLHttpRequest()
+    let settled = false
+    const timeoutId = setTimeout(() => {
+      if (settled) return
+      settled = true
+      try { xhr.abort() } catch {}
+      reject(new Error(`${operation} timed out after ${Math.round(ASSET_UPLOAD_TIMEOUT_MS / 1000)} seconds`))
+    }, ASSET_UPLOAD_TIMEOUT_MS)
 
-  if (!response.ok) throw httpError(`upload ${path}`, response)
+    const settle = (callback: () => void) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeoutId)
+      callback()
+    }
+
+    xhr.upload.onprogress = (event) => {
+      onAssetProgress?.(Math.min(blob.size, Math.max(0, event.loaded)))
+    }
+
+    xhr.onload = () => {
+      settle(() => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          onAssetProgress?.(blob.size)
+          resolve()
+          return
+        }
+
+        reject(httpError(operation, new Response(null, { status: xhr.status })))
+      })
+    }
+
+    xhr.onerror = () => {
+      settle(() => reject(new Error(`${operation} failed with a network error`)))
+    }
+
+    xhr.onabort = () => {
+      settle(() => reject(new Error(`${operation} was aborted`)))
+    }
+
+    xhr.open('PUT', makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(recordingId)}/${path}`))
+    xhr.setRequestHeader('Content-Type', 'application/octet-stream')
+    xhr.setRequestHeader('X-Upload-Token', uploadToken)
+    xhr.setRequestHeader('Authorization', authHeaders.Authorization)
+    xhr.send(blob)
+  })
 }
 
 async function completeUpload(
@@ -165,16 +206,48 @@ async function completeUpload(
 
 export async function uploadRecordingOnce(
   input: UploadRecordingInput,
-  extensionToken: string
+  extensionToken: string,
+  onProgress?: (progress: UploadProgress) => void
 ): Promise<UploadRecordingResult> {
   const authHeaders = await uploadAuthHeaders(extensionToken)
   const session = await initUpload(input, authHeaders)
   const assets: UploadAsset[] = ['video_audio']
+  const totalBytes = input.videoBlob.size + (input.microphoneBlob?.size || 0)
+  const loadedByAsset: Record<UploadAsset, number> = {
+    video_audio: 0,
+    microphone: 0
+  }
+  const reportProgress = (asset: UploadAsset, assetLoadedBytes: number, assetTotalBytes: number) => {
+    loadedByAsset[asset] = Math.min(assetTotalBytes, Math.max(0, assetLoadedBytes))
+    onProgress?.({
+      asset,
+      loadedBytes: loadedByAsset.video_audio + loadedByAsset.microphone,
+      totalBytes,
+      assetLoadedBytes: loadedByAsset[asset],
+      assetTotalBytes
+    })
+  }
 
-  await uploadAsset(session.recordingId, session.uploadToken, 'video', input.videoBlob, authHeaders)
+  reportProgress('video_audio', 0, input.videoBlob.size)
+  await uploadAsset(
+    session.recordingId,
+    session.uploadToken,
+    'video',
+    input.videoBlob,
+    authHeaders,
+    loadedBytes => reportProgress('video_audio', loadedBytes, input.videoBlob.size)
+  )
 
   if (input.microphoneBlob && input.microphoneBlob.size > 0) {
-    await uploadAsset(session.recordingId, session.uploadToken, 'microphone', input.microphoneBlob, authHeaders)
+    reportProgress('microphone', 0, input.microphoneBlob.size)
+    await uploadAsset(
+      session.recordingId,
+      session.uploadToken,
+      'microphone',
+      input.microphoneBlob,
+      authHeaders,
+      loadedBytes => reportProgress('microphone', loadedBytes, input.microphoneBlob!.size)
+    )
     assets.push('microphone')
   }
 


### PR DESCRIPTION
## Zakres

- Pokazuje procent uploadu w popupie jako `uploading (37%)` na podstawie bajtów wysyłanych przez `XMLHttpRequest`.
- Zachowuje progress w lokalnej historii nagrań tylko dla statusu `uploading` i czyści go przy retry albo zakończeniu.
- Uczy popup czytelniejszych etykiet (`queued`, `uploaded`, `processing`, `saving`) zamiast technicznych nazw części lokalnych statusów.
- Merguje lokalne update'y historii z ostatnio znanym stanem backendu, żeby popup nie cofał się łatwo do lokalnego statusu po odświeżeniu kolejki.
- Naprawia ponowne podpinanie handlera portu offscreen po reconnect, co pomaga kolejce uploadu po restarcie service workera/offscreen.

## Kontekst

Duże nagrania mogą wysyłać się długo, a poprzedni popup pokazywał tylko `uploading`, bez informacji czy transfer postępuje. Zmiana dodaje postęp widoczny dla użytkownika bez czyszczenia lokalnego spoolu IndexedDB ani historii nagrań.

Closes #22

## Weryfikacja

- `make check`

## Ryzyka

- Progress jest dostępny tylko dla runtime'u po przeładowaniu rozszerzenia do wersji z tym kodem.
- Chrome nadal może przerwać aktywną próbę uploadu przy ręcznym przeładowaniu rozszerzenia; ta zmiana nie czyści zapisanych lokalnie nagrań.
