### PR TITLE
Recover stale upload sessions

### DIFF
--- a/docs/contracts/meet2note-upload.md
+++ b/docs/contracts/meet2note-upload.md
@@ -31,10 +31,12 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
    d) `startedAt`,
    e) `durationMs`.
 3. Backend zwraca `recordingId`, `uploadToken`, `expiresAt`, `uploadMode`, `recommendedChunkSizeBytes` i `maxAssetSizeBytes`.
+   a) `expiresAt` może być `null`; oznacza to upload session bez znanego terminu wygaśnięcia.
 4. Docelowy `uploadMode` to `chunked`; rozszerzenie nie używa legacy endpointów `/video` ani `/microphone`.
 5. Dla każdego assetu rozszerzenie inicjalizuje metadane przez `PUT /api/upload/{recordingId}/assets/{asset}`.
    a) `asset` to `video_audio` albo `microphone`.
    b) Body zawiera `contentType`, `sizeBytes`, `chunkSizeBytes` i `totalChunks`.
+   c) `chunkSizeBytes` musi być dodatnią liczbą całkowitą i nie może przekraczać limitu backendu, obecnie 32 MiB; dla assetów mniejszych niż rekomendowany rozmiar chunka rozszerzenie używa rozmiaru assetu i `totalChunks: 1`.
 6. Przed wysyłką brakujących chunków albo po błędzie rozszerzenie pobiera stan assetu przez `GET /api/upload/{recordingId}/assets/{asset}`.
    a) Backend zwraca między innymi `receivedChunks` i `receivedBytes`.
    b) Rozszerzenie wysyła tylko chunki, których backend jeszcze nie przyjął.
@@ -66,6 +68,7 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 5. Błędy sieciowe i HTTP trafiają do istniejącej diagnostyki bez sekretów i bez zawartości nagrań.
 6. `401` albo `403` oznacza konieczność ponownego połączenia z Meet2Note.
 7. Po `401` albo `403` rozszerzenie czyści lokalny token, oznacza odpowiednią pozycję jako wymagającą reconnect i nie ponawia zwykłego uploadu bez końca.
+8. Jeśli zapisany `uploadSession` zwróci `404`, rozszerzenie traktuje go jako nieaktualny, czyści tylko sesję backendową i zakłada nową sesję dla tego samego lokalnego nagrania.
 
 ## Uprawnienia Chrome
 

--- a/docs/contracts/upload-queue-and-history.md
+++ b/docs/contracts/upload-queue-and-history.md
@@ -26,8 +26,9 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 1. Lokalna historia trzyma domyślnie 10 ostatnich pozycji terminalnych.
 2. Popup pokazuje 5 najnowszych pozycji.
 3. Pozycje nieterminalne nie powinny być usuwane przez limit historii, dopóki mają szansę na upload.
-4. Kolejka/spool mają twarde limity ochronne: 3 pozycje i 2 GiB łącznego rozmiaru.
-5. Po przekroczeniu limitu nowa pozycja powinna przejść w czytelny błąd lokalny, zamiast cicho znikać.
+4. Kolejka/spool nie mają arbitralnego limitu liczby pozycji ani stałego limitu łącznego rozmiaru po stronie rozszerzenia.
+5. Przed startem nagrania rozszerzenie sprawdza dostępność IndexedDB i szacowane użycie storage przeglądarki; jeśli przeglądarka raportuje prawie pełny storage, start ma zakończyć się czytelnym błędem lokalnym.
+6. Jeśli zapis chunków do IndexedDB nie powiedzie się w trakcie nagrywania, pozycja przechodzi w czytelny błąd lokalny, zamiast cicho znikać.
 
 ## Retry i błędy
 

--- a/docs/contracts/upload-queue-and-history.md
+++ b/docs/contracts/upload-queue-and-history.md
@@ -71,3 +71,4 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 3. Po udanym uploadzie lokalny wpis przechodzi do `processing_queued`, dopóki backend nie zwróci dokładniejszego statusu.
 4. Błędy lokalne i konieczność reconnect są opisywane statusem `failed` oraz metadanym `failureReason`, a nie osobnymi statusami spoza kontraktu.
 5. Legacy statusy `queued`, `retrying`, `uploaded`, `pending`, `auth_required`, `local_error` i `failed_unrecoverable` muszą być mapowane do aktualnego kontraktu przy odczycie lokalnej historii.
+6. Popup nie powinien tłumaczyć `processing_queued` na `uploaded`; statusy backendowe mają być prezentowane kanonicznie, żeby nie rozjeżdżały się z widokiem webowym Meet2Note.

--- a/docs/contracts/upload-queue-and-history.md
+++ b/docs/contracts/upload-queue-and-history.md
@@ -20,6 +20,7 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 3. Lokalny spool jest czyszczony dopiero po potwierdzonym uploadzie albo po przejściu pozycji w terminalny stan lokalnego błędu.
 4. Po restarcie service workera zakończone pozycje uploadu powinny być odtwarzane z IndexedDB.
 5. Aktywne, niefinalizowane nagranie utracone razem z offscreen może zostać oznaczone jako `failed` z metadaną `failureReason: "unrecoverable"`.
+6. Kolejka uploadu trzyma w pamięci metadane pozycji, nie całe Bloby; assety są składane z IndexedDB dopiero na czas uploadu aktywnej pozycji.
 
 ## Limity
 

