### PR TITLE
Implement chunked resumable upload

### DIFF
--- a/docs/contracts/meet2note-upload.md
+++ b/docs/contracts/meet2note-upload.md
@@ -30,14 +30,24 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
    c) `meetingTitle`, jeśli da się go ustalić bez kruchego parsowania UI,
    d) `startedAt`,
    e) `durationMs`.
-3. Backend zwraca `recordingId`, `uploadToken` i `expiresAt`.
-4. Główny asset `video_audio` jest wysyłany przez `PUT /api/upload/{recordingId}/video`.
-5. Opcjonalny asset `microphone` jest wysyłany przez `PUT /api/upload/{recordingId}/microphone`, jeśli mikrofon jest dostępny.
-6. Upload assetów używa `Content-Type: application/octet-stream`.
-7. Upload assetów i `/complete` używają nagłówków `Authorization` oraz `X-Upload-Token`.
-8. Rozszerzenie kończy upload przez `POST /api/upload/{recordingId}/complete`.
-9. Body `/complete` zawiera tylko faktycznie wysłane assety.
-10. `uploadToken`, pełnych URL-i z tokenami ani zawartości blobów nie wolno logować.
+3. Backend zwraca `recordingId`, `uploadToken`, `expiresAt`, `uploadMode`, `recommendedChunkSizeBytes` i `maxAssetSizeBytes`.
+4. Docelowy `uploadMode` to `chunked`; rozszerzenie nie używa legacy endpointów `/video` ani `/microphone`.
+5. Dla każdego assetu rozszerzenie inicjalizuje metadane przez `PUT /api/upload/{recordingId}/assets/{asset}`.
+   a) `asset` to `video_audio` albo `microphone`.
+   b) Body zawiera `contentType`, `sizeBytes`, `chunkSizeBytes` i `totalChunks`.
+6. Przed wysyłką brakujących chunków albo po błędzie rozszerzenie pobiera stan assetu przez `GET /api/upload/{recordingId}/assets/{asset}`.
+   a) Backend zwraca między innymi `receivedChunks` i `receivedBytes`.
+   b) Rozszerzenie wysyła tylko chunki, których backend jeszcze nie przyjął.
+7. Pojedynczy chunk jest wysyłany przez `PUT /api/upload/{recordingId}/assets/{asset}/chunks/{chunkIndex}`.
+   a) Request używa `Content-Type: application/octet-stream`.
+   b) Jeden request zawiera tylko jeden chunk.
+   c) Upload chunków jest sekwencyjny w pierwszej wersji.
+8. Po przyjęciu wszystkich chunków danego assetu rozszerzenie wywołuje `POST /api/upload/{recordingId}/assets/{asset}/complete`.
+9. Rozszerzenie kończy całe nagranie przez `POST /api/upload/{recordingId}/complete`.
+10. Body globalnego `/complete` zawiera tylko faktycznie wysłane i zakończone assety.
+11. Endpointy assetów, chunków i `/complete` używają nagłówków `Authorization` oraz `X-Upload-Token`.
+12. `uploadToken`, pełnych URL-i z tokenami ani zawartości blobów nie wolno logować.
+13. Lokalny spool IndexedDB jest czyszczony dopiero po udanym globalnym `/complete`.
 
 ## Assety
 
@@ -50,10 +60,12 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 ## Błędy i autoryzacja
 
 1. Jeśli `/init` nie powiedzie się, rozszerzenie nie wysyła assetów.
-2. Jeśli upload assetu nie powiedzie się, rozszerzenie nie wywołuje `/complete`.
-3. Błędy sieciowe i HTTP trafiają do istniejącej diagnostyki bez sekretów i bez zawartości nagrań.
-4. `401` albo `403` oznacza konieczność ponownego połączenia z Meet2Note.
-5. Po `401` albo `403` rozszerzenie czyści lokalny token, oznacza odpowiednią pozycję jako wymagającą reconnect i nie ponawia zwykłego uploadu bez końca.
+2. Jeśli inicjalizacja assetu, upload chunka albo asset complete nie powiedzie się, rozszerzenie nie wywołuje globalnego `/complete`.
+3. Przy retry rozszerzenie używa zapisanego `recordingId` i `uploadToken`, jeśli sesja uploadu nie wygasła.
+4. Retry nie wysyła od początku chunków już potwierdzonych przez backend.
+5. Błędy sieciowe i HTTP trafiają do istniejącej diagnostyki bez sekretów i bez zawartości nagrań.
+6. `401` albo `403` oznacza konieczność ponownego połączenia z Meet2Note.
+7. Po `401` albo `403` rozszerzenie czyści lokalny token, oznacza odpowiednią pozycję jako wymagającą reconnect i nie ponawia zwykłego uploadu bez końca.
 
 ## Uprawnienia Chrome
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.16",
+    "version": "1.9.17",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -6,7 +6,7 @@ import {
   Meet2NoteAuthError
 } from './extensionAuth'
 import type { MicPreferences } from './micPreferences'
