### PR TITLE
Stabilize self-hosted extension CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       BUILDER_CPUS: "1.5"
       BUILDER_MEMORY_LIMIT: "1536m"
       BUILDER_NODE_OPTIONS: "--max-old-space-size=1024"
+      COMPOSE_PROJECT_NAME: extension-ci-${{ github.run_id }}-${{ github.run_attempt }}
     runs-on:
       - self-hosted
       - meet2note
@@ -31,5 +32,5 @@ jobs:
         run: make check
 
       - name: Cleanup build environment
-        if: ${{ always() && !cancelled() }}
-        run: make ci-clean || true
+        if: always()
+        run: timeout 120s make ci-clean || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,17 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    timeout-minutes: 20
+    env:
+      BUILDER_CPUS: "1.5"
+      BUILDER_MEMORY_LIMIT: "1536m"
+      BUILDER_NODE_OPTIONS: "--max-old-space-size=1024"
     runs-on:
       - self-hosted
       - meet2note
@@ -22,5 +31,5 @@ jobs:
         run: make check
 
       - name: Cleanup build environment
-        if: always()
-        run: make deps-clean || true
+        if: ${{ always() && !cancelled() }}
+        run: make ci-clean || true

--- a/.github/workflows/publish-extension-package.yml
+++ b/.github/workflows/publish-extension-package.yml
@@ -72,6 +72,7 @@ jobs:
       BUILDER_CPUS: "1.5"
       BUILDER_MEMORY_LIMIT: "1536m"
       BUILDER_NODE_OPTIONS: "--max-old-space-size=1024"
+      COMPOSE_PROJECT_NAME: extension-publish-${{ github.run_id }}-${{ github.run_attempt }}
     runs-on:
       - self-hosted
       - meet2note
@@ -95,8 +96,8 @@ jobs:
           if-no-files-found: error
 
       - name: Cleanup build environment
-        if: ${{ always() && !cancelled() }}
-        run: make ci-clean || true
+        if: always()
+        run: timeout 120s make ci-clean || true
 
   publish-to-meet2note:
     needs:

--- a/.github/workflows/publish-extension-package.yml
+++ b/.github/workflows/publish-extension-package.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   detect-version-bump:
+    timeout-minutes: 5
     runs-on:
       - self-hosted
       - meet2note
@@ -66,6 +67,11 @@ jobs:
   build-package:
     needs: detect-version-bump
     if: needs.detect-version-bump.outputs.should_publish == 'true'
+    timeout-minutes: 20
+    env:
+      BUILDER_CPUS: "1.5"
+      BUILDER_MEMORY_LIMIT: "1536m"
+      BUILDER_NODE_OPTIONS: "--max-old-space-size=1024"
     runs-on:
       - self-hosted
       - meet2note
@@ -89,14 +95,15 @@ jobs:
           if-no-files-found: error
 
       - name: Cleanup build environment
-        if: always()
-        run: make deps-clean || true
+        if: ${{ always() && !cancelled() }}
+        run: make ci-clean || true
 
   publish-to-meet2note:
     needs:
       - detect-version-bump
       - build-package
     if: needs.detect-version-bump.outputs.should_publish == 'true'
+    timeout-minutes: 10
     runs-on:
       - self-hosted
       - meet2note

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,22 @@
 COMPOSE ?= docker compose
 HOST_UID ?= $(shell id -u)
 HOST_GID ?= $(shell id -g)
+BUILDER_CPUS ?= 2
+BUILDER_MEMORY_LIMIT ?= 1536m
+BUILDER_NODE_OPTIONS ?= --max-old-space-size=1024
 SENTRY_DSN ?= $(shell scripts/sentry-public-dsn.sh || true)
 SENTRY_ENVIRONMENT ?= chrome-extension-dev
 UPLOAD_API_BASE_URL ?= https://meet2note.com
 export HOST_UID
 export HOST_GID
+export BUILDER_CPUS
+export BUILDER_MEMORY_LIMIT
+export BUILDER_NODE_OPTIONS
 export SENTRY_DSN
 export SENTRY_ENVIRONMENT
 export UPLOAD_API_BASE_URL
 
-.PHONY: build check shell clean deps-clean prepare-deps package zip
+.PHONY: build check shell clean ci-clean deps-clean prepare-deps package zip
 
 build: prepare-deps
 	$(COMPOSE) run --rm builder ./node_modules/.bin/webpack --mode=production
@@ -28,6 +34,9 @@ shell: prepare-deps
 
 clean:
 	rm -rf dist
+
+ci-clean:
+	$(COMPOSE) down --remove-orphans
 
 deps-clean:
 	$(COMPOSE) down --volumes --remove-orphans

--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ UPLOAD_API_BASE_URL=http://localhost:3000 make build
 `make zip` - alias do `make package`
 `make shell` - otwiera powłokę w kontenerze buildowym
 `make clean` - usuwa wygenerowany `dist/`
-`make deps-clean` - usuwa wolumeny zależności/cache Docker Compose
+`make ci-clean` - usuwa kontenery i sieci Docker Compose bez kasowania wolumenów zależności/cache; używane przez CI
+`make deps-clean` - usuwa także wolumeny zależności/cache Docker Compose; używaj diagnostycznie, gdy trzeba odtworzyć zależności od zera
 
 ### Sentry
 

--- a/compose.yml
+++ b/compose.yml
@@ -6,10 +6,13 @@ services:
     environment:
       HOST_UID: "${HOST_UID:-1000}"
       HOST_GID: "${HOST_GID:-1000}"