--- a/docs/system-map.md
+++ b/docs/system-map.md
@@ -43,15 +43,16 @@ Ten opis dokumentuje aktualne ustalenia integracyjne między wtyczką i backende
 1. Rozszerzenie przechodzi flow `GET /extension/connect`, a callback wymienia jednorazowy `code` przez `POST /api/extension/token`.
 2. Długotrwały `extensionToken` jest zapisywany w `chrome.storage.local` i wysyłany jako `Authorization: Bearer <extensionToken>`.
 3. Rozszerzenie inicjuje upload przez `POST /api/upload/init`.
-4. Backend zwraca `recordingId`, `uploadToken` oraz `expiresAt`.
-5. Rozszerzenie wysyła główny asset `video_audio` przez `PUT /api/upload/{recordingId}/video`.
-6. Jeśli mikrofon jest dostępny, rozszerzenie wysyła osobny asset `microphone` przez `PUT /api/upload/{recordingId}/microphone`.
-7. Każdy upload assetu używa nagłówków `Authorization` oraz `X-Upload-Token`.
-8. Rozszerzenie kończy upload przez `POST /api/upload/{recordingId}/complete`.
-9. Chunks nagrania trafiają do trwałego spoolu IndexedDB już podczas nagrywania, a zakończone nagrania są uploadowane sekwencyjnie.
-10. Jeśli upload się nie powiedzie, offscreen ponawia pełny upload konkretnej pozycji co 15 sekund, bez lokalnego zapisu pliku.
-11. Jeśli backend zwróci `401` albo `403`, zwykły retry tej pozycji jest przerywany, token jest czyszczony i popup wymaga ponownego połączenia z Meet2Note.
-12. Popup scala lokalną historię kolejki z listą nagrań z backendu, jeśli konto jest połączone z Meet2Note.
+4. Backend zwraca `recordingId`, `uploadToken`, opcjonalne `expiresAt`, `recommendedChunkSizeBytes` oraz `maxAssetSizeBytes`.
+5. Rozszerzenie inicjalizuje każdy asset przez `PUT /api/upload/{recordingId}/assets/{asset}`.
+6. Rozszerzenie wysyła brakujące chunki przez `PUT /api/upload/{recordingId}/assets/{asset}/chunks/{chunkIndex}`.
+7. Po chunkach rozszerzenie kończy asset przez `POST /api/upload/{recordingId}/assets/{asset}/complete`.
+8. Każdy request uploadu używa nagłówków `Authorization` oraz `X-Upload-Token`.
+9. Rozszerzenie kończy upload przez `POST /api/upload/{recordingId}/complete`.
+10. Chunks nagrania trafiają do trwałego spoolu IndexedDB już podczas nagrywania, a zakończone nagrania są uploadowane sekwencyjnie.
+11. Jeśli upload się nie powiedzie, offscreen ponawia upload konkretnej pozycji co 15 sekund i wznawia sesję backendową, jeśli nadal jest używalna.
+12. Jeśli backend zwróci `401` albo `403`, zwykły retry tej pozycji jest przerywany, token jest czyszczony i popup wymaga ponownego połączenia z Meet2Note.
+13. Popup scala lokalną historię kolejki z listą nagrań z backendu, jeśli konto jest połączone z Meet2Note.
 
 ## Granice uruchomieniowe
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.25",
+    "version": "1.9.26",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.17",
+    "version": "1.9.20",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.21",
+    "version": "1.9.22",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.24",
+    "version": "1.9.25",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.20",
+    "version": "1.9.21",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.26",
+    "version": "1.9.27",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.22",
+    "version": "1.9.23",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.23",
+    "version": "1.9.24",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/src/background.ts
+++ b/src/background.ts
@@ -153,11 +153,12 @@ async function refreshRecentRecordingsFromBackend(): Promise<RecordingHistoryIte
 }
 
 function backendRecordingToHistoryItem(recording: BackendRecordingListItem): RecordingHistoryItem {
+  const recordedAt = recording.startedAt || recording.createdAt
   return {
     localId: `backend:${recording.id}`,
     status: recording.status,
     title: recording.title,
-    startedAt: recording.createdAt,
+    startedAt: recordedAt,
     stoppedAt: recording.updatedAt || recording.createdAt,
     durationMs: recording.durationMs ?? 0,
     videoBytes: 0,
@@ -169,7 +170,7 @@ function backendRecordingToHistoryItem(recording: BackendRecordingListItem): Rec
     error: recording.status === 'failed' ? 'Processing failed in Meet2Note.' : null,
     failureReason: recording.status === 'failed' ? 'upload_error' : null,
     displayTimeline: recording.displayTimeline,
-    createdAt: recording.createdAt,
+    createdAt: recordedAt,
     updatedAt: recording.updatedAt || recording.createdAt
   }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -170,7 +170,7 @@ function backendRecordingToHistoryItem(recording: BackendRecordingListItem): Rec
     error: recording.status === 'failed' ? 'Processing failed in Meet2Note.' : null,
     failureReason: recording.status === 'failed' ? 'upload_error' : null,
     displayTimeline: recording.displayTimeline,
-    createdAt: recordedAt,
+    createdAt: recording.createdAt,
     updatedAt: recording.updatedAt || recording.createdAt
   }
 }

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -15,11 +15,11 @@ import {
 } from './recordingHistory'
 import {
   appendSpoolChunk,
+  assertSpoolAvailable,
   createSpoolRecording,
   deleteSpoolChunks,
   deleteSpoolRecording,
   getSpoolChunkCounts,
-  getSpoolUsage,
   listInterruptedSpoolRecordings,
   listUploadableSpoolRecordings,
   readSpoolAssetBlob,
@@ -912,9 +912,9 @@ async function enqueueUpload(entry: UploadQueueEntry): Promise<void> {
 
 async function assertSpoolCapacityBeforeRecording(): Promise<void> {
   try {
-    await getSpoolUsage()
+    await assertSpoolAvailable()
   } catch (e) {
-    captureException(e, { operation: 'assertSpoolCapacityBeforeRecording.getSpoolUsage' })
+    captureException(e, { operation: 'assertSpoolCapacityBeforeRecording.assertSpoolAvailable' })
     throw new Error('Local recording storage is unavailable. Refresh the extension or free browser storage before starting another recording.')
   }
 

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -47,6 +47,13 @@ const ORPHANED_PENDING_UPLOAD_STATUSES: RecordingUploadStatus[] = [
   'uploading'
 ]
 
+class UnrecoverableLocalRecordingError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UnrecoverableLocalRecordingError'
+  }
+}
+
 window.addEventListener('error', (e) => {
   console.error('[offscreen] window.onerror', e?.message, e?.error)
   captureException(e?.error || e?.message, { operation: 'window.onerror' })
@@ -576,7 +583,9 @@ async function markCurrentSpoolLocalError(message: string): Promise<void> {
 
 async function uploadInputFromQueueEntry(entry: UploadQueueEntry): Promise<UploadRecordingInput> {
   const videoBlob = await readSpoolAssetBlob(entry.localId, 'video_audio', entry.videoMimeType)
-  if (!videoBlob || videoBlob.size === 0) throw new Error('Recording data is missing from the local spool.')
+  if (!videoBlob || videoBlob.size === 0) {
+    throw new UnrecoverableLocalRecordingError('Recording data is missing from the local spool.')
+  }
   const microphoneBlob = entry.assets.includes('microphone')
     ? await readSpoolAssetBlob(entry.localId, 'microphone', entry.microphoneMimeType || 'audio/webm')
     : null
@@ -778,6 +787,21 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
       log('Upload completed', { localId: entry.localId, recordingId: result.recordingId, assets: result.assets, attempt })
       return 'done'
     } catch (e) {
+      if (e instanceof UnrecoverableLocalRecordingError) {
+        acceptingProgressUpdates = false
+        await progressPersistQueue.catch(() => undefined)
+        await updateQueueEntry(entry, 'failed', {
+          error: e.message,
+          failureReason: 'unrecoverable',
+          nextRetryAt: null,
+          uploadProgressPercent: null
+        })
+        await cleanupTerminalSpoolEntry(entry.localId, 'uploadQueueEntryUntilTerminal.cleanupUnrecoverable')
+        removeQueueEntry(entry.localId)
+        log('Upload failed permanently because local recording data is missing', { localId: entry.localId, attempt })
+        return 'done'
+      }
+
       if (isMeet2NoteAuthError(e)) {
         acceptingProgressUpdates = false
         await progressPersistQueue.catch(() => undefined)

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -42,6 +42,7 @@ const STOP_FINALIZE_TIMEOUT_MS = 10_000
 const MICROPHONE_STOP_TIMEOUT_MS = 2_000
 const MEDIA_RECORDER_TIMESLICE_MS = 5_000
 const INTERRUPTED_RECORDING_MESSAGE = 'Recording was interrupted before it could be finalized.'
+const STORAGE_ALMOST_FULL_MESSAGE = 'Browser storage is almost full. Free space before starting another recording.'
 const ORPHANED_PENDING_UPLOAD_STATUSES: RecordingUploadStatus[] = [
   'upload_queued',
   'uploading'
@@ -921,10 +922,11 @@ async function assertSpoolCapacityBeforeRecording(): Promise<void> {
     await navigator.storage?.persist?.()
     const estimate = await navigator.storage?.estimate?.()
     if (estimate?.quota && estimate.usage && estimate.usage / estimate.quota > 0.95) {
-      throw new Error('Browser storage is almost full. Free space before starting another recording.')
+      throw new Error(STORAGE_ALMOST_FULL_MESSAGE)
     }
   } catch (e) {
-    if (e instanceof Error) throw e
+    if (e instanceof Error && e.message === STORAGE_ALMOST_FULL_MESSAGE) throw e
+    captureException(e, { operation: 'assertSpoolCapacityBeforeRecording.storageEstimate' })
   }
 }
 

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -40,8 +40,6 @@ const MEDIA_CAPTURE_TIMEOUT_MS = 10_000
 const UPLOAD_RETRY_INTERVAL_MS = 15_000
 const STOP_FINALIZE_TIMEOUT_MS = 10_000
 const MICROPHONE_STOP_TIMEOUT_MS = 2_000
-const MAX_UPLOAD_QUEUE_ENTRIES = 3
-const MAX_UPLOAD_QUEUE_BYTES = 2 * 1024 * 1024 * 1024
 const MEDIA_RECORDER_TIMESLICE_MS = 5_000
 const INTERRUPTED_RECORDING_MESSAGE = 'Recording was interrupted before it could be finalized.'
 const ORPHANED_PENDING_UPLOAD_STATUSES: RecordingUploadStatus[] = [
@@ -696,44 +694,6 @@ function removeQueueEntry(localId: string): void {
   uploadQueue = uploadQueue.filter(entry => entry.localId !== localId)
 }
 
-function getQueueEntryBytes(entry: UploadQueueEntry): number {
-  return entry.videoBlob.size + (entry.microphoneBlob?.size || 0)
-}
-
-function getUploadQueueBytes(entries = uploadQueue): number {
-  return entries.reduce((total, entry) => total + getQueueEntryBytes(entry), 0)
-}
-
-async function rejectQueueEntryForMemoryLimit(entry: UploadQueueEntry): Promise<void> {
-  const now = new Date().toISOString()
-  const currentBytes = getUploadQueueBytes()
-  const entryBytes = getQueueEntryBytes(entry)
-  const message = 'Upload queue is full. Try again after active uploads finish.'
-  const failedEntry: UploadQueueEntry = {
-    ...entry,
-    status: 'failed',
-    error: message,
-    failureReason: 'local_error',
-    nextRetryAt: null,
-    updatedAt: now
-  }
-
-  await persistQueueEntry(failedEntry)
-  Object.assign(entry, failedEntry)
-  captureMessage(
-    'Upload queue rejected recording because memory limit was reached.',
-    'warning',
-    {
-      operation: 'enqueueUpload.memoryLimit',
-      queueEntries: uploadQueue.length,
-      queueBytes: currentBytes,
-      recordingBytes: entryBytes,
-      maxQueueEntries: MAX_UPLOAD_QUEUE_ENTRIES,
-      maxQueueBytes: MAX_UPLOAD_QUEUE_BYTES
-    }
-  )
-}
-
 function getNextReadyUploadQueueEntry(now: number): UploadQueueEntry | null {
   return uploadQueue.find((entry) => {
     if (entry.status === 'uploading') return true
@@ -775,9 +735,9 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
       const uploadInput: UploadRecordingInput = {
         ...uploadInputFromQueueEntry(entry),
         uploadSession: entry.uploadSession ?? null,
-        onUploadSession: async (session: UploadSessionState) => {
+        onUploadSession: async (session: UploadSessionState | null) => {
           await updateQueueEntry(entry, 'uploading', {
-            backendRecordingId: session.recordingId,
+            backendRecordingId: session?.recordingId ?? null,
             uploadSession: session
           })
         }
@@ -919,16 +879,6 @@ async function runUploadQueueWorker(): Promise<void> {
 }
 
 async function enqueueUpload(entry: UploadQueueEntry): Promise<void> {
-  const queuedBytes = getUploadQueueBytes()
-  const entryBytes = getQueueEntryBytes(entry)
-  if (
-    uploadQueue.length >= MAX_UPLOAD_QUEUE_ENTRIES ||
-    queuedBytes + entryBytes > MAX_UPLOAD_QUEUE_BYTES
-  ) {
-    await rejectQueueEntryForMemoryLimit(entry)
-    return
-  }
-
   uploadQueue.push(entry)
   await persistQueueEntry(entry)
   wakeUploadQueueWorker()
@@ -939,20 +889,17 @@ async function enqueueUpload(entry: UploadQueueEntry): Promise<void> {
 }
 
 async function assertSpoolCapacityBeforeRecording(): Promise<void> {
-  let usage: Awaited<ReturnType<typeof getSpoolUsage>>
   try {
-    usage = await getSpoolUsage()
+    await getSpoolUsage()
   } catch (e) {
     captureException(e, { operation: 'assertSpoolCapacityBeforeRecording.getSpoolUsage' })
     throw new Error('Local recording storage is unavailable. Refresh the extension or free browser storage before starting another recording.')
   }
-  if (usage.recordings >= MAX_UPLOAD_QUEUE_ENTRIES || usage.bytes >= MAX_UPLOAD_QUEUE_BYTES) {
-    throw new Error('Local recording storage is full. Wait for active uploads to finish before starting another recording.')
-  }
 
   try {
+    await navigator.storage?.persist?.()
     const estimate = await navigator.storage?.estimate?.()
-    if (estimate?.quota && estimate.usage && estimate.usage / estimate.quota > 0.9) {
+    if (estimate?.quota && estimate.usage && estimate.usage / estimate.quota > 0.95) {
       throw new Error('Browser storage is almost full. Free space before starting another recording.')
     }
   } catch (e) {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -121,8 +121,9 @@ function sleepUntilUploadQueueWakeOrTimeout(ms: number): Promise<void> {
 }
 
 interface UploadQueueEntry extends RecordingHistoryItem {
-  videoBlob: Blob
-  microphoneBlob: Blob | null
+  schemaVersion: number
+  videoMimeType: string
+  microphoneMimeType: string | null
   uploadSession?: RecordingSpoolUploadSession | null
 }
 
@@ -133,8 +134,9 @@ let restoreUploadQueuePromise: Promise<void> | null = null
 
 function toHistoryItem(entry: UploadQueueEntry): RecordingHistoryItem {
   const {
-    videoBlob: _videoBlob,
-    microphoneBlob: _microphoneBlob,
+    schemaVersion: _schemaVersion,
+    videoMimeType: _videoMimeType,
+    microphoneMimeType: _microphoneMimeType,
     uploadSession: _uploadSession,
     ...historyItem
   } = entry
@@ -144,9 +146,9 @@ function toHistoryItem(entry: UploadQueueEntry): RecordingHistoryItem {
 async function persistQueueEntry(entry: UploadQueueEntry): Promise<void> {
   await updateSpoolRecording({
     ...toHistoryItem(entry),
-    schemaVersion: SPOOL_SCHEMA_VERSION,
-    videoMimeType: entry.videoBlob.type || 'video/webm',
-    microphoneMimeType: entry.microphoneBlob?.type || null,
+    schemaVersion: entry.schemaVersion,
+    videoMimeType: entry.videoMimeType,
+    microphoneMimeType: entry.microphoneMimeType,
     uploadSession: entry.uploadSession ?? null
   })
   await persistHistoryItem(toHistoryItem(entry))
@@ -518,25 +520,14 @@ function buildSpoolRecording(
   }
 }
 
-function spoolRecordToQueueEntry(
-  record: RecordingSpoolRecord,
-  videoBlob: Blob,
-  microphoneBlob: Blob | null
-): UploadQueueEntry {
-  return {
-    ...record,
-    videoBlob,
-    microphoneBlob: microphoneBlob && microphoneBlob.size > 0 ? microphoneBlob : null
-  }
+function spoolRecordToQueueEntry(record: RecordingSpoolRecord): UploadQueueEntry {
+  return { ...record }
 }
 
 async function buildUploadQueueEntryFromSpool(record: RecordingSpoolRecord): Promise<UploadQueueEntry | null> {
-  const videoBlob = await readSpoolAssetBlob(record.localId, 'video_audio', record.videoMimeType)
-  if (!videoBlob || videoBlob.size === 0) return null
-  const microphoneBlob = record.assets.includes('microphone')
-    ? await readSpoolAssetBlob(record.localId, 'microphone', record.microphoneMimeType || 'audio/webm')
-    : null
-  return spoolRecordToQueueEntry(record, videoBlob, microphoneBlob)
+  const counts = await getSpoolChunkCounts(record.localId)
+  if (counts.video_audio <= 0) return null
+  return spoolRecordToQueueEntry(record)
 }
 
 async function markSpoolRecordFailedUnrecoverable(
@@ -583,15 +574,21 @@ async function markCurrentSpoolLocalError(message: string): Promise<void> {
   await cleanupTerminalSpoolEntry(localId, 'markCurrentSpoolLocalError.cleanup')
 }
 
-function uploadInputFromQueueEntry(entry: UploadQueueEntry): UploadRecordingInput {
+async function uploadInputFromQueueEntry(entry: UploadQueueEntry): Promise<UploadRecordingInput> {
+  const videoBlob = await readSpoolAssetBlob(entry.localId, 'video_audio', entry.videoMimeType)
+  if (!videoBlob || videoBlob.size === 0) throw new Error('Recording data is missing from the local spool.')
+  const microphoneBlob = entry.assets.includes('microphone')
+    ? await readSpoolAssetBlob(entry.localId, 'microphone', entry.microphoneMimeType || 'audio/webm')
+    : null
+
   return {
     title: entry.title,
     meetingId: entry.meetingId,
     meetingTitle: entry.meetingTitle,
     startedAt: entry.startedAt,
     durationMs: entry.durationMs,
-    videoBlob: entry.videoBlob,
-    microphoneBlob: entry.microphoneBlob
+    videoBlob,
+    microphoneBlob: microphoneBlob && microphoneBlob.size > 0 ? microphoneBlob : null
   }
 }
 
@@ -733,7 +730,7 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
     try {
       const extensionToken = await requestMeet2NoteExtensionToken()
       const uploadInput: UploadRecordingInput = {
-        ...uploadInputFromQueueEntry(entry),
+        ...(await uploadInputFromQueueEntry(entry)),
         uploadSession: entry.uploadSession ?? null,
         onUploadSession: async (session: UploadSessionState | null) => {
           await updateQueueEntry(entry, 'uploading', {
@@ -1337,7 +1334,7 @@ async function prepareAndRecord(
 
         const uploadEntry = await buildUploadQueueEntryFromSpool(currentSpoolRecord)
         if (!uploadEntry) throw new Error('Recording was finalized without video data in local spool.')
-        log('Finalizing; video blob.size =', uploadEntry.videoBlob.size, 'microphone blob.size =', uploadEntry.microphoneBlob?.size || 0)
+        log('Finalizing; video bytes =', uploadEntry.videoBytes, 'microphone bytes =', uploadEntry.microphoneBytes)
         void enqueueUpload(uploadEntry).catch((e) => {
           log('Unexpected upload queue enqueue failure', e)
           captureException(e, { operation: 'enqueueUpload.unhandled' })

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -159,7 +159,6 @@ function getHistoryTagText(item: RecordingHistoryItem): string {
   }
 
   if (item.status === 'upload_queued') return 'queued'
-  if (item.status === 'processing_queued') return item.localId.startsWith('backend:') ? 'processing' : 'uploaded'
   if (item.status === 'finalizing') return 'saving'
   return item.status
 }

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -137,7 +137,7 @@ function normalizeUploadSession(value: unknown): RecordingSpoolUploadSession | n
   const record = value as Record<string, unknown>
   const recordingId = record.recordingId
   const uploadToken = record.uploadToken
-  const expiresAt = record.expiresAt
+  const expiresAt = record.expiresAt ?? null
   if (typeof recordingId !== 'string' || !recordingId) return null
   if (typeof uploadToken !== 'string' || !uploadToken) return null
   if (expiresAt !== null && (typeof expiresAt !== 'string' || !expiresAt)) return null

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -227,6 +227,14 @@ export async function listInterruptedSpoolRecordings(): Promise<RecordingSpoolRe
   return records.filter(record => record.status === 'recording' || record.status === 'finalizing')
 }
 
+export async function assertSpoolAvailable(): Promise<void> {
+  const db = await openSpoolDb()
+  const tx = db.transaction(RECORDINGS_STORE, 'readonly')
+  const complete = transactionComplete(tx)
+  await requestResult<number>(tx.objectStore(RECORDINGS_STORE).count())
+  await complete
+}
+
 async function getChunksByIndex(localId: string, asset: RecordingUploadAsset): Promise<RecordingSpoolChunk[]> {
   const db = await openSpoolDb()
   const tx = db.transaction(CHUNKS_STORE, 'readonly')

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -231,8 +231,10 @@ export async function assertSpoolAvailable(): Promise<void> {
   const db = await openSpoolDb()
   const tx = db.transaction(RECORDINGS_STORE, 'readonly')
   const complete = transactionComplete(tx)
-  await requestResult<number>(tx.objectStore(RECORDINGS_STORE).count())
-  await complete
+  await Promise.all([
+    requestResult<number>(tx.objectStore(RECORDINGS_STORE).count()),
+    complete
+  ])
 }
 
 async function getChunksByIndex(localId: string, asset: RecordingUploadAsset): Promise<RecordingSpoolChunk[]> {

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -237,6 +237,13 @@ async function getChunksByIndex(localId: string, asset: RecordingUploadAsset): P
   return chunks.sort((a, b) => a.sequence - b.sequence)
 }
 
+async function countChunksByIndex(localId: string, asset: RecordingUploadAsset): Promise<number> {
+  const db = await openSpoolDb()
+  const tx = db.transaction(CHUNKS_STORE, 'readonly')
+  const index = tx.objectStore(CHUNKS_STORE).index(ASSET_INDEX)
+  return requestResult<number>(index.count(localIdAsset(localId, asset)))
+}
+
 export async function readSpoolAssetBlob(
   localId: string,
   asset: RecordingUploadAsset,
@@ -250,12 +257,12 @@ export async function readSpoolAssetBlob(
 
 export async function getSpoolChunkCounts(localId: string): Promise<Record<RecordingUploadAsset, number>> {
   const [videoChunks, microphoneChunks] = await Promise.all([
-    getChunksByIndex(localId, 'video_audio'),
-    getChunksByIndex(localId, 'microphone')
+    countChunksByIndex(localId, 'video_audio'),
+    countChunksByIndex(localId, 'microphone')
   ])
   return {
-    video_audio: videoChunks.length,
-    microphone: microphoneChunks.length
+    video_audio: videoChunks,
+    microphone: microphoneChunks
   }
 }
 

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -16,7 +16,7 @@ export const SPOOL_SCHEMA_VERSION = 1
 export interface RecordingSpoolUploadSession {
   recordingId: string
   uploadToken: string
-  expiresAt: string
+  expiresAt: string | null
   recommendedChunkSizeBytes?: number
   maxAssetSizeBytes?: number
 }
@@ -140,7 +140,7 @@ function normalizeUploadSession(value: unknown): RecordingSpoolUploadSession | n
   const expiresAt = record.expiresAt
   if (typeof recordingId !== 'string' || !recordingId) return null
   if (typeof uploadToken !== 'string' || !uploadToken) return null
-  if (typeof expiresAt !== 'string' || !expiresAt) return null
+  if (expiresAt !== null && (typeof expiresAt !== 'string' || !expiresAt)) return null
 
   return {
     recordingId,

--- a/src/recordingsClient.ts
+++ b/src/recordingsClient.ts
@@ -11,6 +11,7 @@ export interface BackendRecordingListItem {
   title: string
   status: BackendRecordingStatus
   durationMs: number | null
+  startedAt: string | null
   createdAt: string
   updatedAt: string
   displayTimeline?: string
@@ -51,6 +52,7 @@ function parseBackendRecording(value: unknown): BackendRecordingListItem | null 
   const id = typeof record.id === 'string' ? record.id.trim() : ''
   const title = typeof record.title === 'string' ? record.title.trim() : ''
   const status = normalizeBackendRecordingStatus(record.status)
+  const startedAtRaw = typeof record.startedAt === 'string' ? record.startedAt.trim() : ''
   const createdAt = typeof record.createdAt === 'string' ? record.createdAt.trim() : ''
   const updatedAtRaw = typeof record.updatedAt === 'string' ? record.updatedAt.trim() : ''
   const updatedAt = updatedAtRaw || createdAt
@@ -65,6 +67,7 @@ function parseBackendRecording(value: unknown): BackendRecordingListItem | null 
     durationMs: typeof record.durationMs === 'number' && Number.isFinite(record.durationMs)
       ? record.durationMs
       : null,
+    startedAt: startedAtRaw || null,
     createdAt,
     updatedAt,
     ...(displayTimeline ? { displayTimeline } : {})

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -78,7 +78,7 @@ class Meet2NoteUploadHttpError extends Error {
     message: string,
     public readonly operation: string,
     public readonly status: number,
-    public readonly responseBody: string | null
+    public readonly detail: string | null
   ) {
     super(message)
     this.name = 'Meet2NoteUploadHttpError'
@@ -103,12 +103,12 @@ function normalizeErrorBody(body: string | null): string | null {
   return trimmed.slice(0, 500)
 }
 
-function httpErrorFromStatus(operation: string, status: number, responseBody: string | null = null): Error {
+function httpErrorFromStatus(operation: string, status: number, rawResponseBody: string | null = null): Error {
   if (status === 401 || status === 403) {
     return new Meet2NoteAuthError(`Meet2Note connection required for ${operation}.`, status)
   }
 
-  const detail = normalizeErrorBody(responseBody)
+  const detail = normalizeErrorBody(rawResponseBody)
   const suffix = detail ? `: ${detail}` : ''
   return new Meet2NoteUploadHttpError(
     `${operation} failed with HTTP ${status}${suffix}`,

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -168,7 +168,7 @@ async function parseInitResponse(response: Response): Promise<InitUploadResponse
 
   const recordingId = data.recordingId
   const uploadToken = data.uploadToken
-  const expiresAt = data.expiresAt
+  const expiresAt = data.expiresAt ?? null
   const uploadMode = data.uploadMode
 
   if (typeof recordingId !== 'string' || !recordingId) throw new Error('init upload missing recordingId')

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -119,6 +119,9 @@ function httpErrorFromStatus(operation: string, status: number, responseBody: st
 }
 
 async function httpError(operation: string, response: Response): Promise<Error> {
+  if (response.status === 401 || response.status === 403) {
+    return httpErrorFromStatus(operation, response.status)
+  }
   const body = await response.text().catch(() => null)
   return httpErrorFromStatus(operation, response.status, body)
 }

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -9,7 +9,7 @@ export type UploadAsset = 'video_audio' | 'microphone'
 export interface UploadSessionState {
   recordingId: string
   uploadToken: string
-  expiresAt: string
+  expiresAt: string | null
   recommendedChunkSizeBytes?: number
   maxAssetSizeBytes?: number
 }
@@ -23,7 +23,7 @@ export interface UploadRecordingInput {
   videoBlob: Blob
   microphoneBlob?: Blob | null
   uploadSession?: UploadSessionState | null
-  onUploadSession?: (session: UploadSessionState) => void | Promise<void>
+  onUploadSession?: (session: UploadSessionState | null) => void | Promise<void>
 }
 
 export interface UploadRecordingResult {
@@ -73,11 +73,58 @@ const DEFAULT_CHUNK_SIZE_BYTES = 16 * 1024 * 1024
 const MAX_CHUNK_SIZE_BYTES = 32 * 1024 * 1024
 const SESSION_EXPIRY_SKEW_MS = 60_000
 
-function httpError(operation: string, response: Response): Error {
-  if (response.status === 401 || response.status === 403) {
-    return new Meet2NoteAuthError(`Meet2Note connection required for ${operation}.`, response.status)
+class Meet2NoteUploadHttpError extends Error {
+  constructor(
+    message: string,
+    public readonly operation: string,
+    public readonly status: number,
+    public readonly responseBody: string | null
+  ) {
+    super(message)
+    this.name = 'Meet2NoteUploadHttpError'
   }
-  return new Error(`${operation} failed with HTTP ${response.status}`)
+}
+
+function normalizeErrorBody(body: string | null): string | null {
+  if (!body) return null
+  const trimmed = body.trim()
+  if (!trimmed) return null
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (parsed && typeof parsed === 'object') {
+      const record = parsed as Record<string, unknown>
+      const message = record.message
+      const error = record.error
+      if (Array.isArray(message)) return message.map(String).join('; ').slice(0, 500)
+      if (typeof message === 'string' && message.trim()) return message.trim().slice(0, 500)
+      if (typeof error === 'string' && error.trim()) return error.trim().slice(0, 500)
+    }
+  } catch {}
+  return trimmed.slice(0, 500)
+}
+
+function httpErrorFromStatus(operation: string, status: number, responseBody: string | null = null): Error {
+  if (status === 401 || status === 403) {
+    return new Meet2NoteAuthError(`Meet2Note connection required for ${operation}.`, status)
+  }
+
+  const detail = normalizeErrorBody(responseBody)
+  const suffix = detail ? `: ${detail}` : ''
+  return new Meet2NoteUploadHttpError(
+    `${operation} failed with HTTP ${status}${suffix}`,
+    operation,
+    status,
+    detail
+  )
+}
+
+async function httpError(operation: string, response: Response): Promise<Error> {
+  const body = await response.text().catch(() => null)
+  return httpErrorFromStatus(operation, response.status, body)
+}
+
+function isStaleUploadSessionError(error: unknown): boolean {
+  return error instanceof Meet2NoteUploadHttpError && error.status === 404
 }
 
 async function fetchWithTimeout(
@@ -126,7 +173,9 @@ async function parseInitResponse(response: Response): Promise<InitUploadResponse
 
   if (typeof recordingId !== 'string' || !recordingId) throw new Error('init upload missing recordingId')
   if (typeof uploadToken !== 'string' || !uploadToken) throw new Error('init upload missing uploadToken')
-  if (typeof expiresAt !== 'string' || !expiresAt) throw new Error('init upload missing expiresAt')
+  if (expiresAt !== null && (typeof expiresAt !== 'string' || !expiresAt)) {
+    throw new Error('init upload returned invalid expiresAt')
+  }
   if (uploadMode !== undefined && uploadMode !== 'chunked') {
     throw new Error(`unsupported upload mode: ${String(uploadMode)}`)
   }
@@ -237,7 +286,9 @@ async function uploadAuthHeaders(extensionToken: string): Promise<{ Authorizatio
 }
 
 function isUsableSession(session: UploadSessionState | null | undefined): session is UploadSessionState {
-  if (!session?.recordingId || !session.uploadToken || !session.expiresAt) return false
+  if (!session?.recordingId || !session.uploadToken) return false
+  if (session.expiresAt === null) return true
+  if (typeof session.expiresAt !== 'string' || !session.expiresAt) return false
   const expiresAtMs = Date.parse(session.expiresAt)
   return Number.isFinite(expiresAtMs) && expiresAtMs > Date.now() + SESSION_EXPIRY_SKEW_MS
 }
@@ -269,7 +320,7 @@ async function initUpload(
     INIT_UPLOAD_TIMEOUT_MS
   )
 
-  if (!response.ok) throw httpError('init upload', response)
+  if (!response.ok) throw await httpError('init upload', response)
   return parseInitResponse(response)
 }
 
@@ -350,7 +401,7 @@ async function initAsset(
     ASSET_METADATA_TIMEOUT_MS
   )
 
-  if (!response.ok) throw httpError(operation, response)
+  if (!response.ok) throw await httpError(operation, response)
   return parseAssetState(response, operation)
 }
 
@@ -373,7 +424,7 @@ async function getAssetState(
     ASSET_METADATA_TIMEOUT_MS
   )
 
-  if (!response.ok) throw httpError(operation, response)
+  if (!response.ok) throw await httpError(operation, response)
   return parseAssetState(response, operation)
 }
 
@@ -410,7 +461,7 @@ async function uploadChunk(
     xhr.onload = () => {
       settle(() => {
         if (xhr.status < 200 || xhr.status >= 300) {
-          reject(httpError(operation, new Response(null, { status: xhr.status })))
+          reject(httpErrorFromStatus(operation, xhr.status, xhr.responseText))
           return
         }
 
@@ -462,7 +513,7 @@ async function completeAsset(
     ASSET_COMPLETE_TIMEOUT_MS
   )
 
-  if (!response.ok) throw httpError(operation, response)
+  if (!response.ok) throw await httpError(operation, response)
   return parseAssetState(response, operation)
 }
 
@@ -486,7 +537,7 @@ async function completeUpload(
     COMPLETE_UPLOAD_TIMEOUT_MS
   )
 
-  if (!response.ok) throw httpError('complete upload', response)
+  if (!response.ok) throw await httpError('complete upload', response)
 }
 
 async function uploadAssetChunks(
@@ -539,7 +590,7 @@ async function uploadAssetChunks(
   reportProgress(asset, blob.size, blob.size)
 }
 
-export async function uploadRecordingOnce(
+async function uploadRecordingWithSession(
   input: UploadRecordingInput,
   extensionToken: string,
   onProgress?: (progress: UploadProgress) => void
@@ -575,5 +626,22 @@ export async function uploadRecordingOnce(
   return {
     recordingId: session.recordingId,
     assets
+  }
+}
+
+export async function uploadRecordingOnce(
+  input: UploadRecordingInput,
+  extensionToken: string,
+  onProgress?: (progress: UploadProgress) => void
+): Promise<UploadRecordingResult> {
+  try {
+    return await uploadRecordingWithSession(input, extensionToken, onProgress)
+  } catch (error) {
+    if (!input.uploadSession || !isStaleUploadSessionError(error)) throw error
+    await input.onUploadSession?.(null)
+    return uploadRecordingWithSession({
+      ...input,
+      uploadSession: null
+    }, extensionToken, onProgress)
   }
 }


### PR DESCRIPTION
## Scope
- recover from stale persisted upload sessions by clearing the backend session and creating a fresh one for the same local recording after HTTP 404
- include backend response details in non-auth upload HTTP errors, including XHR chunk uploads
- align the extension with backend chunked upload behavior: nullable expiresAt, positive small chunk sizes, and no hard local 2 GB / 3-entry queue cap
- keep upload queue entries lightweight by loading recording Blobs from IndexedDB only for the active upload
- count spool chunks through lightweight IndexedDB `count()` calls during queue restore
- use a lightweight IndexedDB availability check before recording instead of scanning chunk storage
- align popup recording statuses and dates with backend `status`, `createdAt`, and `startedAt`
- avoid blocking recording start on transient Storage API estimate/persist failures
- bump extension version to 1.9.27

## Verification
- make check
- git diff --check
- dist/manifest.json version: 1.9.27

## Chrome permissions
- No permission changes.