-import { uploadRecordingOnce, type UploadRecordingInput } from './uploadClient'
+import { uploadRecordingOnce, type UploadRecordingInput, type UploadSessionState } from './uploadClient'
 import {
   generateRecordingLocalId,
   normalizeRecordingHistoryItem,
@@ -25,6 +25,7 @@ import {
   readSpoolAssetBlob,
   SPOOL_SCHEMA_VERSION,
   updateSpoolRecording,
+  type RecordingSpoolUploadSession,
   type RecordingSpoolRecord
 } from './recordingSpool'
 
@@ -124,6 +125,7 @@ function sleepUntilUploadQueueWakeOrTimeout(ms: number): Promise<void> {
 interface UploadQueueEntry extends RecordingHistoryItem {
   videoBlob: Blob
   microphoneBlob: Blob | null
+  uploadSession?: RecordingSpoolUploadSession | null
 }
 
 let uploadQueue: UploadQueueEntry[] = []
@@ -135,6 +137,7 @@ function toHistoryItem(entry: UploadQueueEntry): RecordingHistoryItem {
   const {
     videoBlob: _videoBlob,
     microphoneBlob: _microphoneBlob,
+    uploadSession: _uploadSession,
     ...historyItem
   } = entry
   return historyItem
@@ -145,7 +148,8 @@ async function persistQueueEntry(entry: UploadQueueEntry): Promise<void> {
     ...toHistoryItem(entry),
     schemaVersion: SPOOL_SCHEMA_VERSION,
     videoMimeType: entry.videoBlob.type || 'video/webm',
-    microphoneMimeType: entry.microphoneBlob?.type || null
+    microphoneMimeType: entry.microphoneBlob?.type || null,
+    uploadSession: entry.uploadSession ?? null
   })
   await persistHistoryItem(toHistoryItem(entry))
 }
@@ -504,6 +508,7 @@ function buildSpoolRecording(
     attempt: 0,
     nextRetryAt: null,
     backendRecordingId: null,
+    uploadSession: null,
     assets: microphoneEnabled ? ['video_audio', 'microphone'] : ['video_audio'],
     error: null,
     failureReason: null,
@@ -670,6 +675,7 @@ async function updateQueueEntry(
     'attempt' |
     'nextRetryAt' |
     'backendRecordingId' |
+    'uploadSession' |
     'assets' |
     'error' |
     'failureReason' |
@@ -766,7 +772,17 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
 
     try {
       const extensionToken = await requestMeet2NoteExtensionToken()
-      const result = await uploadRecordingOnce(uploadInputFromQueueEntry(entry), extensionToken, (progress) => {
+      const uploadInput: UploadRecordingInput = {
+        ...uploadInputFromQueueEntry(entry),
+        uploadSession: entry.uploadSession ?? null,
+        onUploadSession: async (session: UploadSessionState) => {
+          await updateQueueEntry(entry, 'uploading', {
+            backendRecordingId: session.recordingId,
+            uploadSession: session
+          })
+        }
+      }
+      const result = await uploadRecordingOnce(uploadInput, extensionToken, (progress) => {
         const percent = progress.totalBytes > 0
           ? Math.max(0, Math.min(100, Math.floor((progress.loadedBytes / progress.totalBytes) * 100)))
           : 0

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -810,6 +810,7 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
       await progressPersistQueue.catch(() => undefined)
       await updateQueueEntry(entry, 'processing_queued', {
         backendRecordingId: result.recordingId,
+        uploadSession: null,
         assets: result.assets,
         nextRetryAt: null,
         error: null,

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -13,10 +13,19 @@ const ASSET_INDEX = 'localIdAsset'
 
 export const SPOOL_SCHEMA_VERSION = 1
 
+export interface RecordingSpoolUploadSession {
+  recordingId: string
+  uploadToken: string
+  expiresAt: string
+  recommendedChunkSizeBytes?: number
+  maxAssetSizeBytes?: number
+}
+
 export interface RecordingSpoolRecord extends RecordingHistoryItem {
   schemaVersion: number
   videoMimeType: string
   microphoneMimeType: string | null
+  uploadSession?: RecordingSpoolUploadSession | null
 }
 
 export interface RecordingSpoolChunk {
@@ -118,8 +127,34 @@ function normalizeSpoolRecord(record: RecordingSpoolRecord): RecordingSpoolRecor
       : 'video/webm',
     microphoneMimeType: typeof record.microphoneMimeType === 'string' && record.microphoneMimeType
       ? record.microphoneMimeType
-      : null
+      : null,
+    uploadSession: normalizeUploadSession(record.uploadSession)
   }
+}
+
+function normalizeUploadSession(value: unknown): RecordingSpoolUploadSession | null {
+  if (!value || typeof value !== 'object') return null
+  const record = value as Record<string, unknown>
+  const recordingId = record.recordingId
+  const uploadToken = record.uploadToken
+  const expiresAt = record.expiresAt
+  if (typeof recordingId !== 'string' || !recordingId) return null
+  if (typeof uploadToken !== 'string' || !uploadToken) return null
+  if (typeof expiresAt !== 'string' || !expiresAt) return null
+
+  return {
+    recordingId,
+    uploadToken,
+    expiresAt,
+    recommendedChunkSizeBytes: positiveNumberOrUndefined(record.recommendedChunkSizeBytes),
+    maxAssetSizeBytes: positiveNumberOrUndefined(record.maxAssetSizeBytes)
+  }
+}
+
+function positiveNumberOrUndefined(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined
 }
 
 export async function createSpoolRecording(record: RecordingSpoolRecord): Promise<void> {

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -6,6 +6,14 @@ import { makeMeet2NoteUrl } from './meet2noteConfig'
 
 export type UploadAsset = 'video_audio' | 'microphone'
 
+export interface UploadSessionState {
+  recordingId: string
+  uploadToken: string
+  expiresAt: string
+  recommendedChunkSizeBytes?: number
+  maxAssetSizeBytes?: number
+}
+
 export interface UploadRecordingInput {
   title: string
   meetingId?: string
@@ -14,6 +22,8 @@ export interface UploadRecordingInput {
   durationMs?: number
   videoBlob: Blob
   microphoneBlob?: Blob | null
+  uploadSession?: UploadSessionState | null
+  onUploadSession?: (session: UploadSessionState) => void | Promise<void>
 }
 
 export interface UploadRecordingResult {
@@ -29,15 +39,39 @@ export interface UploadProgress {
   assetTotalBytes: number
 }
 
-interface InitUploadResponse {
+interface InitUploadResponse extends UploadSessionState {
+  uploadMode?: string
+}
+
+interface UploadAssetState {
   recordingId: string
-  uploadToken: string
-  expiresAt: string
+  asset: UploadAsset
+  status: 'initialized' | 'uploading' | 'complete'
+  sizeBytes: number
+  chunkSizeBytes: number
+  totalChunks: number
+  receivedChunks: number[]
+  receivedBytes: number
+}
+
+interface UploadChunkResponse {
+  recordingId: string
+  asset: UploadAsset
+  chunkIndex: number
+  status: 'accepted'
+  sizeBytes: number
+  receivedBytes: number
+  totalBytes: number
 }
 
 const INIT_UPLOAD_TIMEOUT_MS = 30_000
 const COMPLETE_UPLOAD_TIMEOUT_MS = 30_000
-const ASSET_UPLOAD_TIMEOUT_MS = 20 * 60_000
+const ASSET_METADATA_TIMEOUT_MS = 30_000
+const ASSET_COMPLETE_TIMEOUT_MS = 10 * 60_000
+const CHUNK_UPLOAD_TIMEOUT_MS = 5 * 60_000
+const DEFAULT_CHUNK_SIZE_BYTES = 16 * 1024 * 1024
+const MAX_CHUNK_SIZE_BYTES = 32 * 1024 * 1024
+const SESSION_EXPIRY_SKEW_MS = 60_000
 
 function httpError(operation: string, response: Response): Error {
   if (response.status === 401 || response.status === 403) {
@@ -70,25 +104,142 @@ async function fetchWithTimeout(
   }
 }
 
-async function parseInitResponse(response: Response): Promise<InitUploadResponse> {
-  const data = await response.json().catch(() => null)
-  if (!data || typeof data !== 'object') throw new Error('init upload returned invalid JSON')
+function numberOrUndefined(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined
+}
 
-  const recordingId = (data as { recordingId?: unknown }).recordingId
-  const uploadToken = (data as { uploadToken?: unknown }).uploadToken
-  const expiresAt = (data as { expiresAt?: unknown }).expiresAt
+async function parseJsonObject(response: Response, operation: string): Promise<Record<string, unknown>> {
+  const data = await response.json().catch(() => null)
+  if (!data || typeof data !== 'object') throw new Error(`${operation} returned invalid JSON`)
+  return data as Record<string, unknown>
+}
+
+async function parseInitResponse(response: Response): Promise<InitUploadResponse> {
+  const data = await parseJsonObject(response, 'init upload')
+
+  const recordingId = data.recordingId
+  const uploadToken = data.uploadToken
+  const expiresAt = data.expiresAt
+  const uploadMode = data.uploadMode
 
   if (typeof recordingId !== 'string' || !recordingId) throw new Error('init upload missing recordingId')
   if (typeof uploadToken !== 'string' || !uploadToken) throw new Error('init upload missing uploadToken')
   if (typeof expiresAt !== 'string' || !expiresAt) throw new Error('init upload missing expiresAt')
+  if (uploadMode !== undefined && uploadMode !== 'chunked') {
+    throw new Error(`unsupported upload mode: ${String(uploadMode)}`)
+  }
 
-  return { recordingId, uploadToken, expiresAt }
+  return {
+    recordingId,
+    uploadToken,
+    expiresAt,
+    uploadMode: typeof uploadMode === 'string' ? uploadMode : undefined,
+    recommendedChunkSizeBytes: numberOrUndefined(data.recommendedChunkSizeBytes),
+    maxAssetSizeBytes: numberOrUndefined(data.maxAssetSizeBytes)
+  }
+}
+
+function parseReceivedChunks(value: unknown, totalChunks: number): number[] {
+  if (!Array.isArray(value)) return []
+  const chunks: number[] = []
+  const seen = new Set<number>()
+  for (const item of value) {
+    if (!Number.isInteger(item) || item < 0 || item >= totalChunks || seen.has(item)) continue
+    seen.add(item)
+    chunks.push(item)
+  }
+  return chunks.sort((a, b) => a - b)
+}
+
+async function parseAssetState(response: Response, operation: string): Promise<UploadAssetState> {
+  const data = await parseJsonObject(response, operation)
+  const recordingId = data.recordingId
+  const asset = data.asset
+  const status = data.status
+  const sizeBytes = data.sizeBytes
+  const chunkSizeBytes = data.chunkSizeBytes
+  const totalChunks = data.totalChunks
+  const receivedBytes = data.receivedBytes
+
+  if (typeof recordingId !== 'string' || !recordingId) throw new Error(`${operation} missing recordingId`)
+  if (asset !== 'video_audio' && asset !== 'microphone') throw new Error(`${operation} returned invalid asset`)
+  if (status !== 'initialized' && status !== 'uploading' && status !== 'complete') {
+    throw new Error(`${operation} returned invalid asset status`)
+  }
+  if (typeof sizeBytes !== 'number' || !Number.isInteger(sizeBytes) || sizeBytes <= 0) {
+    throw new Error(`${operation} returned invalid sizeBytes`)
+  }
+  if (typeof chunkSizeBytes !== 'number' || !Number.isInteger(chunkSizeBytes) || chunkSizeBytes <= 0) {
+    throw new Error(`${operation} returned invalid chunkSizeBytes`)
+  }
+  if (typeof totalChunks !== 'number' || !Number.isInteger(totalChunks) || totalChunks <= 0) {
+    throw new Error(`${operation} returned invalid totalChunks`)
+  }
+  if (typeof receivedBytes !== 'number' || !Number.isInteger(receivedBytes) || receivedBytes < 0) {
+    throw new Error(`${operation} returned invalid receivedBytes`)
+  }
+
+  return {
+    recordingId,
+    asset,
+    status,
+    sizeBytes,
+    chunkSizeBytes,
+    totalChunks,
+    receivedChunks: parseReceivedChunks(data.receivedChunks, totalChunks),
+    receivedBytes
+  }
+}
+
+async function parseChunkResponse(response: Response, operation: string): Promise<UploadChunkResponse> {
+  const data = await parseJsonObject(response, operation)
+  const recordingId = data.recordingId
+  const asset = data.asset
+  const chunkIndex = data.chunkIndex
+  const status = data.status
+  const sizeBytes = data.sizeBytes
+  const receivedBytes = data.receivedBytes
+  const totalBytes = data.totalBytes
+
+  if (typeof recordingId !== 'string' || !recordingId) throw new Error(`${operation} missing recordingId`)
+  if (asset !== 'video_audio' && asset !== 'microphone') throw new Error(`${operation} returned invalid asset`)
+  if (typeof chunkIndex !== 'number' || !Number.isInteger(chunkIndex) || chunkIndex < 0) {
+    throw new Error(`${operation} returned invalid chunkIndex`)
+  }
+  if (status !== 'accepted') throw new Error(`${operation} returned invalid status`)
+  if (typeof sizeBytes !== 'number' || !Number.isInteger(sizeBytes) || sizeBytes <= 0) {
+    throw new Error(`${operation} returned invalid sizeBytes`)
+  }
+  if (typeof receivedBytes !== 'number' || !Number.isInteger(receivedBytes) || receivedBytes < 0) {
+    throw new Error(`${operation} returned invalid receivedBytes`)
+  }
+  if (typeof totalBytes !== 'number' || !Number.isInteger(totalBytes) || totalBytes <= 0) {
+    throw new Error(`${operation} returned invalid totalBytes`)
+  }
+
+  return {
+    recordingId,
+    asset,
+    chunkIndex,
+    status,
+    sizeBytes,
+    receivedBytes,
+    totalBytes
+  }
 }
 
 async function uploadAuthHeaders(extensionToken: string): Promise<{ Authorization: string }> {
   const token = extensionToken.trim()
   if (!token) throw new Meet2NoteAuthError('Connect to Meet2Note before uploading.')
   return { Authorization: makeAuthorizationHeader(token) }
+}
+
+function isUsableSession(session: UploadSessionState | null | undefined): session is UploadSessionState {
+  if (!session?.recordingId || !session.uploadToken || !session.expiresAt) return false
+  const expiresAtMs = Date.parse(session.expiresAt)
+  return Number.isFinite(expiresAtMs) && expiresAtMs > Date.now() + SESSION_EXPIRY_SKEW_MS
 }
 
 async function initUpload(
@@ -122,24 +273,118 @@ async function initUpload(
   return parseInitResponse(response)
 }
 
-async function uploadAsset(
-  recordingId: string,
-  uploadToken: string,
-  path: 'video' | 'microphone',
+async function ensureUploadSession(
+  input: UploadRecordingInput,
+  authHeaders: { Authorization: string }
+): Promise<UploadSessionState> {
+  if (isUsableSession(input.uploadSession)) return input.uploadSession
+
+  const session = await initUpload(input, authHeaders)
+  await input.onUploadSession?.(session)
+  return session
+}
+
+function assetContentType(asset: UploadAsset): 'video/webm' | 'audio/webm' {
+  return asset === 'video_audio' ? 'video/webm' : 'audio/webm'
+}
+
+function resolveChunkSize(session: UploadSessionState, blob: Blob): number {
+  const recommended = session.recommendedChunkSizeBytes
+  const chunkSize = typeof recommended === 'number' && Number.isFinite(recommended) && recommended > 0
+    ? Math.floor(recommended)
+    : DEFAULT_CHUNK_SIZE_BYTES
+  return Math.max(1, Math.min(blob.size, MAX_CHUNK_SIZE_BYTES, chunkSize))
+}
+
+function expectedChunkSize(blob: Blob, chunkSizeBytes: number, chunkIndex: number, totalChunks: number): number {
+  if (chunkIndex === totalChunks - 1) {
+    return blob.size - chunkSizeBytes * (totalChunks - 1)
+  }
+  return chunkSizeBytes
+}
+
+function sumReceivedBytes(receivedChunks: Set<number>, blob: Blob, chunkSizeBytes: number, totalChunks: number): number {
+  let total = 0
+  receivedChunks.forEach((chunkIndex) => {
+    total += expectedChunkSize(blob, chunkSizeBytes, chunkIndex, totalChunks)
+  })
+  return Math.min(blob.size, total)
+}
+
+async function initAsset(
+  session: UploadSessionState,
+  asset: UploadAsset,
   blob: Blob,
+  chunkSizeBytes: number,
+  authHeaders: { Authorization: string }
+): Promise<UploadAssetState> {
+  const operation = `init ${asset} asset`
+  const totalChunks = Math.ceil(blob.size / chunkSizeBytes)
+  const response = await fetchWithTimeout(
+    operation,
+    makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(session.recordingId)}/assets/${asset}`),
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Upload-Token': session.uploadToken,
+        ...authHeaders
+      },
+      body: JSON.stringify({
+        contentType: assetContentType(asset),
+        sizeBytes: blob.size,
+        chunkSizeBytes,
+        totalChunks
+      })
+    },
+    ASSET_METADATA_TIMEOUT_MS
+  )
+
+  if (!response.ok) throw httpError(operation, response)
+  return parseAssetState(response, operation)
+}
+
+async function getAssetState(
+  session: UploadSessionState,
+  asset: UploadAsset,
+  authHeaders: { Authorization: string }
+): Promise<UploadAssetState> {
+  const operation = `get ${asset} asset state`
+  const response = await fetchWithTimeout(
+    operation,
+    makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(session.recordingId)}/assets/${asset}`),
+    {
+      method: 'GET',
+      headers: {
+        'X-Upload-Token': session.uploadToken,
+        ...authHeaders
+      }
+    },
+    ASSET_METADATA_TIMEOUT_MS
+  )
+
+  if (!response.ok) throw httpError(operation, response)
+  return parseAssetState(response, operation)
+}
+
+async function uploadChunk(
+  session: UploadSessionState,
+  asset: UploadAsset,
+  chunkIndex: number,
+  chunk: Blob,
   authHeaders: { Authorization: string },
-  onAssetProgress?: (loadedBytes: number) => void
-): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const operation = `upload ${path}`
+  onChunkProgress?: (loadedBytes: number) => void
+): Promise<UploadChunkResponse> {
+  return new Promise<UploadChunkResponse>((resolve, reject) => {
+    const operation = `upload ${asset} chunk ${chunkIndex}`
     const xhr = new XMLHttpRequest()
     let settled = false
     const timeoutId = setTimeout(() => {
       if (settled) return
       settled = true
       try { xhr.abort() } catch {}
-      reject(new Error(`${operation} timed out after ${Math.round(ASSET_UPLOAD_TIMEOUT_MS / 1000)} seconds`))
-    }, ASSET_UPLOAD_TIMEOUT_MS)
+      reject(new Error(`${operation} timed out after ${Math.round(CHUNK_UPLOAD_TIMEOUT_MS / 1000)} seconds`))
+    }, CHUNK_UPLOAD_TIMEOUT_MS)
 
     const settle = (callback: () => void) => {
       if (settled) return
@@ -149,18 +394,21 @@ async function uploadAsset(
     }
 
     xhr.upload.onprogress = (event) => {
-      onAssetProgress?.(Math.min(blob.size, Math.max(0, event.loaded)))
+      onChunkProgress?.(Math.min(chunk.size, Math.max(0, event.loaded)))
     }
 
     xhr.onload = () => {
       settle(() => {
-        if (xhr.status >= 200 && xhr.status < 300) {
-          onAssetProgress?.(blob.size)
-          resolve()
+        if (xhr.status < 200 || xhr.status >= 300) {
+          reject(httpError(operation, new Response(null, { status: xhr.status })))
           return
         }
 
-        reject(httpError(operation, new Response(null, { status: xhr.status })))
+        const response = new Response(xhr.responseText, {
+          status: xhr.status,
+          headers: { 'Content-Type': 'application/json' }
+        })
+        parseChunkResponse(response, operation).then(resolve, reject)
       })
     }
 
@@ -172,28 +420,55 @@ async function uploadAsset(
       settle(() => reject(new Error(`${operation} was aborted`)))
     }
 
-    xhr.open('PUT', makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(recordingId)}/${path}`))
+    xhr.open(
+      'PUT',
+      makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(session.recordingId)}/assets/${asset}/chunks/${chunkIndex}`)
+    )
     xhr.setRequestHeader('Content-Type', 'application/octet-stream')
-    xhr.setRequestHeader('X-Upload-Token', uploadToken)
+    xhr.setRequestHeader('X-Upload-Token', session.uploadToken)
     xhr.setRequestHeader('Authorization', authHeaders.Authorization)
-    xhr.send(blob)
+    xhr.send(chunk)
   })
 }
 
+async function completeAsset(
+  session: UploadSessionState,
+  asset: UploadAsset,
+  authHeaders: { Authorization: string }
+): Promise<UploadAssetState> {
+  const operation = `complete ${asset} asset`
+  const response = await fetchWithTimeout(
+    operation,
+    makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(session.recordingId)}/assets/${asset}/complete`),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Upload-Token': session.uploadToken,
+        ...authHeaders
+      },
+      body: '{}'
+    },
+    ASSET_COMPLETE_TIMEOUT_MS
+  )
+
+  if (!response.ok) throw httpError(operation, response)
+  return parseAssetState(response, operation)
+}
+
 async function completeUpload(
-  recordingId: string,
-  uploadToken: string,
+  session: UploadSessionState,
   assets: UploadAsset[],
   authHeaders: { Authorization: string }
 ): Promise<void> {
   const response = await fetchWithTimeout(
     'complete upload',
-    makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(recordingId)}/complete`),
+    makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(session.recordingId)}/complete`),
     {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-Upload-Token': uploadToken,
+        'X-Upload-Token': session.uploadToken,
         ...authHeaders
       },
       body: JSON.stringify({ assets })
@@ -204,13 +479,62 @@ async function completeUpload(
   if (!response.ok) throw httpError('complete upload', response)
 }
 
+async function uploadAssetChunks(
+  session: UploadSessionState,
+  asset: UploadAsset,
+  blob: Blob,
+  authHeaders: { Authorization: string },
+  reportProgress: (asset: UploadAsset, assetLoadedBytes: number, assetTotalBytes: number) => void
+): Promise<void> {
+  const chunkSizeBytes = resolveChunkSize(session, blob)
+  const initialized = await initAsset(session, asset, blob, chunkSizeBytes, authHeaders)
+  const state = initialized.status === 'complete'
+    ? initialized
+    : await getAssetState(session, asset, authHeaders)
+
+  const receivedChunks = new Set(state.receivedChunks)
+  let acceptedBytes = Math.max(
+    state.receivedBytes,
+    sumReceivedBytes(receivedChunks, blob, state.chunkSizeBytes, state.totalChunks)
+  )
+
+  reportProgress(asset, acceptedBytes, blob.size)
+
+  for (let chunkIndex = 0; chunkIndex < state.totalChunks; chunkIndex += 1) {
+    if (receivedChunks.has(chunkIndex)) continue
+
+    const start = chunkIndex * state.chunkSizeBytes
+    const end = Math.min(blob.size, start + state.chunkSizeBytes)
+    const chunk = blob.slice(start, end)
+    const acceptedBeforeChunk = acceptedBytes
+    const response = await uploadChunk(
+      session,
+      asset,
+      chunkIndex,
+      chunk,
+      authHeaders,
+      loadedBytes => reportProgress(asset, acceptedBeforeChunk + loadedBytes, blob.size)
+    )
+
+    receivedChunks.add(chunkIndex)
+    acceptedBytes = Math.max(
+      response.receivedBytes,
+      sumReceivedBytes(receivedChunks, blob, state.chunkSizeBytes, state.totalChunks)
+    )
+    reportProgress(asset, acceptedBytes, blob.size)
+  }
+
+  await completeAsset(session, asset, authHeaders)
+  reportProgress(asset, blob.size, blob.size)
+}
+
 export async function uploadRecordingOnce(
   input: UploadRecordingInput,
   extensionToken: string,
   onProgress?: (progress: UploadProgress) => void
 ): Promise<UploadRecordingResult> {
   const authHeaders = await uploadAuthHeaders(extensionToken)
-  const session = await initUpload(input, authHeaders)
+  const session = await ensureUploadSession(input, authHeaders)
   const assets: UploadAsset[] = ['video_audio']
   const totalBytes = input.videoBlob.size + (input.microphoneBlob?.size || 0)
   const loadedByAsset: Record<UploadAsset, number> = {
@@ -228,30 +552,14 @@ export async function uploadRecordingOnce(
     })
   }
 
-  reportProgress('video_audio', 0, input.videoBlob.size)
-  await uploadAsset(
-    session.recordingId,
-    session.uploadToken,
-    'video',
-    input.videoBlob,
-    authHeaders,
-    loadedBytes => reportProgress('video_audio', loadedBytes, input.videoBlob.size)
-  )
+  await uploadAssetChunks(session, 'video_audio', input.videoBlob, authHeaders, reportProgress)
 
   if (input.microphoneBlob && input.microphoneBlob.size > 0) {
-    reportProgress('microphone', 0, input.microphoneBlob.size)
-    await uploadAsset(
-      session.recordingId,
-      session.uploadToken,
-      'microphone',
-      input.microphoneBlob,
-      authHeaders,
-      loadedBytes => reportProgress('microphone', loadedBytes, input.microphoneBlob!.size)
-    )
+    await uploadAssetChunks(session, 'microphone', input.microphoneBlob, authHeaders, reportProgress)
     assets.push('microphone')
   }
 
-  await completeUpload(session.recordingId, session.uploadToken, assets, authHeaders)
+  await completeUpload(session, assets, authHeaders)
 
   return {
     recordingId: session.recordingId,

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -296,6 +296,16 @@ function resolveChunkSize(session: UploadSessionState, blob: Blob): number {
   return Math.max(1, Math.min(blob.size, MAX_CHUNK_SIZE_BYTES, chunkSize))
 }
 
+function assertAssetSizeAllowed(session: UploadSessionState, asset: UploadAsset, blob: Blob): void {
+  const maxAssetSizeBytes = session.maxAssetSizeBytes
+  if (typeof maxAssetSizeBytes !== 'number' || !Number.isFinite(maxAssetSizeBytes) || maxAssetSizeBytes <= 0) return
+  if (blob.size <= maxAssetSizeBytes) return
+
+  throw new Error(
+    `${asset} asset is ${blob.size} bytes, which exceeds Meet2Note upload limit of ${maxAssetSizeBytes} bytes`
+  )
+}
+
 function expectedChunkSize(blob: Blob, chunkSizeBytes: number, chunkIndex: number, totalChunks: number): number {
   if (chunkIndex === totalChunks - 1) {
     return blob.size - chunkSizeBytes * (totalChunks - 1)
@@ -486,6 +496,7 @@ async function uploadAssetChunks(
   authHeaders: { Authorization: string },
   reportProgress: (asset: UploadAsset, assetLoadedBytes: number, assetTotalBytes: number) => void
 ): Promise<void> {
+  assertAssetSizeAllowed(session, asset, blob)
   const chunkSizeBytes = resolveChunkSize(session, blob)
   const initialized = await initAsset(session, asset, blob, chunkSizeBytes, authHeaders)
   const state = initialized.status === 'complete'


### PR DESCRIPTION
## Zakres
1. Przełącza klienta uploadu z legacy jednorequestowego `/video` i `/microphone` na chunked/resumable flow:
   `init upload -> init asset -> get asset state -> PUT chunks -> asset complete -> global complete`.
2. Zapisuje `uploadSession` (`recordingId`, `uploadToken`, `expiresAt`, preferencje chunków) w lokalnym IndexedDB spoolu, żeby retry albo restart offscreen mogły wznowić istniejącą sesję backendową.
3. Liczy postęp uploadu z bajtów już przyjętych przez backend i aktualnie wysyłanego chunka.
4. Czyści lokalny spool dopiero po udanym globalnym `/complete`.
5. Podbija wersję rozszerzenia do `1.9.17`.

## Weryfikacja
1. `make check`
2. `git diff --check`
3. `dist/manifest.json` ma wersję `1.9.17` po buildzie.

## Ryzyka
1. Backend jest aktualnie kodowany, więc PR opiera się na kontrakcie z `recording-backend/docs/architecture/resumable-upload-spec.md` i aktualnym lokalnym API chunked uploadu.
2. Smoke test end-to-end wymaga backendu z wdrożonymi endpointami chunked uploadu.
3. Brak zmian w uprawnieniach Chrome.

Closes #23