+      NODE_OPTIONS: "${BUILDER_NODE_OPTIONS:---max-old-space-size=1024}"
       SENTRY_DSN: "${SENTRY_DSN:-}"
       SENTRY_ENVIRONMENT: "${SENTRY_ENVIRONMENT:-chrome-extension-dev}"
       UPLOAD_API_BASE_URL: "${UPLOAD_API_BASE_URL:-https://meet2note.com}"
       npm_config_cache: /home/node/.npm
+    cpus: "${BUILDER_CPUS:-2}"
+    mem_limit: "${BUILDER_MEMORY_LIMIT:-1536m}"
     volumes:
       - ./package.json:/workspace/package.json:ro
       - ./package-lock.json:/workspace/package-lock.json:ro

--- a/docs/contracts/build-and-validation.md
+++ b/docs/contracts/build-and-validation.md
@@ -15,6 +15,7 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 7. Pliki w `dist/` mają być tworzone z UID/GID użytkownika hosta, żeby można je było usuwać i przebudowywać bez naprawiania uprawnień.
 8. `dist/` jest wygenerowanym wynikiem builda i nie powinien być edytowany ręcznie.
 9. Kontener `builder` ma limit CPU, RAM i heap Node.js ustawiany przez zmienne `BUILDER_CPUS`, `BUILDER_MEMORY_LIMIT` oraz `BUILDER_NODE_OPTIONS`, żeby build CI nie zagłodził usług Meet2Note działających na tym samym hoście.
+10. CI ustawia per-run `COMPOSE_PROJECT_NAME`, żeby cleanup anulowanego runa sprzątał tylko własne kontenery i sieci Compose.
 
 ## Komendy
 
@@ -36,6 +37,7 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 5. `BUILDER_CPUS` domyślnie ogranicza kontener buildowy do `2` CPU.
 6. `BUILDER_MEMORY_LIMIT` domyślnie ogranicza kontener buildowy do `1536m`.
 7. `BUILDER_NODE_OPTIONS` domyślnie ustawia `--max-old-space-size=1024`.
+8. `COMPOSE_PROJECT_NAME` może zostać nadpisane w CI albo lokalnie, gdy kilka buildów ma działać równolegle bez współdzielenia kontenerów i sieci Compose.
 
 ## Walidacja przeglądarkowa
 

--- a/docs/contracts/build-and-validation.md
+++ b/docs/contracts/build-and-validation.md
@@ -14,6 +14,7 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 6. `npm ci` jest jedynym wspieranym sposobem instalacji zależności w buildzie; zależności muszą wynikać z `package-lock.json`.
 7. Pliki w `dist/` mają być tworzone z UID/GID użytkownika hosta, żeby można je było usuwać i przebudowywać bez naprawiania uprawnień.
 8. `dist/` jest wygenerowanym wynikiem builda i nie powinien być edytowany ręcznie.
+9. Kontener `builder` ma limit CPU, RAM i heap Node.js ustawiany przez zmienne `BUILDER_CPUS`, `BUILDER_MEMORY_LIMIT` oraz `BUILDER_NODE_OPTIONS`, żeby build CI nie zagłodził usług Meet2Note działających na tym samym hoście.
 
 ## Komendy
 
@@ -23,7 +24,8 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 4. `make zip` jest aliasem do `make package`.
 5. `make shell` otwiera powłokę w kontenerze buildowym.
 6. `make clean` usuwa tylko wygenerowany katalog `dist/`.
-7. `make deps-clean` usuwa wolumeny zależności/cache i jest operacją diagnostyczną przy problemach z zależnościami.
+7. `make ci-clean` usuwa kontenery i sieci Compose bez kasowania wolumenów zależności/cache; to domyślne sprzątanie po CI.
+8. `make deps-clean` usuwa wolumeny zależności/cache i jest operacją diagnostyczną przy problemach z zależnościami.
 
 ## Konfiguracja builda
 
@@ -31,6 +33,9 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 2. `SENTRY_DSN` jest opcjonalny; jeśli nie jest ustawiony, diagnostyka Sentry nie powinna blokować builda.
 3. `SENTRY_ENVIRONMENT` domyślnie opisuje build deweloperski rozszerzenia.
 4. `HOST_UID` i `HOST_GID` są wyliczane z hosta, ale mogą zostać nadpisane z zewnątrz.
+5. `BUILDER_CPUS` domyślnie ogranicza kontener buildowy do `2` CPU.
+6. `BUILDER_MEMORY_LIMIT` domyślnie ogranicza kontener buildowy do `1536m`.
+7. `BUILDER_NODE_OPTIONS` domyślnie ustawia `--max-old-space-size=1024`.
 
 ## Walidacja przeglądarkowa
 


### PR DESCRIPTION
## Zakres
1. Dodaje `concurrency` i `timeout-minutes` do CI, żeby stare runy PR nie blokowały self-hosted runnera bez końca.
2. Ogranicza kontener buildowy przez `BUILDER_CPUS`, `BUILDER_MEMORY_LIMIT` i `BUILDER_NODE_OPTIONS`, żeby build nie zagłodził aplikacji Meet2Note działającej na tym samym LXC.
3. Zastępuje cleanup CI przez `make ci-clean`, który nie usuwa wolumenów cache po każdym runie i nie odpala się przy anulowaniu joba.
4. Dokumentuje kontrakt builda i nowe zmienne.

## Weryfikacja
1. `docker compose config >/tmp/chrome-extension-compose-config.yml`
2. `make check`
3. Runner `meet2note-extension` odzyskany i poprzedni run PR #24 przeszedł na zielono po zwiększeniu limitu LXC do 8 GB RAM / 4 GB swap.

## Ryzyka
1. Build CI ma teraz limit 1536 MB RAM i 1024 MB heap Node.js; jeśli bundle mocno urośnie, job powinien failować zamiast zawieszać współdzielony host.
2. Brak zmian w uprawnieniach Chrome.
