### PR TITLE
[codex] Sync extension recording states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,9 +103,11 @@ Ten plik definiuje zasady dla agentow AI i automatyzacji pracujacych w tym repoz
 
 1. Jesli zmiana w tym repozytorium wymaga pracy po stronie `recording-backend`, utworz issue w repozytorium backendu z konkretnym zakresem, kontekstem i kryteriami akceptacji.
 2. Jesli zmiana w `recording-backend` wymaga pracy po stronie tej wtyczki, oczekiwanym miejscem przekazania pracy jest issue w tym repozytorium.
-3. W issue linkuj odpowiednia specyfikacje, kontrakt albo PR, jesli istnieje.
-4. Gdy podczas pracy widzisz, ze po drugiej stronie integracji potrzebna jest zmiana, od razu utworz issue w odpowiednim repozytorium i poinformuj czlowieka, ze issue zostalo zalozone.
-5. Nie zakladaj, ze ustalenia z rozmowy sa wystarczajaca dokumentacja zaleznosci miedzy projektami.
+3. Zadania integracyjne rozdzielaj na jawna czesc wtyczki i jawna czesc backendu; jesli obie strony sa potrzebne do dzialania calosci, utrzymuj osobne issue w obu repozytoriach.
+4. Powiazane issue w repozytoriach wtyczki i backendu musza linkowac do siebie nawzajem, z opisem ktora strona blokuje albo domyka druga.
+5. Gdy podczas pracy widzisz, ze po drugiej stronie integracji potrzebna jest zmiana, od razu utworz issue w odpowiednim repozytorium i poinformuj czlowieka, ze issue zostalo zalozone.
+6. W issue linkuj odpowiednia specyfikacje, kontrakt albo PR, jesli istnieje.
+7. Nie zakladaj, ze ustalenia z rozmowy sa wystarczajaca dokumentacja zaleznosci miedzy projektami.
 
 ## Skrot `+PR`
 

--- a/docs/contracts/meet2note-upload.md
+++ b/docs/contracts/meet2note-upload.md
@@ -49,7 +49,7 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 10. Body globalnego `/complete` zawiera tylko faktycznie wysłane i zakończone assety.
 11. Endpointy assetów, chunków i `/complete` używają nagłówków `Authorization` oraz `X-Upload-Token`.
 12. `uploadToken`, pełnych URL-i z tokenami ani zawartości blobów nie wolno logować.
-13. Lokalny spool IndexedDB jest czyszczony dopiero po udanym globalnym `/complete`.
+13. Lokalny spool IndexedDB nie jest obecnie czyszczony automatycznie po `/complete`; decyzje o porzuceniu albo usuwaniu pozycji pozostają poza automatem rozszerzenia.
 
 ## Assety
 
@@ -69,6 +69,19 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 6. `401` albo `403` oznacza konieczność ponownego połączenia z Meet2Note.
 7. Po `401` albo `403` rozszerzenie czyści lokalny token, oznacza odpowiednią pozycję jako wymagającą reconnect i nie ponawia zwykłego uploadu bez końca.
 8. Jeśli zapisany `uploadSession` zwróci `404`, rozszerzenie traktuje go jako nieaktualny, czyści tylko sesję backendową i zakłada nową sesję dla tego samego lokalnego nagrania.
+9. Błędy uploadu i błędy lokalne mają być raportowane do backendu jako stan nagrania z uzasadnieniem, a nie tylko do lokalnego popupu albo Sentry.
+
+## Synchronizacja stanu rozszerzenia
+
+1. Rozszerzenie synchronizuje stan każdej backendowo mutowalnej pozycji przez `PUT /api/recordings/{recordingId}/extension-state`.
+2. `recordingId` jest stabilnym UUID po stronie rozszerzenia. Dla historycznych lokalnych identyfikatorów spoza formatu UUID rozszerzenie dogenerowuje UUID i zapisuje go jako `backendRecordingId`.
+3. Ten sam identyfikator trafia później do `POST /api/upload/init`, żeby stan przeduploadowy i sesja uploadu dotyczyły tego samego rekordu backendu.
+4. Synchronizacja obejmuje statusy właścicielskie rozszerzenia: `recording`, `finalizing`, `upload_queued`, `uploading`, `failed` i `canceled`.
+5. Rozszerzenie nie wysyła przez ten endpoint statusów backendowych `processing_queued`, `processing`, `ready` ani `expired`.
+6. Obecny backendowy payload przyjmuje `title`, `status`, `startedAt`, `durationMs`, `uploadProgressPercent`, `meetingId` i `meetingUrl`.
+7. Docelowo payload musi zostać rozszerzony po stronie backendu o uzasadnienie błędu, między innymi `failureReason`, `error`, `attempt` i `nextRetryAt`; jest to zakres backendowego issue `pawel-walaszek/recording-backend#31`.
+8. `failed` bez uzasadnienia jest niepoprawnym stanem produktowym; dopóki backend nie przyjmie tych pól, rozszerzenie przechowuje uzasadnienie lokalnie i synchronizuje sam status.
+9. Automatyka rozszerzenia nie powinna wysyłać decyzji o porzuceniu pozycji. Porzucenie, usunięcie albo świadome zakończenie failed pozycji jest decyzją użytkownika w backendzie.
 
 ## Uprawnienia Chrome
 

--- a/docs/contracts/recording-statuses.md
+++ b/docs/contracts/recording-statuses.md
@@ -20,16 +20,16 @@ Rozszerzenie nie powinno emitować ani pokazywać legacy statusu `pending`. Stat
 
 | Status | Owner | Znaczenie |
 |--------|-------|-----------|
-| `recording` | Chrome extension | Trwa lokalne nagrywanie spotkania. Backend może jeszcze nie znać tej pozycji. |
+| `recording` | Chrome extension | Trwa lokalne nagrywanie spotkania; docelowo backend zna tę pozycję przez synchronizację stanu rozszerzenia. |
 | `finalizing` | Chrome extension | Użytkownik zatrzymał nagrywanie, a rozszerzenie finalizuje lokalne bloby i metadane przed uploadem. |
 | `upload_queued` | Chrome extension | Nagranie jest gotowe do uploadu, ale upload czeka albo jest zaplanowany do retry. |
 | `uploading` | Chrome extension | Rozszerzenie aktywnie wysyła assety nagrania do backendu. |
 | `processing_queued` | Backend | Backend ma pliki i metadane, a przetwarzanie po stronie serwera czeka na start. |
 | `processing` | Backend | Worker backendu aktywnie przetwarza nagranie. |
 | `ready` | Backend | Przetworzone nagranie web-playable jest dostępne. |
-| `failed` | Backend albo Chrome extension | Aktualny etap zakończył się błędem i wymaga retry, diagnostyki albo akcji użytkownika. |
+| `failed` | Backend albo Chrome extension | Aktualny etap zakończył się błędem i wymaga retry, diagnostyki albo akcji użytkownika. Stan musi zawierać uzasadnienie błędu. |
 | `canceled` | Chrome extension | Użytkownik celowo anulował nagrywanie albo upload. |
-| `expired` | Backend | Backend wygasił niedokończone albo osierocone nagranie przejściowe. |
+| `expired` | Backend/admin | Rezerwacja dla przyszłego ręcznego albo administracyjnego cleanupu. Nie jest automatycznym porzuceniem pozycji przez rozszerzenie. |
 
 ## Model przejść
 
@@ -43,7 +43,7 @@ Przepływy błędów:
 
 1. Każdy aktywny status może przejść do `failed`.
 2. Celowe przerwanie przez użytkownika przechodzi do `canceled`.
-3. Backendowy cleanup porzuconych pozycji przejściowych przechodzi do `expired`.
+3. Porzucenie pozycji jest decyzją użytkownika albo administracji w backendzie, nie automatyczną decyzją rozszerzenia.
 
 ## Polityka legacy
 

--- a/docs/contracts/upload-queue-and-history.md
+++ b/docs/contracts/upload-queue-and-history.md
@@ -12,21 +12,33 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 4. Offscreen odpowiada za finalizację nagrania, lokalny spool, kolejkę uploadu i wysyłkę assetów.
 5. Background koordynuje lifecycle rozszerzenia, stan nagrywania, komunikację z popupem i operacje Chrome storage.
 6. Popup pokazuje osobno stan aktywnego nagrywania oraz listę ostatnich nagrań.
+7. Backend Meet2Note ma być docelowym źródłem widoczności dla wszystkich pozycji, które rozszerzenie nagrywa, finalizuje, próbuje uploadować albo oznacza jako `failed`.
+
+## Widoczność w backendzie
+
+1. Backend powinien widzieć każdą pozycję znaną rozszerzeniu, także taką, której assety nigdy nie zostały w pełni wysłane.
+2. Każdy `failed` musi mieć uzasadnienie widoczne w backendzie: etap błędu, komunikat, `failureReason`, liczba prób i ostatni znany czas retry, jeśli dotyczy.
+3. Rozszerzenie nie powinno samodzielnie porzucać ani ukrywać pozycji tylko dlatego, że upload się nie udaje.
+4. Użytkownik decyduje w backendowym widoku `/recordings`, kiedy pozycja ma zostać porzucona, usunięta albo oznaczona jako świadomie zakończona.
+5. Automatyczny cleanup porzuconych pozycji nie jest częścią obecnego kontraktu; może wrócić wyłącznie jako osobna decyzja produktowa.
+6. Do czasu pełnej implementacji synchronizacji stanów w backendzie popup może nadal scalać lokalne wpisy z listą backendową, ale nie jest to docelowe źródło prawdy.
 
 ## Lokalny spool
 
 1. Chunks nagrań są zapisywane w IndexedDB podczas nagrywania.
 2. `chrome.storage.local` przechowuje metadane historii, nie zawartość nagrań.
-3. Lokalny spool jest czyszczony dopiero po potwierdzonym uploadzie albo po przejściu pozycji w terminalny stan lokalnego błędu.
+3. Lokalny spool nie jest obecnie czyszczony automatycznie po potwierdzonym globalnym `/complete`; automatyczne usuwanie może wrócić tylko jako osobna decyzja produktowa.
 4. Po restarcie service workera zakończone pozycje uploadu powinny być odtwarzane z IndexedDB.
 5. Aktywne, niefinalizowane nagranie utracone razem z offscreen może zostać oznaczone jako `failed` z metadaną `failureReason: "unrecoverable"`.
 6. Kolejka uploadu trzyma w pamięci metadane pozycji, nie całe Bloby; assety są składane z IndexedDB dopiero na czas uploadu aktywnej pozycji.
+7. Automatyka rozszerzenia nie powinna usuwać failed pozycji ani ich chunków jako decyzji produktowej o porzuceniu; decyzja o porzuceniu należy do użytkownika w backendzie.
+8. Jeśli lokalne dane są fizycznie niedostępne albo uszkodzone, rozszerzenie może oznaczyć pozycję jako `failed`, ale powinno zsynchronizować ten fakt z backendem zamiast cicho usuwać pozycję z widoczności użytkownika.
 
 ## Limity
 
-1. Lokalna historia trzyma domyślnie 10 ostatnich pozycji terminalnych.
+1. Lokalna historia nie usuwa automatycznie pozycji terminalnych tylko dlatego, że przekroczono limit liczby wpisów.
 2. Popup pokazuje 5 najnowszych pozycji.
-3. Pozycje nieterminalne nie powinny być usuwane przez limit historii, dopóki mają szansę na upload.
+3. Pozycje nieterminalne i terminalne pozostają dostępne dla synchronizacji z backendem, dopóki istnieją w lokalnej historii albo spoolu.
 4. Kolejka/spool nie mają arbitralnego limitu liczby pozycji ani stałego limitu łącznego rozmiaru po stronie rozszerzenia.
 5. Przed startem nagrania rozszerzenie sprawdza dostępność IndexedDB i szacowane użycie storage przeglądarki; jeśli przeglądarka raportuje prawie pełny storage, start ma zakończyć się czytelnym błędem lokalnym.
 6. Jeśli zapis chunków do IndexedDB nie powiedzie się w trakcie nagrywania, pozycja przechodzi w czytelny błąd lokalny, zamiast cicho znikać.
@@ -39,6 +51,8 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 4. `401` albo `403` przełącza pozycję w stan wymagający ponownego połączenia z Meet2Note i zatrzymuje zwykły retry.
 5. Po reconnect pozycje wymagające autoryzacji mogą wrócić do kolejki, jeśli lokalny spool nadal zawiera ich chunks.
 6. Jeśli chunks zostały utracone albo storage jest uszkodzony, pozycja pozostaje w stanie błędu nieodwracalnego.
+7. Błędy lokalne, błędy uploadu i pauzy autoryzacyjne powinny być raportowane do backendu jako stan tej samej pozycji, a nie wyłącznie jako lokalna diagnostyka.
+8. `failed` nie oznacza automatycznego porzucenia; oznacza stan wymagający diagnostyki, retry, reconnect albo decyzji użytkownika.
 
 ## Historia i popup
 
@@ -48,8 +62,8 @@ Indeks i zasady katalogu kontraktów: [README.md](README.md), [AGENTS.md](AGENTS
 4. Długie tytuły w popupie powinny być skracane elipsą.
 5. Po udanym uploadzie lokalny wpis powinien zostać scalony z backendowym `recordingId` i późniejszym statusem przetwarzania.
 6. Gdy backend zwraca listę nagrań, popup traktuje ją jako źródło kolejności i pozycji dla nagrań znanych backendowi.
-7. Lokalne wpisy bez `backendRecordingId` mogą uzupełniać popup tylko dla stanów przejściowych, których backend jeszcze nie zna: `recording`, `finalizing`, `upload_queued`, `uploading` oraz `failed` z `failureReason: "auth_required"`.
-8. Lokalne `failed` bez `backendRecordingId` i bez możliwości wznowienia uploadu nie reprezentują nagrania; mogą być widoczne w popupie maksymalnie 3 minuty jako diagnostyka, nie powinny wypierać pozycji backendowych i nie są propagowane do backendu.
+7. Lokalne wpisy bez `backendRecordingId` są stanem przejściowym i powinny zostać zsynchronizowane do backendu, jeśli tylko rozszerzenie ma ważne połączenie z Meet2Note.
+8. Lokalne `failed` bez `backendRecordingId` nadal reprezentują próbę nagrania albo uploadu; docelowo mają być widoczne w backendzie z uzasadnieniem błędu.
 9. Snapshot lokalnej kolejki z offscreen nie może zastępować backendowej listy nagrań; background scala go z cachem backendu.
 10. Popup może używać lokalnego cache UI dla stanu połączenia i ostatniej listy nagrań, żeby pierwszy render nie pokazywał fałszywego stanu rozłączenia ani pustej listy przed asynchroniczną synchronizacją.
 11. Popup pokazuje dla pozycji nagrania tylko tytuł, status oraz jedną linię czasu. Jeśli backend zwraca `displayTimeline`, popup renderuje tę wartość bez własnego formatowania; fallback lokalny istnieje tylko dla wpisów, których backend jeszcze nie zna albo dla starszej wersji API.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.27",
+    "version": "1.9.28",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/src/background.ts
+++ b/src/background.ts
@@ -30,6 +30,7 @@ let recordingStopping = false
 let currentRecordingTabId: number | null = null
 let autoStopMeetTabId: number | null = null
 let recordingStartedAt: number | null = null
+let lastRecordingError: string | null = null
 const meetTabsInMeeting = new Set<number>()
 let recentRecordings: RecordingHistoryItem[] = []
 let backendRecordings: RecordingHistoryItem[] = []
@@ -40,6 +41,14 @@ const BACKEND_RECORDINGS_REFRESH_THROTTLE_MS = 15_000
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
 const DEFAULT_OFFSCREEN_RESPONSE_TIMEOUT_MS = 15_000
 const STOP_OFFSCREEN_RESPONSE_TIMEOUT_MS = 3_000
+type CaptureSource = 'tab' | 'desktop'
+
+interface CaptureStreamRequest {
+  streamId: string
+  captureSource: CaptureSource
+  canRequestAudioTrack: boolean
+}
+
 function bglog(...a: any[]) { console.log('[background]', ...a) }
 function setBadge(recording: boolean, tabId?: number | null) {
   const details: chrome.action.BadgeTextDetails = { text: recording ? 'REC' : '' }
@@ -104,7 +113,8 @@ function persistRecordingState(recording: boolean, startedAt: number | null): vo
       recordingStarting,
       recordingStartingTabId,
       recordingStartRequestedAt,
-      recordingStopping
+      recordingStopping,
+      lastRecordingError
     })?.catch?.(() => {})
   } catch {}
 }
@@ -118,6 +128,7 @@ function broadcastRecordingState(extra?: Record<string, unknown>): void {
     startingTabId: recordingStartingTabId,
     startRequestedAt: recordingStartRequestedAt,
     stopping: recordingStopping,
+    error: lastRecordingError,
     ...extra
   }).catch(() => {})
 }
@@ -126,6 +137,13 @@ function setRecordingStarting(starting: boolean, tabId: number | null = null): v
   recordingStarting = starting
   recordingStartingTabId = starting ? tabId : null
   recordingStartRequestedAt = starting ? Date.now() : null
+  if (starting) lastRecordingError = null
+  persistRecordingState(lastKnownRecording, recordingStartedAt)
+  broadcastRecordingState()
+}
+
+function setLastRecordingError(error: unknown): void {
+  lastRecordingError = getErrorMessage(error) || 'Recording could not start.'
   persistRecordingState(lastKnownRecording, recordingStartedAt)
   broadcastRecordingState()
 }
@@ -298,7 +316,8 @@ function hasPendingLocalUpload(items = recentRecordings): boolean {
   return items.some(item =>
     item.status === 'upload_queued' ||
     item.status === 'uploading' ||
-    (item.status === 'failed' && item.failureReason === 'auth_required') ||
+    (item.status === 'failed' && (item.failureReason === 'auth_required' || !item.backendRecordingId)) ||
+    (item.status === 'canceled' && !item.backendRecordingId) ||
     item.status === 'recording' ||
     item.status === 'finalizing'
   )
@@ -505,6 +524,11 @@ function postToOffscreen(msg: any, timeoutMs = DEFAULT_OFFSCREEN_RESPONSE_TIMEOU
   })
 }
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return `${error || ''}`
+}
+
 function isRecoverableOffscreenStartFailure(error: unknown): boolean {
   const message = `${error || ''}`
   return message.includes('Offscreen response timeout') ||
@@ -512,15 +536,57 @@ function isRecoverableOffscreenStartFailure(error: unknown): boolean {
     message.includes('Cannot capture a tab with an active stream')
 }
 
+function shouldFallbackToDesktopCapture(error: unknown): boolean {
+  const message = getErrorMessage(error)
+  if (!message) return false
+  if (message.includes('Screen/tab selection was canceled')) return false
+  if (message.includes('Already recording')) return false
+  if (message.includes('Recording is still stopping')) return false
+  return message.includes('OFFSCREEN_START') ||
+    message.includes('tabCapture') ||
+    message.includes('getMediaStreamId') ||
+    message.includes('getUserMedia') ||
+    message.includes('Could not start') ||
+    message.includes('Permission denied') ||
+    message.includes('NotAllowedError') ||
+    message.includes('NotReadableError') ||
+    message.includes('No video track') ||
+    message.includes('media stream') ||
+    message.includes('capture')
+}
+
 // Helper streamId po stronie tła.
-function getStreamIdForTab(tabId: number): Promise<string> {
+function getStreamIdForTab(tabId: number): Promise<CaptureStreamRequest> {
   return new Promise((resolve, reject) => {
     try {
-      chrome.tabCapture.getMediaStreamId({ targetTabId: tabId }, (id?: string) => {
+      chrome.tabCapture.getMediaStreamId({ targetTabId: tabId }, (streamId?: string) => {
         const err = chrome.runtime.lastError
         if (err) return reject(new Error(err.message))
-        if (!id) return reject(new Error('Empty streamId'))
-        resolve(id)
+        if (!streamId) return reject(new Error('Empty streamId'))
+        resolve({
+          streamId,
+          captureSource: 'tab',
+          canRequestAudioTrack: true
+        })
+      })
+    } catch (e) {
+      reject(e as any)
+    }
+  })
+}
+
+function chooseDesktopStream(): Promise<CaptureStreamRequest> {
+  return new Promise((resolve, reject) => {
+    try {
+      chrome.desktopCapture.chooseDesktopMedia(['tab', 'audio'], (streamId, options) => {
+        const err = chrome.runtime.lastError
+        if (err) return reject(new Error(err.message))
+        if (!streamId) return reject(new Error('Screen/tab selection was canceled.'))
+        resolve({
+          streamId,
+          captureSource: 'desktop',
+          canRequestAudioTrack: options?.canRequestAudioTrack !== false
+        })
       })
     } catch (e) {
       reject(e as any)
@@ -623,16 +689,18 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       setRecordingStarting(true, tabId)
 
       try {
-        const start = async () => {
+        const start = async (captureRequestFactory: () => Promise<CaptureStreamRequest>) => {
           await ensureOffscreen()
           bglog('ensureOffscreen() completed')
 
-          const streamId = await getStreamIdForTab(tabId)
+          const captureRequest = await captureRequestFactory()
           const micPreferences = await getMicPreferencesForOffscreen()
           const tab = await chrome.tabs.get(tabId).catch(() => null)
           const r = await postToOffscreen({
             type: 'OFFSCREEN_START',
-            streamId,
+            streamId: captureRequest.streamId,
+            captureSource: captureRequest.captureSource,
+            canRequestAudioTrack: captureRequest.canRequestAudioTrack,
             micPreferences,
             recordingContext: {
               tabUrl: tab?.url || null,
@@ -643,23 +711,41 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           return r
         }
 
-        const startWithRecovery = async () => {
-          const first = await start()
+        const startWithRecovery = async (captureRequestFactory: () => Promise<CaptureStreamRequest>) => {
+          const first = await start(captureRequestFactory)
           if (first?.ok !== false || !isRecoverableOffscreenStartFailure(first?.error)) return first
 
           bglog('OFFSCREEN_START returned recoverable error; resetting offscreen and retrying once', first?.error)
           await resetOffscreen()
-          return await start()
+          return await start(captureRequestFactory)
         }
 
         let r: any
+        let tabCaptureFailure: unknown = null
         try {
-          r = await startWithRecovery()
+          r = await startWithRecovery(() => getStreamIdForTab(tabId))
         } catch (e: any) {
-          if (!isRecoverableOffscreenStartFailure(e?.message || e)) throw e
-          bglog('OFFSCREEN_START failed with recoverable transport error; resetting offscreen and retrying once')
+          tabCaptureFailure = e
+          if (!isRecoverableOffscreenStartFailure(e?.message || e)) {
+            r = { ok: false, error: e?.message || String(e) }
+          } else {
+            bglog('OFFSCREEN_START failed with recoverable transport error; resetting offscreen and retrying once')
+            await resetOffscreen()
+            try {
+              r = await start(() => getStreamIdForTab(tabId))
+            } catch (retryError: any) {
+              tabCaptureFailure = retryError
+              r = { ok: false, error: retryError?.message || String(retryError) }
+            }
+          }
+        }
+
+        if (r?.ok === false) tabCaptureFailure = r.error
+        if (r?.ok === false && shouldFallbackToDesktopCapture(tabCaptureFailure)) {
+          bglog('Tab capture failed; falling back to desktop capture picker', tabCaptureFailure)
           await resetOffscreen()
-          r = await start()
+          setRecordingStarting(true, tabId)
+          r = await startWithRecovery(chooseDesktopStream)
         }
 
         if (r?.ok) {
@@ -678,6 +764,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           sendResponse({ ok: true, micIncluded: r.micIncluded, warning: r.warning, recordingStartedAt })
         } else {
           setRecordingStarting(false)
+          setLastRecordingError(r?.error || 'Failed to start')
           sendResponse({ ok: false, error: r?.error || 'Failed to start' })
         }
       } catch (e: any) {
@@ -685,6 +772,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         captureException(e, { operation: 'START_RECORDING' })
         await resetOffscreen()
         setRecordingStarting(false)
+        setLastRecordingError(`OFFSCREEN_START failed: ${e?.message || e}`)
         sendResponse({ ok: false, error: `OFFSCREEN_START failed: ${e?.message || e}` })
       }
       return
@@ -719,7 +807,8 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           'recordingStarting',
           'recordingStartingTabId',
           'recordingStartRequestedAt',
-          'recordingStopping'
+          'recordingStopping',
+          'lastRecordingError'
         ])
         lastKnownRecording = !!sessionState?.recording
         recordingStartedAt = typeof sessionState?.recordingStartedAt === 'number'
@@ -733,6 +822,9 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           ? sessionState.recordingStartRequestedAt
           : null
         recordingStopping = !!sessionState?.recordingStopping
+        lastRecordingError = typeof sessionState?.lastRecordingError === 'string'
+          ? sessionState.lastRecordingError
+          : null
         if (!lastKnownRecording && !recordingStarting && !recordingStopping) {
           clearRecordingBadges(currentRecordingTabId)
         }
@@ -746,6 +838,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         startingTabId: recordingStartingTabId,
         startRequestedAt: recordingStartRequestedAt,
         stopping: recordingStopping,
+        error: lastRecordingError,
         recentRecordings
       })
       return
@@ -863,7 +956,8 @@ async function hydrateRecordingRuntimeState(): Promise<void> {
       'recordingStarting',
       'recordingStartingTabId',
       'recordingStartRequestedAt',
-      'recordingStopping'
+      'recordingStopping',
+      'lastRecordingError'
     ])
     lastKnownRecording = !!sessionState?.recording
     recordingStartedAt = typeof sessionState?.recordingStartedAt === 'number'
@@ -877,6 +971,9 @@ async function hydrateRecordingRuntimeState(): Promise<void> {
       ? sessionState.recordingStartRequestedAt
       : null
     recordingStopping = !!sessionState?.recordingStopping
+    lastRecordingError = typeof sessionState?.lastRecordingError === 'string'
+      ? sessionState.lastRecordingError
+      : null
 
     if (lastKnownRecording) {
       setBadge(true, currentRecordingTabId)

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -10,17 +10,23 @@ import { uploadRecordingOnce, type UploadRecordingInput, type UploadSessionState
 import {
   generateRecordingLocalId,
   normalizeRecordingHistoryItem,
+  readRecordingHistory,
   type RecordingHistoryItem,
   type RecordingUploadStatus
 } from './recordingHistory'
 import {
+  isExtensionMutableRecordingStatus,
+  resolveExtensionRecordingId,
+  syncExtensionRecordingState
+} from './recordingStateSync'
+import {
   appendSpoolChunk,
   assertSpoolAvailable,
   createSpoolRecording,
-  deleteSpoolChunks,
-  deleteSpoolRecording,
+  getSpoolRecording,
   getSpoolChunkCounts,
   listInterruptedSpoolRecordings,
+  listSpoolRecordings,
   listUploadableSpoolRecordings,
   readSpoolAssetBlob,
   SPOOL_SCHEMA_VERSION,
@@ -38,6 +44,7 @@ initDiagnostics('offscreen')
 const WANT_MIC_ASSET = true
 const MEDIA_CAPTURE_TIMEOUT_MS = 10_000
 const UPLOAD_RETRY_INTERVAL_MS = 15_000
+const RECORDING_STATE_SYNC_RETRY_INTERVAL_MS = 30_000
 const STOP_FINALIZE_TIMEOUT_MS = 10_000
 const MICROPHONE_STOP_TIMEOUT_MS = 2_000
 const MEDIA_RECORDER_TIMESLICE_MS = 5_000
@@ -128,6 +135,33 @@ function sleepUntilUploadQueueWakeOrTimeout(ms: number): Promise<void> {
   })
 }
 
+function wakeRecordingStateSyncWorker(): void {
+  const wake = recordingStateSyncWake
+  recordingStateSyncWake = null
+  if (wake) wake()
+}
+
+function sleepUntilRecordingStateSyncWakeOrTimeout(ms: number): Promise<void> {
+  let wake: (() => void) | null = null
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+  const wakePromise = new Promise<'wake'>((resolve) => {
+    wake = () => resolve('wake')
+    recordingStateSyncWake = wake
+  })
+  const timeoutPromise = new Promise<'timeout'>((resolve) => {
+    timeoutId = setTimeout(() => resolve('timeout'), ms)
+  })
+
+  return Promise.race([
+    timeoutPromise,
+    wakePromise
+  ]).then((result) => {
+    if (result === 'wake' && timeoutId) clearTimeout(timeoutId)
+    if (wake && recordingStateSyncWake === wake) recordingStateSyncWake = null
+  })
+}
+
 interface UploadQueueEntry extends RecordingHistoryItem {
   schemaVersion: number
   videoMimeType: string
@@ -135,10 +169,28 @@ interface UploadQueueEntry extends RecordingHistoryItem {
   uploadSession?: RecordingSpoolUploadSession | null
 }
 
+type CaptureSource = 'tab' | 'desktop'
+
 let uploadQueue: UploadQueueEntry[] = []
 let uploadWorkerRunning = false
 let uploadQueueWake: (() => void) | null = null
 let restoreUploadQueuePromise: Promise<void> | null = null
+let recordingStateSyncWorkerRunning = false
+let recordingStateSyncWake: (() => void) | null = null
+const recordingStateSyncQueue = new Map<string, RecordingHistoryItem>()
+
+function generateBackendRecordingId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  const bytes = new Uint8Array(16)
+  crypto.getRandomValues(bytes)
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('')
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`
+}
 
 function toHistoryItem(entry: UploadQueueEntry): RecordingHistoryItem {
   const {
@@ -152,6 +204,17 @@ function toHistoryItem(entry: UploadQueueEntry): RecordingHistoryItem {
 }
 
 async function persistQueueEntry(entry: UploadQueueEntry): Promise<void> {
+  const normalizedHistory = normalizeRecordingHistoryItem(toHistoryItem(entry))
+  if (normalizedHistory &&
+    isExtensionMutableRecordingStatus(normalizedHistory.status) &&
+    !resolveExtensionRecordingId(normalizedHistory)) {
+    const backendRecordingId = generateBackendRecordingId()
+    Object.assign(entry, {
+      backendRecordingId,
+      updatedAt: new Date().toISOString()
+    })
+  }
+
   await updateSpoolRecording({
     ...toHistoryItem(entry),
     schemaVersion: entry.schemaVersion,
@@ -370,14 +433,20 @@ function routeTabAudioToOutput(tabStream: MediaStream): void {
   }
 }
 
-// Buduje ograniczenia z użyciem streamId. Najpierw próbuje 'tab', potem 'desktop'.
-function makeConstraints(streamId: string, source: 'tab' | 'desktop'): MediaStreamConstraints {
+// Buduje ograniczenia z użyciem streamId przekazanego przez background.
+function makeConstraints(
+  streamId: string,
+  source: CaptureSource,
+  canRequestAudioTrack = true
+): MediaStreamConstraints {
   const mandatory = { chromeMediaSource: source, chromeMediaSourceId: streamId } as any
   return {
-    audio: {
-      mandatory,
-      optional: [{ googDisableLocalEcho: false }]
-    } as any,
+    audio: canRequestAudioTrack
+      ? {
+          mandatory,
+          optional: [{ googDisableLocalEcho: false }]
+        } as any
+      : false,
     video: {
       mandatory: {
         ...mandatory,
@@ -390,11 +459,23 @@ function makeConstraints(streamId: string, source: 'tab' | 'desktop'): MediaStre
 }
 
 // Próbuje nagrywać z użyciem streamId.
-async function captureWithStreamId(streamId: string): Promise<MediaStream> {
+async function captureWithStreamId(
+  streamId: string,
+  captureSource: CaptureSource,
+  canRequestAudioTrack = true
+): Promise<MediaStream> {
+  if (captureSource === 'desktop') {
+    log(`Attempting getUserMedia with streamId ${streamId} source= desktop`)
+    return await withStreamTimeout(
+      navigator.mediaDevices.getUserMedia(makeConstraints(streamId, 'desktop', canRequestAudioTrack)),
+      'desktop getUserMedia'
+    )
+  }
+
   try {
     log(`Attempting getUserMedia with streamId ${streamId} source= tab`)
     const s = await withStreamTimeout(
-      navigator.mediaDevices.getUserMedia(makeConstraints(streamId, 'tab')),
+      navigator.mediaDevices.getUserMedia(makeConstraints(streamId, 'tab', canRequestAudioTrack)),
       'tab getUserMedia'
     )
     return s
@@ -404,7 +485,7 @@ async function captureWithStreamId(streamId: string): Promise<MediaStream> {
   }
   log(`Attempting getUserMedia with streamId ${streamId} source= desktop`)
   return await withStreamTimeout(
-    navigator.mediaDevices.getUserMedia(makeConstraints(streamId, 'desktop')),
+    navigator.mediaDevices.getUserMedia(makeConstraints(streamId, 'desktop', canRequestAudioTrack)),
     'desktop getUserMedia'
   )
 }
@@ -540,8 +621,7 @@ async function buildUploadQueueEntryFromSpool(record: RecordingSpoolRecord): Pro
 
 async function markSpoolRecordFailedUnrecoverable(
   record: RecordingSpoolRecord,
-  message: string,
-  cleanupChunks = true
+  message: string
 ): Promise<RecordingSpoolRecord> {
   const failedRecord: RecordingSpoolRecord = {
     ...record,
@@ -553,17 +633,12 @@ async function markSpoolRecordFailedUnrecoverable(
   }
   await updateSpoolRecording(failedRecord)
   await persistHistoryItem(failedRecord)
-  if (cleanupChunks) await cleanupTerminalSpoolEntry(record.localId, 'markSpoolRecordFailedUnrecoverable.cleanup')
+  retainTerminalSpoolEntry(record.localId, 'markSpoolRecordFailedUnrecoverable.retain')
   return failedRecord
 }
 
-async function cleanupTerminalSpoolEntry(localId: string, operation: string): Promise<void> {
-  try {
-    await deleteSpoolChunks(localId)
-    await deleteSpoolRecording(localId)
-  } catch (e) {
-    captureException(e, { operation, localId })
-  }
+function retainTerminalSpoolEntry(localId: string, operation: string): void {
+  log('Retaining local recording spool entry', { localId, operation })
 }
 
 async function markCurrentSpoolLocalError(message: string): Promise<void> {
@@ -579,7 +654,7 @@ async function markCurrentSpoolLocalError(message: string): Promise<void> {
   }
   await updateSpoolRecording(currentSpoolRecord)
   await persistHistoryItem(currentSpoolRecord)
-  await cleanupTerminalSpoolEntry(localId, 'markCurrentSpoolLocalError.cleanup')
+  retainTerminalSpoolEntry(localId, 'markCurrentSpoolLocalError.retain')
 }
 
 async function uploadInputFromQueueEntry(entry: UploadQueueEntry): Promise<UploadRecordingInput> {
@@ -592,6 +667,7 @@ async function uploadInputFromQueueEntry(entry: UploadQueueEntry): Promise<Uploa
     : null
 
   return {
+    recordingId: resolveExtensionRecordingId(entry) ?? undefined,
     title: entry.title,
     meetingId: entry.meetingId,
     meetingTitle: entry.meetingTitle,
@@ -635,7 +711,193 @@ function saveRecorderChunk(asset: 'video_audio' | 'microphone', blob: Blob, mime
   })
 }
 
-async function persistHistoryItem(item: RecordingHistoryItem): Promise<RecordingHistoryItem[]> {
+function withBackendRecordingId(item: RecordingHistoryItem): RecordingHistoryItem {
+  if (resolveExtensionRecordingId(item)) return item
+  return {
+    ...item,
+    backendRecordingId: generateBackendRecordingId(),
+    updatedAt: new Date().toISOString()
+  }
+}
+
+async function storeGeneratedBackendRecordingId(item: RecordingHistoryItem): Promise<void> {
+  const queueEntry = uploadQueue.find(entry => entry.localId === item.localId)
+  if (queueEntry && queueEntry.backendRecordingId !== item.backendRecordingId) {
+    queueEntry.backendRecordingId = item.backendRecordingId
+    await updateSpoolRecording({
+      ...toHistoryItem(queueEntry),
+      schemaVersion: queueEntry.schemaVersion,
+      videoMimeType: queueEntry.videoMimeType,
+      microphoneMimeType: queueEntry.microphoneMimeType,
+      uploadSession: queueEntry.uploadSession ?? null
+    }).catch((e) => {
+      captureException(e, { operation: 'storeGeneratedBackendRecordingId.queueEntry', localId: item.localId })
+    })
+  }
+
+  if (currentSpoolRecord?.localId === item.localId && currentSpoolRecord.backendRecordingId !== item.backendRecordingId) {
+    currentSpoolRecord = {
+      ...currentSpoolRecord,
+      backendRecordingId: item.backendRecordingId,
+      updatedAt: item.updatedAt
+    }
+    await updateSpoolRecording(currentSpoolRecord).catch((e) => {
+      captureException(e, { operation: 'storeGeneratedBackendRecordingId.currentSpool', localId: item.localId })
+    })
+  }
+
+  const spoolRecord = await getSpoolRecording(item.localId).catch((e) => {
+    captureException(e, { operation: 'storeGeneratedBackendRecordingId.getSpoolRecording', localId: item.localId })
+    return null
+  })
+  if (spoolRecord && spoolRecord.backendRecordingId !== item.backendRecordingId) {
+    await updateSpoolRecording({
+      ...spoolRecord,
+      backendRecordingId: item.backendRecordingId,
+      updatedAt: item.updatedAt
+    }).catch((e) => {
+      captureException(e, { operation: 'storeGeneratedBackendRecordingId.spoolRecord', localId: item.localId })
+    })
+  }
+}
+
+async function queueRecordingStateSync(item: RecordingHistoryItem): Promise<RecordingHistoryItem | null> {
+  const normalizedItem = normalizeRecordingHistoryItem(item)
+  if (!normalizedItem || !isExtensionMutableRecordingStatus(normalizedItem.status)) return normalizedItem
+
+  const syncItem = withBackendRecordingId(normalizedItem)
+  const recordingId = resolveExtensionRecordingId(syncItem)
+  if (!recordingId) {
+    captureMessage('Recording state cannot be synchronized because no backend recording id could be generated.', 'warning', {
+      operation: 'queueRecordingStateSync',
+      localId: syncItem.localId,
+      status: syncItem.status
+    })
+    return syncItem
+  }
+
+  if (syncItem.backendRecordingId !== normalizedItem.backendRecordingId) {
+    await storeGeneratedBackendRecordingId(syncItem)
+  }
+
+  recordingStateSyncQueue.set(recordingId, syncItem)
+  wakeRecordingStateSyncWorker()
+  void runRecordingStateSyncWorker().catch((e) => {
+    log('Unexpected recording state sync worker failure', e)
+    captureException(e, { operation: 'runRecordingStateSyncWorker.unhandled' })
+  })
+  return syncItem
+}
+
+async function markRecordingStateSynced(
+  item: RecordingHistoryItem,
+  recordingId: string
+): Promise<void> {
+  if (item.backendRecordingId === recordingId) return
+
+  const updatedItem: RecordingHistoryItem = {
+    ...item,
+    backendRecordingId: recordingId
+  }
+
+  if (currentSpoolRecord?.localId === item.localId) {
+    currentSpoolRecord = {
+      ...currentSpoolRecord,
+      backendRecordingId: recordingId
+    }
+    await updateSpoolRecording(currentSpoolRecord).catch((e) => {
+      captureException(e, { operation: 'markRecordingStateSynced.currentSpool', localId: item.localId })
+    })
+  }
+
+  const queueEntry = uploadQueue.find(entry => entry.localId === item.localId)
+  if (queueEntry) {
+    queueEntry.backendRecordingId = recordingId
+    await updateSpoolRecording({
+      ...toHistoryItem(queueEntry),
+      schemaVersion: queueEntry.schemaVersion,
+      videoMimeType: queueEntry.videoMimeType,
+      microphoneMimeType: queueEntry.microphoneMimeType,
+      uploadSession: queueEntry.uploadSession ?? null
+    }).catch((e) => {
+      captureException(e, { operation: 'markRecordingStateSynced.queueEntry', localId: item.localId })
+    })
+  }
+
+  await persistHistoryItem(updatedItem, { syncState: false })
+}
+
+async function queueAllKnownRecordingStates(): Promise<void> {
+  const [spoolRecords, historyItems] = await Promise.all([
+    listSpoolRecordings().catch((e) => {
+      captureException(e, { operation: 'queueAllKnownRecordingStates.listSpoolRecordings' })
+      return [] as RecordingSpoolRecord[]
+    }),
+    readRecordingHistory().catch((e) => {
+      captureException(e, { operation: 'queueAllKnownRecordingStates.readRecordingHistory' })
+      return [] as RecordingHistoryItem[]
+    })
+  ])
+
+  const byLocalId = new Map<string, RecordingHistoryItem>()
+  for (const item of historyItems) byLocalId.set(item.localId, item)
+  for (const record of spoolRecords) byLocalId.set(record.localId, record)
+  for (const item of byLocalId.values()) await queueRecordingStateSync(item)
+}
+
+async function runRecordingStateSyncWorker(): Promise<void> {
+  if (recordingStateSyncWorkerRunning) return
+  recordingStateSyncWorkerRunning = true
+
+  try {
+    while (recordingStateSyncQueue.size > 0) {
+      let extensionToken: string
+      try {
+        extensionToken = await requestMeet2NoteExtensionToken()
+      } catch (e) {
+        if (!isMeet2NoteAuthError(e)) {
+          captureException(e, { operation: 'runRecordingStateSyncWorker.auth' })
+        }
+        return
+      }
+
+      let hadRetryableFailure = false
+      for (const [recordingId, item] of Array.from(recordingStateSyncQueue.entries())) {
+        try {
+          const result = await syncExtensionRecordingState(item, extensionToken)
+          recordingStateSyncQueue.delete(recordingId)
+          await markRecordingStateSynced(item, result.recordingId)
+        } catch (e) {
+          if (isMeet2NoteAuthError(e)) {
+            await chrome.runtime.sendMessage({
+              type: 'MARK_MEET2NOTE_RECONNECT_REQUIRED',
+              message: e.message
+            }).catch(() => {})
+            return
+          }
+
+          hadRetryableFailure = true
+          captureException(e, {
+            operation: 'runRecordingStateSyncWorker.sync',
+            localId: item.localId,
+            status: item.status
+          })
+        }
+      }
+
+      if (hadRetryableFailure) {
+        await sleepUntilRecordingStateSyncWakeOrTimeout(RECORDING_STATE_SYNC_RETRY_INTERVAL_MS)
+      }
+    }
+  } finally {
+    recordingStateSyncWorkerRunning = false
+  }
+}
+
+async function persistHistoryItem(
+  item: RecordingHistoryItem,
+  options: { syncState?: boolean } = {}
+): Promise<RecordingHistoryItem[]> {
   const normalizedItem = normalizeRecordingHistoryItem(item)
   if (!normalizedItem) {
     captureMessage('Recording history item could not be normalized; continuing with local spool state.', 'warning', {
@@ -646,30 +908,34 @@ async function persistHistoryItem(item: RecordingHistoryItem): Promise<Recording
     return [item]
   }
 
+  const itemToPersist = options.syncState === false
+    ? normalizedItem
+    : await queueRecordingStateSync(normalizedItem) ?? normalizedItem
+
   try {
     const response = await chrome.runtime.sendMessage({
       type: 'UPSERT_RECORDING_HISTORY_ITEM',
-      item: normalizedItem
+      item: itemToPersist
     })
     if (response?.ok === false) {
       captureMessage('Recording history update rejected by background; continuing with local spool state.', 'warning', {
         operation: 'persistHistoryItem',
-        status: normalizedItem.status,
-        localId: normalizedItem.localId,
+        status: itemToPersist.status,
+        localId: itemToPersist.localId,
         error: typeof response.error === 'string' ? response.error : null
       })
-      return [normalizedItem]
+      return [itemToPersist]
     }
     return Array.isArray(response?.items)
       ? response.items as RecordingHistoryItem[]
-      : [normalizedItem]
+      : [itemToPersist]
   } catch (e) {
     captureException(e, {
       operation: 'persistHistoryItem',
-      status: normalizedItem.status,
-      localId: normalizedItem.localId
+      status: itemToPersist.status,
+      localId: itemToPersist.localId
     })
-    return [normalizedItem]
+    return [itemToPersist]
   }
 }
 
@@ -783,7 +1049,7 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
         error: null,
         uploadProgressPercent: null
       })
-      await cleanupTerminalSpoolEntry(entry.localId, 'uploadQueueEntryUntilTerminal.cleanupUploaded')
+      retainTerminalSpoolEntry(entry.localId, 'uploadQueueEntryUntilTerminal.retainUploaded')
       removeQueueEntry(entry.localId)
       log('Upload completed', { localId: entry.localId, recordingId: result.recordingId, assets: result.assets, attempt })
       return 'done'
@@ -797,7 +1063,7 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
           nextRetryAt: null,
           uploadProgressPercent: null
         })
-        await cleanupTerminalSpoolEntry(entry.localId, 'uploadQueueEntryUntilTerminal.cleanupUnrecoverable')
+        retainTerminalSpoolEntry(entry.localId, 'uploadQueueEntryUntilTerminal.retainUnrecoverable')
         removeQueueEntry(entry.localId)
         log('Upload failed permanently because local recording data is missing', { localId: entry.localId, attempt })
         return 'done'
@@ -939,11 +1205,13 @@ async function markInterruptedSpoolRecordings(): Promise<void> {
       : INTERRUPTED_RECORDING_MESSAGE
     await markSpoolRecordFailedUnrecoverable(record, message)
   }
+  if (interrupted.length > 0) {
+    pushState(false, { warning: 'INTERRUPTED_RECORDING_RESTORED' })
+  }
 }
 
 async function readLocalRecordingHistory(): Promise<RecordingHistoryItem[]> {
-  const response = await chrome.runtime.sendMessage({ type: 'READ_RECORDING_HISTORY' }).catch(() => null)
-  return Array.isArray(response?.items) ? response.items as RecordingHistoryItem[] : []
+  return readRecordingHistory()
 }
 
 async function markOrphanedPendingHistoryItems(uploadableSpoolLocalIds: Set<string>): Promise<void> {
@@ -976,6 +1244,7 @@ async function restoreUploadQueueFromSpool(): Promise<void> {
 
 async function restoreUploadQueueFromSpoolOnce(): Promise<void> {
   await markInterruptedSpoolRecordings()
+  await queueAllKnownRecordingStates()
   const records = await listUploadableSpoolRecordings()
   await markOrphanedPendingHistoryItems(new Set(records.map(record => record.localId)))
   let restored = 0
@@ -1023,6 +1292,7 @@ async function restoreUploadQueueFromSpoolOnce(): Promise<void> {
 }
 
 async function requeueAuthRequiredUploads(): Promise<void> {
+  await queueAllKnownRecordingStates()
   let changed = false
   for (const entry of uploadQueue) {
     if (entry.status !== 'failed' || entry.failureReason !== 'auth_required') continue
@@ -1129,7 +1399,7 @@ function markCurrentSpoolFailedUnrecoverable(message: string): void {
   currentSpoolRecord = nextRecord
   void updateSpoolRecording(nextRecord).catch(() => {})
   void persistHistoryItem(nextRecord).catch(() => {})
-  void cleanupTerminalSpoolEntry(nextRecord.localId, 'markCurrentSpoolFailedUnrecoverable.cleanup')
+  retainTerminalSpoolEntry(nextRecord.localId, 'markCurrentSpoolFailedUnrecoverable.retain')
 }
 
 function forceClearStuckRecording(recordingId: number, reason: string, error?: unknown): void {
@@ -1413,6 +1683,8 @@ async function prepareAndRecord(
 
 async function startRecordingFromStreamId(
   streamId: string,
+  captureSource: CaptureSource,
+  canRequestAudioTrack: boolean,
   micPreferences: MicPreferences,
   recordingContext: RecordingContext
 ): Promise<RecordingStartInfo> {
@@ -1424,9 +1696,14 @@ async function startRecordingFromStreamId(
   }
   cleanupRecordingResources()
   try {
-    const baseStream = await captureWithStreamId(streamId)
+    const baseStream = await captureWithStreamId(streamId, captureSource, canRequestAudioTrack)
     return await prepareAndRecord(baseStream, micPreferences, recordingContext)
   } catch (e) {
+    if (currentSpoolRecord) {
+      await markCurrentSpoolLocalError(e instanceof Error ? e.message : String(e)).catch((markError) => {
+        captureException(markError, { operation: 'startRecordingFromStreamId.markCurrentSpoolLocalError' })
+      })
+    }
     cleanupRecordingResources()
     captureException(e, { operation: 'startRecordingFromStreamId' })
     mediaRecorder = null
@@ -1473,6 +1750,8 @@ async function handleOffscreenPortMessage(msg: any): Promise<void> {
     if (msg?.type === 'OFFSCREEN_START') {
       const streamId = msg.streamId as string | undefined
       if (!streamId) return respond(msg, { ok: false, error: 'Missing streamId' })
+      const captureSource = msg.captureSource === 'desktop' ? 'desktop' : 'tab'
+      const canRequestAudioTrack = msg.canRequestAudioTrack !== false
       const micPreferences = (msg.micPreferences || {
         preferredMicDeviceId: null,
         preferredMicLabel: null
@@ -1480,7 +1759,13 @@ async function handleOffscreenPortMessage(msg: any): Promise<void> {
       const recordingContext = (msg.recordingContext || {}) as RecordingContext
       try {
         // Poczekaj, aż nagrywanie faktycznie wystartuje.
-        const recordingInfo = await startRecordingFromStreamId(streamId, micPreferences, recordingContext)
+        const recordingInfo = await startRecordingFromStreamId(
+          streamId,
+          captureSource,
+          canRequestAudioTrack,
+          micPreferences,
+          recordingContext
+        )
         return respond(msg, { ok: true, ...recordingInfo })
       } catch (e: any) {
         captureException(e, { operation: 'OFFSCREEN_START' })

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -778,6 +778,7 @@ async function queueRecordingStateSync(item: RecordingHistoryItem): Promise<Reco
 
   if (syncItem.backendRecordingId !== normalizedItem.backendRecordingId) {
     await storeGeneratedBackendRecordingId(syncItem)
+    await persistHistoryItem(syncItem, { syncState: false })
   }
 
   recordingStateSyncQueue.set(recordingId, syncItem)
@@ -793,8 +794,6 @@ async function markRecordingStateSynced(
   item: RecordingHistoryItem,
   recordingId: string
 ): Promise<void> {
-  if (item.backendRecordingId === recordingId) return
-
   const updatedItem: RecordingHistoryItem = {
     ...item,
     backendRecordingId: recordingId
@@ -855,7 +854,12 @@ async function runRecordingStateSyncWorker(): Promise<void> {
       try {
         extensionToken = await requestMeet2NoteExtensionToken()
       } catch (e) {
-        if (!isMeet2NoteAuthError(e)) {
+        if (isMeet2NoteAuthError(e)) {
+          await chrome.runtime.sendMessage({
+            type: 'MARK_MEET2NOTE_RECONNECT_REQUIRED',
+            message: e.message
+          }).catch(() => {})
+        } else {
           captureException(e, { operation: 'runRecordingStateSyncWorker.auth' })
         }
         return

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -215,14 +215,17 @@ async function persistQueueEntry(entry: UploadQueueEntry): Promise<void> {
     })
   }
 
+  const historyItem = toHistoryItem(entry)
   await updateSpoolRecording({
-    ...toHistoryItem(entry),
+    ...historyItem,
     schemaVersion: entry.schemaVersion,
     videoMimeType: entry.videoMimeType,
     microphoneMimeType: entry.microphoneMimeType,
     uploadSession: entry.uploadSession ?? null
   })
-  await persistHistoryItem(toHistoryItem(entry))
+
+  const syncItem = await queueRecordingStateSync(historyItem) ?? historyItem
+  await persistHistoryItem(syncItem, { syncState: false })
 }
 
 let activeStreams = new Set<MediaStream>()
@@ -869,8 +872,10 @@ async function runRecordingStateSyncWorker(): Promise<void> {
       for (const [recordingId, item] of Array.from(recordingStateSyncQueue.entries())) {
         try {
           const result = await syncExtensionRecordingState(item, extensionToken)
-          recordingStateSyncQueue.delete(recordingId)
-          await markRecordingStateSynced(item, result.recordingId)
+          if (recordingStateSyncQueue.get(recordingId) === item) {
+            recordingStateSyncQueue.delete(recordingId)
+            await markRecordingStateSynced(item, result.recordingId)
+          }
         } catch (e) {
           if (isMeet2NoteAuthError(e)) {
             await chrome.runtime.sendMessage({

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -39,6 +39,7 @@ interface RecordingStatus {
   starting: boolean
   stopping: boolean
   recordingStartedAt: number | null
+  error: string | null
 }
 
 const { Text } = Typography
@@ -233,7 +234,8 @@ function App(): React.ReactElement {
     recording: false,
     starting: false,
     stopping: false,
-    recordingStartedAt: null
+    recordingStartedAt: null,
+    error: null
   })
   const [recentRecordings, setRecentRecordings] = useState<RecordingHistoryItem[]>(initialCache.recentRecordings)
   const [micStatus, setMicStatus] = useState('')
@@ -289,7 +291,8 @@ function App(): React.ReactElement {
           recording: !!status?.recording,
           starting: !!status?.starting,
           stopping: !!status?.stopping,
-          recordingStartedAt: typeof startedAt === 'number' ? startedAt : null
+          recordingStartedAt: typeof startedAt === 'number' ? startedAt : null,
+          error: typeof status?.error === 'string' ? status.error : null
         })
         setRecentRecordings(sanitizeRecordingHistory(status?.recentRecordings))
       } catch {
@@ -297,7 +300,8 @@ function App(): React.ReactElement {
           recording: false,
           starting: false,
           stopping: false,
-          recordingStartedAt: null
+          recordingStartedAt: null,
+          error: null
         })
       }
       await Promise.all([
@@ -341,7 +345,8 @@ function App(): React.ReactElement {
           recording: !!msg.recording,
           starting: !!msg.starting,
           stopping: !!msg.stopping,
-          recordingStartedAt: typeof startedAt === 'number' ? startedAt : null
+          recordingStartedAt: typeof startedAt === 'number' ? startedAt : null,
+          error: typeof msg.error === 'string' ? msg.error : null
         })
       }
 
@@ -441,26 +446,11 @@ function App(): React.ReactElement {
       recording: false,
       starting: true,
       stopping: false,
-      recordingStartedAt: null
+      recordingStartedAt: null,
+      error: null
     })
 
     try {
-      if ('permissions' in navigator) {
-        try {
-          const status = await (navigator as any).permissions.query({ name: 'microphone' })
-          if (status.state !== 'granted') {
-            try {
-              const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-              stream.getTracks().forEach(track => track.stop())
-            } catch {
-              // Continue with tab audio only.
-            }
-          }
-        } catch {
-          // Ignore unavailable permission state.
-        }
-      }
-
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true })
       if (!tab?.id) throw new Error('No active tab')
 
@@ -471,7 +461,8 @@ function App(): React.ReactElement {
           recording: false,
           starting: true,
           stopping: false,
-          recordingStartedAt: null
+          recordingStartedAt: null,
+          error: null
         })
         return
       }
@@ -490,7 +481,8 @@ function App(): React.ReactElement {
         recording: true,
         starting: false,
         stopping: false,
-        recordingStartedAt: typeof startedAt === 'number' ? startedAt : Date.now()
+        recordingStartedAt: typeof startedAt === 'number' ? startedAt : Date.now(),
+        error: null
       })
       console.log('[popup] Recording started')
       if (response.warning === 'NO_MIC_AUDIO') {
@@ -504,7 +496,8 @@ function App(): React.ReactElement {
         recording: false,
         starting: false,
         stopping: false,
-        recordingStartedAt: null
+        recordingStartedAt: null,
+        error: error?.message || String(error)
       })
       alert(`Failed to start recording:\n${error?.message || error}`)
     } finally {
@@ -520,7 +513,8 @@ function App(): React.ReactElement {
       ...previous,
       recording: true,
       starting: false,
-      stopping: true
+      stopping: true,
+      error: null
     }))
 
     try {
@@ -539,7 +533,8 @@ function App(): React.ReactElement {
           recording: false,
           starting: false,
           stopping: false,
-          recordingStartedAt: null
+          recordingStartedAt: null,
+          error: null
         })
       }
       console.log('[popup] Stopping... uploading...')
@@ -551,7 +546,8 @@ function App(): React.ReactElement {
         recording: false,
         starting: false,
         stopping: false,
-        recordingStartedAt: null
+        recordingStartedAt: null,
+        error: null
       })
     } finally {
       inFlightRef.current = false
@@ -661,15 +657,25 @@ function App(): React.ReactElement {
                 Loading...
               </Button>
             ) : recordingControlsAvailable ? (
-              <Button
-                block
-                disabled={actionDisabled}
-                icon={actionIcon}
-                onClick={toggleRecording}
-                type={recordingState.recording ? 'default' : 'primary'}
-              >
-                {recordingButtonText}
-              </Button>
+              <>
+                <Button
+                  block
+                  disabled={actionDisabled}
+                  icon={actionIcon}
+                  onClick={toggleRecording}
+                  type={recordingState.recording ? 'default' : 'primary'}
+                >
+                  {recordingButtonText}
+                </Button>
+                {recordingState.error ? (
+                  <Alert
+                    type="error"
+                    showIcon={false}
+                    message={recordingState.error}
+                    style={{ fontSize: 12, padding: '4px 8px' }}
+                  />
+                ) : null}
+              </>
             ) : (
               <Button
                 block

--- a/src/recordingHistory.ts
+++ b/src/recordingHistory.ts
@@ -45,9 +45,7 @@ export interface RecordingHistoryItem {
 }
 
 export const RECORDING_HISTORY_KEY = 'meet2noteRecordingHistory'
-export const RECORDING_HISTORY_LIMIT = 10
 export const POPUP_RECORDING_HISTORY_LIMIT = 5
-export const LOCAL_ONLY_FAILURE_HISTORY_TTL_MS = 3 * 60 * 1000
 
 type StoredRecordingHistory = Partial<Record<typeof RECORDING_HISTORY_KEY, unknown>>
 
@@ -198,11 +196,6 @@ export function normalizeRecordingHistoryItem(value: unknown): RecordingHistoryI
   return sanitizeHistoryItem(value)
 }
 
-function timestampMs(value: string): number | null {
-  const parsed = Date.parse(value)
-  return Number.isFinite(parsed) ? parsed : null
-}
-
 export function isLocalOnlyFailureWithoutRecording(item: RecordingHistoryItem): boolean {
   return item.status === 'failed' &&
     !item.backendRecordingId &&
@@ -210,41 +203,24 @@ export function isLocalOnlyFailureWithoutRecording(item: RecordingHistoryItem): 
 }
 
 export function isExpiredLocalOnlyFailureWithoutRecording(
-  item: RecordingHistoryItem,
-  nowMs = Date.now()
+  _item: RecordingHistoryItem,
+  _nowMs = Date.now()
 ): boolean {
-  if (!isLocalOnlyFailureWithoutRecording(item)) return false
-  const timestamp = timestampMs(item.updatedAt) ?? timestampMs(item.createdAt)
-  if (timestamp == null) return false
-  return nowMs - timestamp >= LOCAL_ONLY_FAILURE_HISTORY_TTL_MS
+  return false
 }
 
-export function normalizeRecordingHistory(value: unknown, nowMs = Date.now()): RecordingHistoryItem[] {
+export function normalizeRecordingHistory(value: unknown, _nowMs = Date.now()): RecordingHistoryItem[] {
   if (!Array.isArray(value)) return []
   const unique = new Map<string, RecordingHistoryItem>()
   for (const item of value) {
     const sanitized = sanitizeHistoryItem(item)
     if (sanitized) unique.set(sanitized.localId, sanitized)
   }
-  return trimRecordingHistory(
-    Array.from(unique.values()).filter(item => !isExpiredLocalOnlyFailureWithoutRecording(item, nowMs))
-  )
+  return trimRecordingHistory(Array.from(unique.values()))
 }
 
 export function trimRecordingHistory(items: RecordingHistoryItem[]): RecordingHistoryItem[] {
-  const sorted = [...items].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
-  const kept: RecordingHistoryItem[] = []
-  let terminalCount = 0
-
-  for (const item of sorted) {
-    if (isTerminalRecordingStatus(item.status)) {
-      terminalCount += 1
-      if (terminalCount > RECORDING_HISTORY_LIMIT) continue
-    }
-    kept.push(item)
-  }
-
-  return kept
+  return [...items].sort((a, b) => b.createdAt.localeCompare(a.createdAt))
 }
 
 function enqueueRecordingHistoryWrite<T>(operation: () => Promise<T>): Promise<T> {

--- a/src/recordingStateSync.ts
+++ b/src/recordingStateSync.ts
@@ -1,0 +1,136 @@
+import { makeAuthorizationHeader, Meet2NoteAuthError } from './extensionAuth'
+import { makeMeet2NoteUrl } from './meet2noteConfig'
+import type { RecordingHistoryItem, RecordingUploadStatus } from './recordingHistory'
+
+export type ExtensionMutableRecordingStatus = Extract<
+  RecordingUploadStatus,
+  'recording' | 'finalizing' | 'upload_queued' | 'uploading' | 'failed' | 'canceled'
+>
+
+const EXTENSION_MUTABLE_RECORDING_STATUSES = new Set<RecordingUploadStatus>([
+  'recording',
+  'finalizing',
+  'upload_queued',
+  'uploading',
+  'failed',
+  'canceled'
+])
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const SYNC_EXTENSION_STATE_TIMEOUT_MS = 30_000
+
+export interface SyncExtensionRecordingStateResult {
+  recordingId: string
+}
+
+export function isExtensionMutableRecordingStatus(
+  status: RecordingUploadStatus
+): status is ExtensionMutableRecordingStatus {
+  return EXTENSION_MUTABLE_RECORDING_STATUSES.has(status)
+}
+
+export function resolveExtensionRecordingId(item: RecordingHistoryItem): string | null {
+  if (item.backendRecordingId && UUID_PATTERN.test(item.backendRecordingId)) return item.backendRecordingId
+  if (UUID_PATTERN.test(item.localId)) return item.localId
+  return null
+}
+
+function normalizeErrorBody(body: string | null): string | null {
+  if (!body) return null
+  const trimmed = body.trim()
+  if (!trimmed) return null
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (parsed && typeof parsed === 'object') {
+      const record = parsed as Record<string, unknown>
+      const message = record.message
+      const error = record.error
+      if (Array.isArray(message)) return message.map(String).join('; ').slice(0, 500)
+      if (typeof message === 'string' && message.trim()) return message.trim().slice(0, 500)
+      if (typeof error === 'string' && error.trim()) return error.trim().slice(0, 500)
+    }
+  } catch {}
+  return trimmed.slice(0, 500)
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), SYNC_EXTENSION_STATE_TIMEOUT_MS)
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal
+    })
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error('sync extension recording state timed out after 30 seconds')
+    }
+    throw error
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+function titleForSync(title: string): string {
+  const normalizedTitle = title.trim() || 'Browser recording'
+  return normalizedTitle.slice(0, 255)
+}
+
+function isIsoDateString(value: string): boolean {
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp)
+}
+
+export async function syncExtensionRecordingState(
+  item: RecordingHistoryItem,
+  extensionToken: string
+): Promise<SyncExtensionRecordingStateResult> {
+  if (!isExtensionMutableRecordingStatus(item.status)) {
+    throw new Error(`Recording status is backend-owned and cannot be synced by the extension: ${item.status}`)
+  }
+
+  const recordingId = resolveExtensionRecordingId(item)
+  if (!recordingId) {
+    throw new Error(`Recording localId is not a backend-compatible UUID: ${item.localId}`)
+  }
+
+  const body: Record<string, unknown> = {
+    title: titleForSync(item.title),
+    status: item.status
+  }
+
+  if (item.startedAt && isIsoDateString(item.startedAt)) body.startedAt = item.startedAt
+  if (typeof item.durationMs === 'number' && Number.isFinite(item.durationMs) && item.durationMs >= 0) {
+    body.durationMs = Math.floor(item.durationMs)
+  }
+  if (item.status === 'uploading' &&
+    typeof item.uploadProgressPercent === 'number' &&
+    Number.isFinite(item.uploadProgressPercent)) {
+    body.uploadProgressPercent = Math.max(0, Math.min(100, Math.floor(item.uploadProgressPercent)))
+  }
+  if (item.meetingId) body.meetingId = item.meetingId
+  if (item.tabUrl && /^https?:\/\//i.test(item.tabUrl)) body.meetingUrl = item.tabUrl
+
+  const response = await fetchWithTimeout(
+    makeMeet2NoteUrl(`/api/recordings/${encodeURIComponent(recordingId)}/extension-state`),
+    {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: makeAuthorizationHeader(extensionToken)
+      },
+      body: JSON.stringify(body)
+    }
+  )
+
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      throw new Meet2NoteAuthError('Meet2Note connection required to synchronize recording state.', response.status)
+    }
+    const detail = normalizeErrorBody(await response.text().catch(() => null))
+    const suffix = detail ? `: ${detail}` : ''
+    throw new Error(`sync extension recording state failed with HTTP ${response.status}${suffix}`)
+  }
+
+  return { recordingId }
+}

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -15,6 +15,7 @@ export interface UploadSessionState {
 }
 
 export interface UploadRecordingInput {
+  recordingId?: string
   title: string
   meetingId?: string
   meetingTitle?: string
@@ -304,6 +305,7 @@ async function initUpload(
     title: input.title
   }
 
+  if (input.recordingId) body.recordingId = input.recordingId
   if (input.meetingId) body.meetingId = input.meetingId
   if (input.meetingTitle) body.meetingTitle = input.meetingTitle
   if (input.startedAt) body.startedAt = input.startedAt


### PR DESCRIPTION
## Zakres

- Synchronizuje stany nagrań rozszerzenia do backendu przez `PUT /api/recordings/{recordingId}/extension-state` dla statusów właścicielskich rozszerzenia.
- Dogenerowuje stabilny UUID w `backendRecordingId` dla lokalnych pozycji, które go jeszcze nie mają, i używa tego samego `recordingId` przy `POST /api/upload/init`.
- Kolejkuje sync dla bieżących wpisów oraz backlogu z historii i IndexedDB.
- Zatrzymuje automatyczne czyszczenie lokalnego spoolu/historii po sukcesie albo błędzie, zgodnie z decyzją, że użytkownik porzuca pozycje w backendzie.
- Dokłada diagnostykę błędów startu nagrywania oraz fallback do desktop capture, które były już częścią tego brancha.
- Aktualizuje kontrakty i zasady cross-repo.

## Kontekst

Realizuje część wtyczki dla `chrome-recording-transcription-extension#21`. Backendowe rozszerzenie payloadu o pełne uzasadnienie `failed` pozostaje w `recording-backend#31`; obecny backend przyjmuje już podstawowy endpoint syncu stanu.

## Weryfikacja

- `npm run typecheck`
- `make check`

`make check` kończy się sukcesem; webpack nadal raportuje istniejące warningi o rozmiarze `popup.js` i `micsetup.js` oraz npm audit pokazuje istniejące podatności zależności.

## Uprawnienia Chrome

Brak zmian w `permissions` i `host_permissions`.
