### PR TITLE
[codex] Sync failed recordings and orphan spool diagnostics

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -21,6 +21,7 @@ services:
       - ./manifest.json:/workspace/manifest.json:ro
       - ./connect-callback.html:/workspace/connect-callback.html:ro
       - ./popup.html:/workspace/popup.html:ro
+      - ./debug.html:/workspace/debug.html:ro
       - ./offscreen.html:/workspace/offscreen.html:ro
       - ./micsetup.html:/workspace/micsetup.html:ro
       - ./assets:/workspace/assets:ro

--- a/debug.html
+++ b/debug.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Meet2Note Debug</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="debug.js"></script>
+</body>
+</html>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.28",
+    "version": "1.9.31",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/src/debug.tsx
+++ b/src/debug.tsx
@@ -1,0 +1,142 @@
+import {
+  CopyOutlined,
+  ReloadOutlined
+} from '@ant-design/icons'
+import { Alert, Button, ConfigProvider, Flex, Tag, Typography, theme } from 'antd'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import { captureException, initDiagnostics } from './diagnostics'
+import { readDebugSnapshot, type DebugSnapshot } from './debugSnapshot'
+
+initDiagnostics('debug')
+
+const { Text, Title } = Typography
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB']
+  let value = bytes
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+  return `${value.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`
+}
+
+function App(): React.ReactElement {
+  const [snapshot, setSnapshot] = useState<DebugSnapshot | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const snapshotJson = useMemo(
+    () => snapshot ? JSON.stringify(snapshot, null, 2) : '',
+    [snapshot]
+  )
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setSnapshot(await readDebugSnapshot())
+    } catch (err) {
+      console.error('[debug] snapshot error', err)
+      captureException(err, { operation: 'readDebugSnapshot.debugPage' })
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const copyJson = useCallback(async () => {
+    if (!snapshotJson) return
+    try {
+      await navigator.clipboard.writeText(snapshotJson)
+    } catch (err) {
+      console.error('[debug] copy snapshot error', err)
+      captureException(err, { operation: 'copyDebugSnapshot.debugPage' })
+      setError(`Could not copy debug snapshot: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }, [snapshotJson])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  return (
+    <ConfigProvider
+      theme={{
+        algorithm: theme.defaultAlgorithm,
+        token: {
+          borderRadius: 4,
+          fontSize: 14
+        }
+      }}
+    >
+      <Flex vertical gap={16} style={{ minHeight: '100vh', padding: 24, background: '#f6f8fa' }}>
+        <Flex align="center" justify="space-between" gap={12} wrap>
+          <Flex vertical gap={2}>
+            <Title level={3} style={{ margin: 0 }}>
+              Meet2Note Debug
+            </Title>
+            <Text type="secondary">
+              Local extension storage and recording spool snapshot
+            </Text>
+          </Flex>
+          <Flex gap={8}>
+            <Button icon={<ReloadOutlined />} loading={loading} onClick={refresh}>
+              Refresh
+            </Button>
+            <Button disabled={!snapshotJson} icon={<CopyOutlined />} onClick={copyJson} type="primary">
+              Copy JSON
+            </Button>
+          </Flex>
+        </Flex>
+
+        {error ? (
+          <Alert message={error} showIcon type="error" />
+        ) : null}
+
+        {snapshot ? (
+          <Flex vertical gap={12}>
+            <Flex gap={8} wrap>
+              <Tag color="blue">spool: {snapshot.summary.spoolRecordCount}</Tag>
+              <Tag color="warning">blocking: {snapshot.summary.spoolBlockingCount}</Tag>
+              <Tag color="processing">uploadable: {snapshot.summary.spoolUploadableCount}</Tag>
+              <Tag>history: {snapshot.summary.historyCount}</Tag>
+              <Tag>chunks: {snapshot.summary.totalChunks}</Tag>
+              <Tag>bytes: {formatBytes(snapshot.summary.totalChunkBytes)}</Tag>
+              <Tag>version: {snapshot.extension.version}</Tag>
+            </Flex>
+            <pre
+              style={{
+                background: '#111827',
+                borderRadius: 4,
+                color: '#f9fafb',
+                fontSize: 12,
+                lineHeight: 1.45,
+                margin: 0,
+                minHeight: 420,
+                overflow: 'auto',
+                padding: 16,
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word'
+              }}
+            >
+              {snapshotJson}
+            </pre>
+          </Flex>
+        ) : (
+          <Text type="secondary">
+            {loading ? 'Loading debug snapshot...' : 'No debug snapshot loaded'}
+          </Text>
+        )}
+      </Flex>
+    </ConfigProvider>
+  )
+}
+
+const rootElement = document.getElementById('root')
+if (rootElement) {
+  createRoot(rootElement).render(<App />)
+}

--- a/src/debugSnapshot.ts
+++ b/src/debugSnapshot.ts
@@ -106,55 +106,24 @@ async function spoolDatabaseExists(): Promise<boolean> {
   return databases.some(db => db.name === RECORDING_SPOOL_DB_NAME)
 }
 
-function deleteEmptyDebugSpoolDb(timeoutMs = 2_000): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const request = indexedDB.deleteDatabase(RECORDING_SPOOL_DB_NAME)
-    let blocked = false
-    let settled = false
-    const timeoutId = window.setTimeout(() => {
-      if (settled) return
-      settled = true
-      reject(new Error(blocked
-        ? 'Deleting empty debug spool database is blocked by another open connection.'
-        : 'Deleting empty debug spool database timed out.'))
-    }, timeoutMs)
-    const settle = (callback: () => void) => {
-      if (settled) return
-      settled = true
-      window.clearTimeout(timeoutId)
-      callback()
-    }
-
-    request.onsuccess = () => settle(resolve)
-    request.onerror = () => settle(() => reject(request.error || new Error('Could not delete empty debug spool database.')))
-    request.onblocked = () => {
-      blocked = true
-    }
-  })
-}
-
 async function openDebugSpoolDb(): Promise<DebugSpoolOpenResult> {
   if (!await spoolDatabaseExists()) return { db: null, error: null }
   return new Promise((resolve, reject) => {
-    let createdDuringDebugOpen = false
+    let missingDatabaseOpenAborted = false
     const request = indexedDB.open(RECORDING_SPOOL_DB_NAME)
     request.onupgradeneeded = () => {
-      createdDuringDebugOpen = true
+      missingDatabaseOpenAborted = true
+      request.transaction?.abort()
     }
-    request.onerror = () => reject(request.error || new Error('Could not open recording spool.'))
-    request.onsuccess = () => {
-      if (!createdDuringDebugOpen) {
-        resolve({ db: request.result, error: null })
+    request.onerror = () => {
+      if (missingDatabaseOpenAborted) {
+        resolve({ db: null, error: null })
         return
       }
-
-      request.result.close()
-      deleteEmptyDebugSpoolDb()
-        .then(() => resolve({ db: null, error: null }))
-        .catch((e) => resolve({
-          db: null,
-          error: e instanceof Error ? e.message : String(e)
-        }))
+      reject(request.error || new Error('Could not open recording spool.'))
+    }
+    request.onsuccess = () => {
+      resolve({ db: request.result, error: null })
     }
   })
 }

--- a/src/debugSnapshot.ts
+++ b/src/debugSnapshot.ts
@@ -1,8 +1,9 @@
 import { MEET2NOTE_EXTENSION_TOKEN_KEY } from './extensionAuth'
-
-const DEBUG_SPOOL_DB_NAME = 'meet2noteRecordingSpool'
-const DEBUG_RECORDINGS_STORE = 'recordings'
-const DEBUG_CHUNKS_STORE = 'chunks'
+import {
+  RECORDING_SPOOL_CHUNKS_STORE,
+  RECORDING_SPOOL_DB_NAME,
+  RECORDING_SPOOL_RECORDINGS_STORE
+} from './recordingSpool'
 const DEBUG_REDACTED_STORAGE_KEYS = new Set([
   MEET2NOTE_EXTENSION_TOKEN_KEY,
   'meet2noteConnectState',
@@ -96,13 +97,13 @@ function transactionComplete(tx: IDBTransaction): Promise<void> {
 async function spoolDatabaseExists(): Promise<boolean> {
   if (typeof indexedDB.databases !== 'function') return true
   const databases = await indexedDB.databases()
-  return databases.some(db => db.name === DEBUG_SPOOL_DB_NAME)
+  return databases.some(db => db.name === RECORDING_SPOOL_DB_NAME)
 }
 
 async function openDebugSpoolDb(): Promise<IDBDatabase | null> {
   if (!await spoolDatabaseExists()) return null
   return new Promise((resolve, reject) => {
-    const request = indexedDB.open(DEBUG_SPOOL_DB_NAME)
+    const request = indexedDB.open(RECORDING_SPOOL_DB_NAME)
     request.onerror = () => reject(request.error || new Error('Could not open recording spool.'))
     request.onsuccess = () => resolve(request.result)
   })
@@ -268,15 +269,15 @@ async function readDebugSpool(): Promise<DebugSnapshot['spool']> {
     let rawRecords: unknown[] = []
     const chunkStatsByLocalId: Record<string, DebugChunkStats> = {}
 
-    if (stores.includes(DEBUG_RECORDINGS_STORE)) {
-      const tx = db.transaction(DEBUG_RECORDINGS_STORE, 'readonly')
-      rawRecords = await requestResult<unknown[]>(tx.objectStore(DEBUG_RECORDINGS_STORE).getAll())
+    if (stores.includes(RECORDING_SPOOL_RECORDINGS_STORE)) {
+      const tx = db.transaction(RECORDING_SPOOL_RECORDINGS_STORE, 'readonly')
+      rawRecords = await requestResult<unknown[]>(tx.objectStore(RECORDING_SPOOL_RECORDINGS_STORE).getAll())
       await transactionComplete(tx)
     }
 
-    if (stores.includes(DEBUG_CHUNKS_STORE)) {
-      const tx = db.transaction(DEBUG_CHUNKS_STORE, 'readonly')
-      const store = tx.objectStore(DEBUG_CHUNKS_STORE)
+    if (stores.includes(RECORDING_SPOOL_CHUNKS_STORE)) {
+      const tx = db.transaction(RECORDING_SPOOL_CHUNKS_STORE, 'readonly')
+      const store = tx.objectStore(RECORDING_SPOOL_CHUNKS_STORE)
       await new Promise<void>((resolve, reject) => {
         const request = store.openCursor()
         request.onerror = () => reject(request.error || new Error('Recording spool cursor failed.'))

--- a/src/debugSnapshot.ts
+++ b/src/debugSnapshot.ts
@@ -72,11 +72,17 @@ export interface DebugSnapshot {
   }
   spool: {
     available: boolean
+    error: string | null
     stores: string[]
     records: DebugSpoolRecordSummary[]
     chunkStatsByLocalId: Record<string, DebugChunkStats>
   }
   storageLocal: Record<string, unknown>
+}
+
+interface DebugSpoolOpenResult {
+  db: IDBDatabase | null
+  error: string | null
 }
 
 function requestResult<T>(request: IDBRequest<T>): Promise<T> {
@@ -100,17 +106,35 @@ async function spoolDatabaseExists(): Promise<boolean> {
   return databases.some(db => db.name === RECORDING_SPOOL_DB_NAME)
 }
 
-function deleteEmptyDebugSpoolDb(): Promise<void> {
+function deleteEmptyDebugSpoolDb(timeoutMs = 2_000): Promise<void> {
   return new Promise((resolve, reject) => {
     const request = indexedDB.deleteDatabase(RECORDING_SPOOL_DB_NAME)
-    request.onsuccess = () => resolve()
-    request.onerror = () => reject(request.error || new Error('Could not delete empty debug spool database.'))
-    request.onblocked = () => resolve()
+    let blocked = false
+    let settled = false
+    const timeoutId = window.setTimeout(() => {
+      if (settled) return
+      settled = true
+      reject(new Error(blocked
+        ? 'Deleting empty debug spool database is blocked by another open connection.'
+        : 'Deleting empty debug spool database timed out.'))
+    }, timeoutMs)
+    const settle = (callback: () => void) => {
+      if (settled) return
+      settled = true
+      window.clearTimeout(timeoutId)
+      callback()
+    }
+
+    request.onsuccess = () => settle(resolve)
+    request.onerror = () => settle(() => reject(request.error || new Error('Could not delete empty debug spool database.')))
+    request.onblocked = () => {
+      blocked = true
+    }
   })
 }
 
-async function openDebugSpoolDb(): Promise<IDBDatabase | null> {
-  if (!await spoolDatabaseExists()) return null
+async function openDebugSpoolDb(): Promise<DebugSpoolOpenResult> {
+  if (!await spoolDatabaseExists()) return { db: null, error: null }
   return new Promise((resolve, reject) => {
     let createdDuringDebugOpen = false
     const request = indexedDB.open(RECORDING_SPOOL_DB_NAME)
@@ -120,14 +144,17 @@ async function openDebugSpoolDb(): Promise<IDBDatabase | null> {
     request.onerror = () => reject(request.error || new Error('Could not open recording spool.'))
     request.onsuccess = () => {
       if (!createdDuringDebugOpen) {
-        resolve(request.result)
+        resolve({ db: request.result, error: null })
         return
       }
 
       request.result.close()
       deleteEmptyDebugSpoolDb()
-        .then(() => resolve(null))
-        .catch(reject)
+        .then(() => resolve({ db: null, error: null }))
+        .catch((e) => resolve({
+          db: null,
+          error: e instanceof Error ? e.message : String(e)
+        }))
     }
   })
 }
@@ -277,10 +304,11 @@ function addDebugChunkStats(
 }
 
 async function readDebugSpool(): Promise<DebugSnapshot['spool']> {
-  const db = await openDebugSpoolDb()
+  const { db, error } = await openDebugSpoolDb()
   if (!db) {
     return {
       available: false,
+      error,
       stores: [],
       records: [],
       chunkStatsByLocalId: {}
@@ -332,6 +360,7 @@ async function readDebugSpool(): Promise<DebugSnapshot['spool']> {
 
     return {
       available: true,
+      error: null,
       stores,
       records,
       chunkStatsByLocalId

--- a/src/debugSnapshot.ts
+++ b/src/debugSnapshot.ts
@@ -1,0 +1,380 @@
+import { MEET2NOTE_EXTENSION_TOKEN_KEY } from './extensionAuth'
+
+const DEBUG_SPOOL_DB_NAME = 'meet2noteRecordingSpool'
+const DEBUG_RECORDINGS_STORE = 'recordings'
+const DEBUG_CHUNKS_STORE = 'chunks'
+const DEBUG_REDACTED_STORAGE_KEYS = new Set([
+  MEET2NOTE_EXTENSION_TOKEN_KEY,
+  'meet2noteConnectState',
+  'extensionToken',
+  'uploadToken'
+])
+
+export interface DebugAssetStats {
+  chunks: number
+  bytes: number
+  firstChunkCreatedAt: string | null
+  lastChunkCreatedAt: string | null
+}
+
+export interface DebugChunkStats {
+  chunks: number
+  bytes: number
+  firstChunkCreatedAt: string | null
+  lastChunkCreatedAt: string | null
+  assets: Record<string, DebugAssetStats>
+}
+
+export interface DebugSpoolRecordSummary {
+  localId: string | null
+  status: string | null
+  failureReason: string | null
+  error: string | null
+  title: string | null
+  createdAt: string | null
+  updatedAt: string | null
+  startedAt: string | null
+  stoppedAt: string | null
+  attempt: number | null
+  nextRetryAt: number | null
+  backendRecordingId: string | null
+  uploadSession: Record<string, unknown> | null
+  assets: unknown[]
+  videoBytes: number | null
+  microphoneBytes: number | null
+  chunkStats: DebugChunkStats | null
+  countsAgainstSpoolCapacity: boolean
+  uploadable: boolean
+}
+
+export interface DebugSnapshot {
+  generatedAt: string
+  extension: {
+    id: string
+    version: string
+  }
+  runtime: {
+    pageUrl: string
+    userAgent: string
+  }
+  summary: {
+    spoolRecordCount: number
+    spoolBlockingCount: number
+    spoolUploadableCount: number
+    spoolWithBackendIdCount: number
+    spoolWithoutBackendIdCount: number
+    spoolByStatus: Record<string, number>
+    historyCount: number
+    historyByStatus: Record<string, number>
+    totalChunks: number
+    totalChunkBytes: number
+  }
+  spool: {
+    available: boolean
+    stores: string[]
+    records: DebugSpoolRecordSummary[]
+    chunkStatsByLocalId: Record<string, DebugChunkStats>
+  }
+  storageLocal: Record<string, unknown>
+}
+
+function requestResult<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result)
+    request.onerror = () => reject(request.error || new Error('IndexedDB request failed.'))
+  })
+}
+
+function transactionComplete(tx: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    tx.oncomplete = () => resolve()
+    tx.onerror = () => reject(tx.error || new Error('IndexedDB transaction failed.'))
+    tx.onabort = () => reject(tx.error || new Error('IndexedDB transaction aborted.'))
+  })
+}
+
+async function spoolDatabaseExists(): Promise<boolean> {
+  if (typeof indexedDB.databases !== 'function') return true
+  const databases = await indexedDB.databases()
+  return databases.some(db => db.name === DEBUG_SPOOL_DB_NAME)
+}
+
+async function openDebugSpoolDb(): Promise<IDBDatabase | null> {
+  if (!await spoolDatabaseExists()) return null
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DEBUG_SPOOL_DB_NAME)
+    request.onerror = () => reject(request.error || new Error('Could not open recording spool.'))
+    request.onsuccess = () => resolve(request.result)
+  })
+}
+
+function getRecordString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value ? value : null
+}
+
+function getRecordNumber(record: Record<string, unknown>, key: string): number | null {
+  const value = record[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function getRecordTimestamp(record: Record<string, unknown>, key: string): string | null {
+  const value = getRecordString(record, key)
+  if (!value) return null
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) return null
+  return new Date(timestamp).toISOString()
+}
+
+function countsAgainstSpoolCapacity(record: Record<string, unknown>): boolean {
+  return record.status === 'recording' ||
+    record.status === 'finalizing' ||
+    record.status === 'upload_queued' ||
+    record.status === 'uploading' ||
+    (record.status === 'failed' && record.failureReason === 'auth_required')
+}
+
+function isUploadableDebugRecord(record: Record<string, unknown>): boolean {
+  return record.status === 'upload_queued' ||
+    record.status === 'uploading' ||
+    (record.status === 'failed' && record.failureReason === 'auth_required')
+}
+
+function redactedToken(value: unknown): Record<string, unknown> {
+  return {
+    redacted: true,
+    present: typeof value === 'string' ? value.trim().length > 0 : value != null,
+    length: typeof value === 'string' ? value.length : null
+  }
+}
+
+function sanitizeDebugValue(value: unknown, key?: string): unknown {
+  if (key && DEBUG_REDACTED_STORAGE_KEYS.has(key)) return redactedToken(value)
+  if (value instanceof Blob) {
+    return {
+      blob: true,
+      type: value.type || null,
+      size: value.size
+    }
+  }
+  if (Array.isArray(value)) return value.map(item => sanitizeDebugValue(item))
+  if (!value || typeof value !== 'object') return value
+
+  const output: Record<string, unknown> = {}
+  for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+    output[childKey] = sanitizeDebugValue(childValue, childKey)
+  }
+  return output
+}
+
+function sanitizeUploadSession(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object') return null
+  const session = value as Record<string, unknown>
+  return {
+    recordingId: sanitizeDebugValue(session.recordingId),
+    uploadToken: redactedToken(session.uploadToken),
+    expiresAt: sanitizeDebugValue(session.expiresAt),
+    recommendedChunkSizeBytes: sanitizeDebugValue(session.recommendedChunkSizeBytes),
+    maxAssetSizeBytes: sanitizeDebugValue(session.maxAssetSizeBytes)
+  }
+}
+
+function summarizeDebugSpoolRecord(
+  value: unknown,
+  chunkStatsByLocalId: Record<string, DebugChunkStats>
+): DebugSpoolRecordSummary {
+  const record = value && typeof value === 'object'
+    ? value as Record<string, unknown>
+    : {}
+  const localId = getRecordString(record, 'localId')
+  return {
+    localId,
+    status: getRecordString(record, 'status'),
+    failureReason: getRecordString(record, 'failureReason'),
+    error: getRecordString(record, 'error'),
+    title: getRecordString(record, 'title'),
+    createdAt: getRecordString(record, 'createdAt'),
+    updatedAt: getRecordString(record, 'updatedAt'),
+    startedAt: getRecordString(record, 'startedAt'),
+    stoppedAt: getRecordString(record, 'stoppedAt'),
+    attempt: getRecordNumber(record, 'attempt'),
+    nextRetryAt: getRecordNumber(record, 'nextRetryAt'),
+    backendRecordingId: getRecordString(record, 'backendRecordingId'),
+    uploadSession: sanitizeUploadSession(record.uploadSession),
+    assets: Array.isArray(record.assets) ? record.assets.map(item => sanitizeDebugValue(item)) : [],
+    videoBytes: getRecordNumber(record, 'videoBytes'),
+    microphoneBytes: getRecordNumber(record, 'microphoneBytes'),
+    chunkStats: localId ? chunkStatsByLocalId[localId] || null : null,
+    countsAgainstSpoolCapacity: countsAgainstSpoolCapacity(record),
+    uploadable: isUploadableDebugRecord(record)
+  }
+}
+
+function addDebugChunkStats(
+  chunkStatsByLocalId: Record<string, DebugChunkStats>,
+  localId: string,
+  asset: string,
+  bytes: number,
+  createdAt: string | null
+): void {
+  const localStats = chunkStatsByLocalId[localId] || {
+    chunks: 0,
+    bytes: 0,
+    firstChunkCreatedAt: null,
+    lastChunkCreatedAt: null,
+    assets: {}
+  }
+  const assetStats = localStats.assets[asset] || {
+    chunks: 0,
+    bytes: 0,
+    firstChunkCreatedAt: null,
+    lastChunkCreatedAt: null
+  }
+  assetStats.chunks += 1
+  assetStats.bytes += bytes
+  localStats.chunks += 1
+  localStats.bytes += bytes
+  if (createdAt) {
+    if (!assetStats.firstChunkCreatedAt || createdAt < assetStats.firstChunkCreatedAt) {
+      assetStats.firstChunkCreatedAt = createdAt
+    }
+    if (!assetStats.lastChunkCreatedAt || createdAt > assetStats.lastChunkCreatedAt) {
+      assetStats.lastChunkCreatedAt = createdAt
+    }
+    if (!localStats.firstChunkCreatedAt || createdAt < localStats.firstChunkCreatedAt) {
+      localStats.firstChunkCreatedAt = createdAt
+    }
+    if (!localStats.lastChunkCreatedAt || createdAt > localStats.lastChunkCreatedAt) {
+      localStats.lastChunkCreatedAt = createdAt
+    }
+  }
+  localStats.assets[asset] = assetStats
+  chunkStatsByLocalId[localId] = localStats
+}
+
+async function readDebugSpool(): Promise<DebugSnapshot['spool']> {
+  const db = await openDebugSpoolDb()
+  if (!db) {
+    return {
+      available: false,
+      stores: [],
+      records: [],
+      chunkStatsByLocalId: {}
+    }
+  }
+
+  try {
+    const stores = Array.from(db.objectStoreNames)
+    let rawRecords: unknown[] = []
+    const chunkStatsByLocalId: Record<string, DebugChunkStats> = {}
+
+    if (stores.includes(DEBUG_RECORDINGS_STORE)) {
+      const tx = db.transaction(DEBUG_RECORDINGS_STORE, 'readonly')
+      rawRecords = await requestResult<unknown[]>(tx.objectStore(DEBUG_RECORDINGS_STORE).getAll())
+      await transactionComplete(tx)
+    }
+
+    if (stores.includes(DEBUG_CHUNKS_STORE)) {
+      const tx = db.transaction(DEBUG_CHUNKS_STORE, 'readonly')
+      const store = tx.objectStore(DEBUG_CHUNKS_STORE)
+      await new Promise<void>((resolve, reject) => {
+        const request = store.openCursor()
+        request.onerror = () => reject(request.error || new Error('Recording spool cursor failed.'))
+        request.onsuccess = () => {
+          const cursor = request.result
+          if (!cursor) {
+            resolve()
+            return
+          }
+
+          const chunk = cursor.value && typeof cursor.value === 'object'
+            ? cursor.value as Record<string, unknown>
+            : {}
+          const localId = getRecordString(chunk, 'localId') || 'missing-localId'
+          const asset = getRecordString(chunk, 'asset') || 'missing-asset'
+          const createdAt = getRecordTimestamp(chunk, 'createdAt')
+          const blob = chunk.blob instanceof Blob ? chunk.blob : null
+          const size = getRecordNumber(chunk, 'sizeBytes') ?? blob?.size ?? 0
+          addDebugChunkStats(chunkStatsByLocalId, localId, asset, size, createdAt)
+          cursor.continue()
+        }
+      })
+      await transactionComplete(tx)
+    }
+
+    const records = rawRecords
+      .map(record => summarizeDebugSpoolRecord(record, chunkStatsByLocalId))
+      .sort((a, b) => String(a.createdAt).localeCompare(String(b.createdAt)))
+
+    return {
+      available: true,
+      stores,
+      records,
+      chunkStatsByLocalId
+    }
+  } finally {
+    db.close()
+  }
+}
+
+function readChromeStorageLocal(): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    chrome.storage.local.get(null, (items) => {
+      const runtimeError = chrome.runtime.lastError
+      if (runtimeError) return reject(new Error(runtimeError.message))
+      const output: Record<string, unknown> = {}
+      for (const [key, value] of Object.entries(items)) output[key] = sanitizeDebugValue(value, key)
+      resolve(output)
+    })
+  })
+}
+
+function countByStatus(items: Array<{ status?: unknown }>): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const item of items) {
+    const status = typeof item.status === 'string' && item.status ? item.status : 'missing'
+    counts[status] = (counts[status] || 0) + 1
+  }
+  return counts
+}
+
+export async function readDebugSnapshot(): Promise<DebugSnapshot> {
+  const [spool, storageLocal] = await Promise.all([
+    readDebugSpool(),
+    readChromeStorageLocal()
+  ])
+  const historyValue = storageLocal.meet2noteRecordingHistory
+  const history = Array.isArray(historyValue)
+    ? historyValue.filter(item => item && typeof item === 'object') as Array<{ status?: unknown }>
+    : []
+  const totalChunks = Object.values(spool.chunkStatsByLocalId)
+    .reduce((sum, item) => sum + item.chunks, 0)
+  const totalChunkBytes = Object.values(spool.chunkStatsByLocalId)
+    .reduce((sum, item) => sum + item.bytes, 0)
+
+  return {
+    generatedAt: new Date().toISOString(),
+    extension: {
+      id: chrome.runtime.id,
+      version: chrome.runtime.getManifest().version
+    },
+    runtime: {
+      pageUrl: window.location.href,
+      userAgent: navigator.userAgent
+    },
+    summary: {
+      spoolRecordCount: spool.records.length,
+      spoolBlockingCount: spool.records.filter(record => record.countsAgainstSpoolCapacity).length,
+      spoolUploadableCount: spool.records.filter(record => record.uploadable).length,
+      spoolWithBackendIdCount: spool.records.filter(record => !!record.backendRecordingId).length,
+      spoolWithoutBackendIdCount: spool.records.filter(record => !record.backendRecordingId).length,
+      spoolByStatus: countByStatus(spool.records),
+      historyCount: history.length,
+      historyByStatus: countByStatus(history),
+      totalChunks,
+      totalChunkBytes
+    },
+    spool,
+    storageLocal
+  }
+}

--- a/src/debugSnapshot.ts
+++ b/src/debugSnapshot.ts
@@ -100,12 +100,35 @@ async function spoolDatabaseExists(): Promise<boolean> {
   return databases.some(db => db.name === RECORDING_SPOOL_DB_NAME)
 }
 
+function deleteEmptyDebugSpoolDb(): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(RECORDING_SPOOL_DB_NAME)
+    request.onsuccess = () => resolve()
+    request.onerror = () => reject(request.error || new Error('Could not delete empty debug spool database.'))
+    request.onblocked = () => resolve()
+  })
+}
+
 async function openDebugSpoolDb(): Promise<IDBDatabase | null> {
   if (!await spoolDatabaseExists()) return null
   return new Promise((resolve, reject) => {
+    let createdDuringDebugOpen = false
     const request = indexedDB.open(RECORDING_SPOOL_DB_NAME)
+    request.onupgradeneeded = () => {
+      createdDuringDebugOpen = true
+    }
     request.onerror = () => reject(request.error || new Error('Could not open recording spool.'))
-    request.onsuccess = () => resolve(request.result)
+    request.onsuccess = () => {
+      if (!createdDuringDebugOpen) {
+        resolve(request.result)
+        return
+      }
+
+      request.result.close()
+      deleteEmptyDebugSpoolDb()
+        .then(() => resolve(null))
+        .catch(reject)
+    }
   })
 }
 

--- a/src/extensionDiagnosticsClient.ts
+++ b/src/extensionDiagnosticsClient.ts
@@ -1,0 +1,82 @@
+import {
+  makeAuthorizationHeader,
+  Meet2NoteAuthError
+} from './extensionAuth'
+import { makeMeet2NoteUrl } from './meet2noteConfig'
+
+const REPORT_EXTENSION_DIAGNOSTIC_TIMEOUT_MS = 30_000
+
+export interface ExtensionDiagnosticEvent {
+  eventId: string
+  type: string
+  severity: 'debug' | 'info' | 'warning' | 'error'
+  occurredAt: string
+  source: 'chrome_extension'
+  schemaVersion: number
+  payload: Record<string, unknown>
+}
+
+function normalizeErrorBody(body: string | null): string | null {
+  if (!body) return null
+  const trimmed = body.trim()
+  if (!trimmed) return null
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (parsed && typeof parsed === 'object') {
+      const record = parsed as Record<string, unknown>
+      const message = record.message
+      const error = record.error
+      if (Array.isArray(message)) return message.map(String).join('; ').slice(0, 500)
+      if (typeof message === 'string' && message.trim()) return message.trim().slice(0, 500)
+      if (typeof error === 'string' && error.trim()) return error.trim().slice(0, 500)
+    }
+  } catch {}
+  return trimmed.slice(0, 500)
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), REPORT_EXTENSION_DIAGNOSTIC_TIMEOUT_MS)
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal
+    })
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error('extension diagnostic report timed out after 30 seconds')
+    }
+    throw error
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+export async function reportExtensionDiagnostic(
+  event: ExtensionDiagnosticEvent,
+  extensionToken: string
+): Promise<void> {
+  const token = extensionToken.trim()
+  if (!token) throw new Meet2NoteAuthError('Connect to Meet2Note before reporting extension diagnostics.')
+
+  const response = await fetchWithTimeout(
+    makeMeet2NoteUrl('/api/extension/diagnostics'),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: makeAuthorizationHeader(token)
+      },
+      body: JSON.stringify(event)
+    }
+  )
+
+  if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      throw new Meet2NoteAuthError('Meet2Note connection required to report extension diagnostics.', response.status)
+    }
+    const detail = normalizeErrorBody(await response.text().catch(() => null))
+    const suffix = detail ? `: ${detail}` : ''
+    throw new Error(`extension diagnostic report failed with HTTP ${response.status}${suffix}`)
+  }
+}

--- a/src/extensionDiagnosticsClient.ts
+++ b/src/extensionDiagnosticsClient.ts
@@ -2,6 +2,7 @@ import {
   makeAuthorizationHeader,
   Meet2NoteAuthError
 } from './extensionAuth'
+import { fetchWithTimeout, normalizeErrorBody } from './httpClientUtils'
 import { makeMeet2NoteUrl } from './meet2noteConfig'
 
 const REPORT_EXTENSION_DIAGNOSTIC_TIMEOUT_MS = 30_000
@@ -14,42 +15,6 @@ export interface ExtensionDiagnosticEvent {
   source: 'chrome_extension'
   schemaVersion: number
   payload: Record<string, unknown>
-}
-
-function normalizeErrorBody(body: string | null): string | null {
-  if (!body) return null
-  const trimmed = body.trim()
-  if (!trimmed) return null
-  try {
-    const parsed = JSON.parse(trimmed) as unknown
-    if (parsed && typeof parsed === 'object') {
-      const record = parsed as Record<string, unknown>
-      const message = record.message
-      const error = record.error
-      if (Array.isArray(message)) return message.map(String).join('; ').slice(0, 500)
-      if (typeof message === 'string' && message.trim()) return message.trim().slice(0, 500)
-      if (typeof error === 'string' && error.trim()) return error.trim().slice(0, 500)
-    }
-  } catch {}
-  return trimmed.slice(0, 500)
-}
-
-async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), REPORT_EXTENSION_DIAGNOSTIC_TIMEOUT_MS)
-  try {
-    return await fetch(url, {
-      ...init,
-      signal: controller.signal
-    })
-  } catch (error) {
-    if (controller.signal.aborted) {
-      throw new Error('extension diagnostic report timed out after 30 seconds')
-    }
-    throw error
-  } finally {
-    clearTimeout(timeoutId)
-  }
 }
 
 export async function reportExtensionDiagnostic(
@@ -68,7 +33,9 @@ export async function reportExtensionDiagnostic(
         Authorization: makeAuthorizationHeader(token)
       },
       body: JSON.stringify(event)
-    }
+    },
+    REPORT_EXTENSION_DIAGNOSTIC_TIMEOUT_MS,
+    'extension diagnostic report timed out after 30 seconds'
   )
 
   if (!response.ok) {

--- a/src/httpClientUtils.ts
+++ b/src/httpClientUtils.ts
@@ -1,0 +1,41 @@
+export function normalizeErrorBody(body: string | null, maxLength = 500): string | null {
+  if (!body) return null
+  const trimmed = body.trim()
+  if (!trimmed) return null
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+    if (parsed && typeof parsed === 'object') {
+      const record = parsed as Record<string, unknown>
+      const message = record.message
+      const error = record.error
+      if (Array.isArray(message)) return message.map(String).join('; ').slice(0, maxLength)
+      if (typeof message === 'string' && message.trim()) return message.trim().slice(0, maxLength)
+      if (typeof error === 'string' && error.trim()) return error.trim().slice(0, maxLength)
+    }
+  } catch {}
+  return trimmed.slice(0, maxLength)
+}
+
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+  timeoutMessage: string
+): Promise<Response> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: controller.signal
+    })
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(timeoutMessage)
+    }
+    throw error
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -24,7 +24,7 @@ import {
   appendSpoolChunk,
   assertSpoolAvailable,
   createSpoolRecording,
-  deleteSpoolChunks,
+  deleteSpoolChunkKeys,
   getSpoolRecording,
   getSpoolChunkCounts,
   listInterruptedSpoolRecordings,
@@ -50,6 +50,7 @@ const MEDIA_CAPTURE_TIMEOUT_MS = 10_000
 const UPLOAD_RETRY_INTERVAL_MS = 15_000
 const RECORDING_STATE_SYNC_RETRY_INTERVAL_MS = 30_000
 const ORPHANED_CHUNK_REPORT_GRACE_PERIOD_MS = 15 * 60 * 1000
+const ORPHANED_CHUNK_DIAGNOSTIC_INTERVAL_MS = 15 * 60 * 1000
 const STOP_FINALIZE_TIMEOUT_MS = 10_000
 const MICROPHONE_STOP_TIMEOUT_MS = 2_000
 const MEDIA_RECORDER_TIMESLICE_MS = 5_000
@@ -183,6 +184,7 @@ let restoreUploadQueuePromise: Promise<void> | null = null
 let recordingStateSyncWorkerRunning = false
 let recordingStateSyncWake: (() => void) | null = null
 let orphanedChunkDiagnosticsRunning = false
+let lastOrphanedChunkDiagnosticsStartedAtMs = 0
 const recordingStateSyncQueue = new Map<string, RecordingHistoryItem>()
 
 function generateBackendRecordingId(): string {
@@ -1306,6 +1308,9 @@ function isCurrentOrQueuedLocalId(localId: string): boolean {
 
 async function reportAndDeleteOrphanedSpoolChunks(): Promise<void> {
   if (orphanedChunkDiagnosticsRunning) return
+  const nowMs = Date.now()
+  if (nowMs - lastOrphanedChunkDiagnosticsStartedAtMs < ORPHANED_CHUNK_DIAGNOSTIC_INTERVAL_MS) return
+  lastOrphanedChunkDiagnosticsStartedAtMs = nowMs
   orphanedChunkDiagnosticsRunning = true
 
   try {
@@ -1365,7 +1370,7 @@ async function reportAndDeleteOrphanedSpoolChunks(): Promise<void> {
         })
         if (recordAfterReport) continue
 
-        await deleteSpoolChunks(group.localId)
+        await deleteSpoolChunkKeys(group.chunkKeys)
         captureMessage('Deleted orphaned local spool chunks after backend diagnostic acknowledgement.', 'info', {
           operation: 'reportAndDeleteOrphanedSpoolChunks',
           localId: group.localId,
@@ -1395,6 +1400,14 @@ async function reportAndDeleteOrphanedSpoolChunks(): Promise<void> {
   }
 }
 
+function scheduleOrphanedSpoolChunkDiagnostics(): void {
+  window.setTimeout(() => {
+    void reportAndDeleteOrphanedSpoolChunks().catch((e) => {
+      captureException(e, { operation: 'scheduleOrphanedSpoolChunkDiagnostics.unhandled' })
+    })
+  }, 0)
+}
+
 async function restoreUploadQueueFromSpool(): Promise<void> {
   if (restoreUploadQueuePromise) return restoreUploadQueuePromise
   restoreUploadQueuePromise = restoreUploadQueueFromSpoolOnce()
@@ -1409,7 +1422,7 @@ async function restoreUploadQueueFromSpoolOnce(): Promise<void> {
   await queueAllKnownRecordingStates()
   const records = await listUploadableSpoolRecordings()
   await markOrphanedPendingHistoryItems(new Set(records.map(record => record.localId)))
-  await reportAndDeleteOrphanedSpoolChunks()
+  scheduleOrphanedSpoolChunkDiagnostics()
   let restored = 0
   const canResumeAuthRequired = await requestMeet2NoteExtensionToken()
     .then(() => true)

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -7,6 +7,7 @@ import {
 } from './extensionAuth'
 import type { MicPreferences } from './micPreferences'
 import { uploadRecordingOnce, type UploadRecordingInput, type UploadSessionState } from './uploadClient'
+import { reportExtensionDiagnostic } from './extensionDiagnosticsClient'
 import {
   generateRecordingLocalId,
   normalizeRecordingHistoryItem,
@@ -23,14 +24,17 @@ import {
   appendSpoolChunk,
   assertSpoolAvailable,
   createSpoolRecording,
+  deleteSpoolChunks,
   getSpoolRecording,
   getSpoolChunkCounts,
   listInterruptedSpoolRecordings,
+  listOrphanedSpoolChunkGroups,
   listSpoolRecordings,
   listUploadableSpoolRecordings,
   readSpoolAssetBlob,
   SPOOL_SCHEMA_VERSION,
   updateSpoolRecording,
+  type OrphanedSpoolChunkGroup,
   type RecordingSpoolUploadSession,
   type RecordingSpoolRecord
 } from './recordingSpool'
@@ -45,6 +49,7 @@ const WANT_MIC_ASSET = true
 const MEDIA_CAPTURE_TIMEOUT_MS = 10_000
 const UPLOAD_RETRY_INTERVAL_MS = 15_000
 const RECORDING_STATE_SYNC_RETRY_INTERVAL_MS = 30_000
+const ORPHANED_CHUNK_REPORT_GRACE_PERIOD_MS = 15 * 60 * 1000
 const STOP_FINALIZE_TIMEOUT_MS = 10_000
 const MICROPHONE_STOP_TIMEOUT_MS = 2_000
 const MEDIA_RECORDER_TIMESLICE_MS = 5_000
@@ -177,6 +182,7 @@ let uploadQueueWake: (() => void) | null = null
 let restoreUploadQueuePromise: Promise<void> | null = null
 let recordingStateSyncWorkerRunning = false
 let recordingStateSyncWake: (() => void) | null = null
+let orphanedChunkDiagnosticsRunning = false
 const recordingStateSyncQueue = new Map<string, RecordingHistoryItem>()
 
 function generateBackendRecordingId(): string {
@@ -1242,6 +1248,153 @@ async function markOrphanedPendingHistoryItems(uploadableSpoolLocalIds: Set<stri
   }
 }
 
+function historyContextForDiagnostic(item: RecordingHistoryItem | undefined): Record<string, unknown> | null {
+  if (!item) return null
+  return {
+    localId: item.localId,
+    backendRecordingId: item.backendRecordingId,
+    status: item.status,
+    title: item.title,
+    meetingId: item.meetingId ?? null,
+    tabUrl: item.tabUrl ?? null,
+    startedAt: item.startedAt,
+    stoppedAt: item.stoppedAt,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+    durationMs: item.durationMs,
+    attempt: item.attempt,
+    error: item.error,
+    failureReason: item.failureReason,
+    assets: item.assets,
+    videoBytes: item.videoBytes,
+    microphoneBytes: item.microphoneBytes
+  }
+}
+
+function buildOrphanedChunkDiagnosticEvent(
+  group: OrphanedSpoolChunkGroup,
+  historyItem: RecordingHistoryItem | undefined
+) {
+  return {
+    eventId: `chrome-extension:local-spool-orphaned-chunks:${group.localId}`,
+    type: 'local_spool_orphaned_chunks',
+    severity: 'warning' as const,
+    occurredAt: group.lastChunkCreatedAt || new Date().toISOString(),
+    source: 'chrome_extension' as const,
+    schemaVersion: 1,
+    payload: {
+      localId: group.localId,
+      reason: 'chunks_without_spool_record',
+      disposition: 'delete_after_backend_ack',
+      chunks: group.chunks,
+      bytes: group.bytes,
+      firstChunkCreatedAt: group.firstChunkCreatedAt,
+      lastChunkCreatedAt: group.lastChunkCreatedAt,
+      assets: group.assets,
+      extension: {
+        id: chrome.runtime.id,
+        version: chrome.runtime.getManifest().version
+      },
+      historyItem: historyContextForDiagnostic(historyItem)
+    }
+  }
+}
+
+function isCurrentOrQueuedLocalId(localId: string): boolean {
+  return currentSpoolRecord?.localId === localId || uploadQueue.some(entry => entry.localId === localId)
+}
+
+async function reportAndDeleteOrphanedSpoolChunks(): Promise<void> {
+  if (orphanedChunkDiagnosticsRunning) return
+  orphanedChunkDiagnosticsRunning = true
+
+  try {
+    const groups = await listOrphanedSpoolChunkGroups({
+      gracePeriodMs: ORPHANED_CHUNK_REPORT_GRACE_PERIOD_MS
+    }).catch((e) => {
+      captureException(e, { operation: 'reportAndDeleteOrphanedSpoolChunks.listOrphanedSpoolChunkGroups' })
+      return [] as OrphanedSpoolChunkGroup[]
+    })
+    if (!groups.length) return
+
+    let extensionToken: string
+    try {
+      extensionToken = await requestMeet2NoteExtensionToken()
+    } catch (e) {
+      if (isMeet2NoteAuthError(e)) {
+        await chrome.runtime.sendMessage({
+          type: 'MARK_MEET2NOTE_RECONNECT_REQUIRED',
+          message: e.message
+        }).catch(() => {})
+      } else {
+        captureException(e, { operation: 'reportAndDeleteOrphanedSpoolChunks.auth' })
+      }
+      return
+    }
+
+    const historyItems = await readLocalRecordingHistory().catch((e) => {
+      captureException(e, { operation: 'reportAndDeleteOrphanedSpoolChunks.readRecordingHistory' })
+      return [] as RecordingHistoryItem[]
+    })
+    const historyByLocalId = new Map(historyItems.map(item => [item.localId, item]))
+
+    for (const group of groups) {
+      if (isCurrentOrQueuedLocalId(group.localId)) continue
+      const currentRecord = await getSpoolRecording(group.localId).catch((e) => {
+        captureException(e, {
+          operation: 'reportAndDeleteOrphanedSpoolChunks.getSpoolRecording',
+          localId: group.localId
+        })
+        return null
+      })
+      if (currentRecord) continue
+
+      try {
+        await reportExtensionDiagnostic(
+          buildOrphanedChunkDiagnosticEvent(group, historyByLocalId.get(group.localId)),
+          extensionToken
+        )
+
+        if (isCurrentOrQueuedLocalId(group.localId)) continue
+        const recordAfterReport = await getSpoolRecording(group.localId).catch((e) => {
+          captureException(e, {
+            operation: 'reportAndDeleteOrphanedSpoolChunks.getSpoolRecordingAfterReport',
+            localId: group.localId
+          })
+          return null
+        })
+        if (recordAfterReport) continue
+
+        await deleteSpoolChunks(group.localId)
+        captureMessage('Deleted orphaned local spool chunks after backend diagnostic acknowledgement.', 'info', {
+          operation: 'reportAndDeleteOrphanedSpoolChunks',
+          localId: group.localId,
+          chunks: group.chunks,
+          bytes: group.bytes,
+          firstChunkCreatedAt: group.firstChunkCreatedAt,
+          lastChunkCreatedAt: group.lastChunkCreatedAt
+        })
+      } catch (e) {
+        if (isMeet2NoteAuthError(e)) {
+          await chrome.runtime.sendMessage({
+            type: 'MARK_MEET2NOTE_RECONNECT_REQUIRED',
+            message: e.message
+          }).catch(() => {})
+          return
+        }
+        captureException(e, {
+          operation: 'reportAndDeleteOrphanedSpoolChunks.reportOrDelete',
+          localId: group.localId,
+          chunks: group.chunks,
+          bytes: group.bytes
+        })
+      }
+    }
+  } finally {
+    orphanedChunkDiagnosticsRunning = false
+  }
+}
+
 async function restoreUploadQueueFromSpool(): Promise<void> {
   if (restoreUploadQueuePromise) return restoreUploadQueuePromise
   restoreUploadQueuePromise = restoreUploadQueueFromSpoolOnce()
@@ -1256,6 +1409,7 @@ async function restoreUploadQueueFromSpoolOnce(): Promise<void> {
   await queueAllKnownRecordingStates()
   const records = await listUploadableSpoolRecordings()
   await markOrphanedPendingHistoryItems(new Set(records.map(record => record.localId)))
+  await reportAndDeleteOrphanedSpoolChunks()
   let restored = 0
   const canResumeAuthRequired = await requestMeet2NoteExtensionToken()
     .then(() => true)

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -184,6 +184,7 @@ let restoreUploadQueuePromise: Promise<void> | null = null
 let recordingStateSyncWorkerRunning = false
 let recordingStateSyncWake: (() => void) | null = null
 let orphanedChunkDiagnosticsRunning = false
+let orphanedChunkDiagnosticsTimeoutId: number | null = null
 let lastOrphanedChunkDiagnosticsStartedAtMs = 0
 const recordingStateSyncQueue = new Map<string, RecordingHistoryItem>()
 
@@ -1400,12 +1401,18 @@ async function reportAndDeleteOrphanedSpoolChunks(): Promise<void> {
   }
 }
 
-function scheduleOrphanedSpoolChunkDiagnostics(): void {
-  window.setTimeout(() => {
-    void reportAndDeleteOrphanedSpoolChunks().catch((e) => {
-      captureException(e, { operation: 'scheduleOrphanedSpoolChunkDiagnostics.unhandled' })
-    })
-  }, 0)
+function scheduleOrphanedSpoolChunkDiagnostics(delayMs = 0): void {
+  if (orphanedChunkDiagnosticsTimeoutId != null) return
+  orphanedChunkDiagnosticsTimeoutId = window.setTimeout(() => {
+    orphanedChunkDiagnosticsTimeoutId = null
+    void reportAndDeleteOrphanedSpoolChunks()
+      .catch((e) => {
+        captureException(e, { operation: 'scheduleOrphanedSpoolChunkDiagnostics.unhandled' })
+      })
+      .finally(() => {
+        scheduleOrphanedSpoolChunkDiagnostics(ORPHANED_CHUNK_DIAGNOSTIC_INTERVAL_MS)
+      })
+  }, delayMs)
 }
 
 async function restoreUploadQueueFromSpool(): Promise<void> {
@@ -1996,6 +2003,7 @@ async function handleOffscreenPortMessage(msg: any): Promise<void> {
 }
 
 getPort()
+scheduleOrphanedSpoolChunkDiagnostics()
 
 // Pozwala tłu sprawdzić stan, zanim port będzie gotowy.
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -1,6 +1,7 @@
 // src/popup.tsx
 
 import {
+  BugOutlined,
   CheckOutlined,
   CloudUploadOutlined,
   LinkOutlined,
@@ -70,6 +71,10 @@ function formatDuration(ms: number): string {
 
 async function openMicSetupTab(): Promise<void> {
   await chrome.tabs.create({ url: chrome.runtime.getURL('micsetup.html') })
+}
+
+async function openDebugTab(): Promise<void> {
+  await chrome.tabs.create({ url: chrome.runtime.getURL('debug.html') })
 }
 
 async function readMicStatus(): Promise<string> {
@@ -439,6 +444,16 @@ function App(): React.ReactElement {
     }
   }, [refreshMeet2NoteConnection])
 
+  const openDebug = useCallback(async () => {
+    try {
+      await openDebugTab()
+    } catch (error) {
+      console.error('[popup] debug page open error', error)
+      captureException(error, { operation: 'openDebugTab' })
+      alert(`Could not open the debug page:\n${error instanceof Error ? error.message : String(error)}`)
+    }
+  }, [])
+
   const startRecording = useCallback(async () => {
     inFlightRef.current = true
     setInFlight(true)
@@ -649,6 +664,16 @@ function App(): React.ReactElement {
                 ) : null}
               </Flex>
             )}
+            <Divider style={{ margin: '4px 0' }} />
+            <Button
+              block
+              icon={<BugOutlined />}
+              onClick={openDebug}
+              size="small"
+              title="Open local extension storage and recording spool debug data"
+            >
+              Debug
+            </Button>
           </>
         ) : (
           <>

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -49,6 +49,7 @@ export interface RecordingSpoolChunkAssetStats {
 
 export interface OrphanedSpoolChunkGroup {
   localId: string
+  chunkKeys: IDBValidKey[]
   chunks: number
   bytes: number
   firstChunkCreatedAt: string | null
@@ -313,6 +314,7 @@ export async function listOrphanedSpoolChunkGroups(options: {
         const createdAt = normalizeChunkTimestamp(chunk.createdAt)
         const group = groups[localId] || {
           localId,
+          chunkKeys: [],
           chunks: 0,
           bytes: 0,
           firstChunkCreatedAt: null,
@@ -325,6 +327,7 @@ export async function listOrphanedSpoolChunkGroups(options: {
         updateChunkStatsTimestamp(assetStats, createdAt)
         group.chunks += 1
         group.bytes += bytes
+        group.chunkKeys.push(cursor.primaryKey)
         updateChunkStatsTimestamp(group, createdAt)
         group.assets[asset] = assetStats
         groups[localId] = group
@@ -400,6 +403,17 @@ export async function deleteSpoolChunks(localId: string): Promise<void> {
     const store = tx.objectStore(RECORDING_SPOOL_CHUNKS_STORE)
     const index = store.index(LOCAL_ID_INDEX)
     const keys = await requestResult<IDBValidKey[]>(index.getAllKeys(localId))
+    for (const key of keys) store.delete(key)
+    await transactionComplete(tx)
+  })
+}
+
+export async function deleteSpoolChunkKeys(keys: IDBValidKey[]): Promise<void> {
+  if (!keys.length) return
+  await enqueueSpoolWrite(async () => {
+    const db = await openSpoolDb()
+    const tx = db.transaction(RECORDING_SPOOL_CHUNKS_STORE, 'readwrite')
+    const store = tx.objectStore(RECORDING_SPOOL_CHUNKS_STORE)
     for (const key of keys) store.delete(key)
     await transactionComplete(tx)
   })

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -40,6 +40,22 @@ export interface RecordingSpoolChunk {
   createdAt: string
 }
 
+export interface RecordingSpoolChunkAssetStats {
+  chunks: number
+  bytes: number
+  firstChunkCreatedAt: string | null
+  lastChunkCreatedAt: string | null
+}
+
+export interface OrphanedSpoolChunkGroup {
+  localId: string
+  chunks: number
+  bytes: number
+  firstChunkCreatedAt: string | null
+  lastChunkCreatedAt: string | null
+  assets: Record<string, RecordingSpoolChunkAssetStats>
+}
+
 let dbPromise: Promise<IDBDatabase> | null = null
 let spoolWriteQueue: Promise<unknown> = Promise.resolve()
 
@@ -157,6 +173,35 @@ function positiveNumberOrUndefined(value: unknown): number | undefined {
     : undefined
 }
 
+function normalizeChunkTimestamp(value: unknown): string | null {
+  if (typeof value !== 'string' || !value.trim()) return null
+  const timestamp = Date.parse(value)
+  if (!Number.isFinite(timestamp)) return null
+  return new Date(timestamp).toISOString()
+}
+
+function updateChunkStatsTimestamp(
+  stats: RecordingSpoolChunkAssetStats,
+  createdAt: string | null
+): void {
+  if (!createdAt) return
+  if (!stats.firstChunkCreatedAt || createdAt < stats.firstChunkCreatedAt) {
+    stats.firstChunkCreatedAt = createdAt
+  }
+  if (!stats.lastChunkCreatedAt || createdAt > stats.lastChunkCreatedAt) {
+    stats.lastChunkCreatedAt = createdAt
+  }
+}
+
+function emptyChunkStats(): RecordingSpoolChunkAssetStats {
+  return {
+    chunks: 0,
+    bytes: 0,
+    firstChunkCreatedAt: null,
+    lastChunkCreatedAt: null
+  }
+}
+
 export async function createSpoolRecording(record: RecordingSpoolRecord): Promise<void> {
   await enqueueSpoolWrite(async () => {
     const db = await openSpoolDb()
@@ -225,6 +270,78 @@ export async function listUploadableSpoolRecordings(): Promise<RecordingSpoolRec
 export async function listInterruptedSpoolRecordings(): Promise<RecordingSpoolRecord[]> {
   const records = await listSpoolRecordings()
   return records.filter(record => record.status === 'recording' || record.status === 'finalizing')
+}
+
+export async function listOrphanedSpoolChunkGroups(options: {
+  gracePeriodMs: number
+  nowMs?: number
+}): Promise<OrphanedSpoolChunkGroup[]> {
+  const db = await openSpoolDb()
+  const nowMs = options.nowMs ?? Date.now()
+  const gracePeriodMs = Math.max(0, options.gracePeriodMs)
+  const recordsTx = db.transaction(RECORDINGS_STORE, 'readonly')
+  const records = await requestResult<RecordingSpoolRecord[]>(
+    recordsTx.objectStore(RECORDINGS_STORE).getAll()
+  )
+  await transactionComplete(recordsTx)
+
+  const knownLocalIds = new Set(records.map(record => record.localId))
+  const groups: Record<string, OrphanedSpoolChunkGroup> = {}
+  const chunksTx = db.transaction(CHUNKS_STORE, 'readonly')
+  const store = chunksTx.objectStore(CHUNKS_STORE)
+  await new Promise<void>((resolve, reject) => {
+    const request = store.openCursor()
+    request.onerror = () => reject(request.error || new Error('Recording spool cursor failed.'))
+    request.onsuccess = () => {
+      const cursor = request.result
+      if (!cursor) {
+        resolve()
+        return
+      }
+
+      const chunk = cursor.value as Partial<RecordingSpoolChunk>
+      const localId = typeof chunk.localId === 'string' && chunk.localId
+        ? chunk.localId
+        : 'missing-localId'
+      if (!knownLocalIds.has(localId)) {
+        const asset = typeof chunk.asset === 'string' && chunk.asset ? chunk.asset : 'missing-asset'
+        const bytes = typeof chunk.sizeBytes === 'number' && Number.isFinite(chunk.sizeBytes)
+          ? chunk.sizeBytes
+          : chunk.blob instanceof Blob
+            ? chunk.blob.size
+            : 0
+        const createdAt = normalizeChunkTimestamp(chunk.createdAt)
+        const group = groups[localId] || {
+          localId,
+          chunks: 0,
+          bytes: 0,
+          firstChunkCreatedAt: null,
+          lastChunkCreatedAt: null,
+          assets: {}
+        }
+        const assetStats = group.assets[asset] || emptyChunkStats()
+        assetStats.chunks += 1
+        assetStats.bytes += bytes
+        updateChunkStatsTimestamp(assetStats, createdAt)
+        group.chunks += 1
+        group.bytes += bytes
+        updateChunkStatsTimestamp(group, createdAt)
+        group.assets[asset] = assetStats
+        groups[localId] = group
+      }
+
+      cursor.continue()
+    }
+  })
+  await transactionComplete(chunksTx)
+
+  return Object.values(groups)
+    .filter(group => {
+      if (!group.lastChunkCreatedAt) return false
+      const lastChunkMs = Date.parse(group.lastChunkCreatedAt)
+      return Number.isFinite(lastChunkMs) && nowMs - lastChunkMs >= gracePeriodMs
+    })
+    .sort((a, b) => String(a.firstChunkCreatedAt).localeCompare(String(b.firstChunkCreatedAt)))
 }
 
 export async function assertSpoolAvailable(): Promise<void> {

--- a/src/recordingSpool.ts
+++ b/src/recordingSpool.ts
@@ -4,10 +4,10 @@ import type {
 } from './recordingHistory'
 import { normalizeRecordingHistoryItem } from './recordingHistory'
 
-const DB_NAME = 'meet2noteRecordingSpool'
+export const RECORDING_SPOOL_DB_NAME = 'meet2noteRecordingSpool'
 const DB_VERSION = 1
-const RECORDINGS_STORE = 'recordings'
-const CHUNKS_STORE = 'chunks'
+export const RECORDING_SPOOL_RECORDINGS_STORE = 'recordings'
+export const RECORDING_SPOOL_CHUNKS_STORE = 'chunks'
 const LOCAL_ID_INDEX = 'localId'
 const ASSET_INDEX = 'localIdAsset'
 
@@ -63,7 +63,7 @@ function openSpoolDb(): Promise<IDBDatabase> {
   if (dbPromise) return dbPromise
 
   dbPromise = new Promise((resolve, reject) => {
-    const request = indexedDB.open(DB_NAME, DB_VERSION)
+    const request = indexedDB.open(RECORDING_SPOOL_DB_NAME, DB_VERSION)
     request.onerror = () => {
       dbPromise = null
       reject(request.error || new Error('Could not open recording spool.'))
@@ -74,11 +74,11 @@ function openSpoolDb(): Promise<IDBDatabase> {
     }
     request.onupgradeneeded = () => {
       const db = request.result
-      if (!db.objectStoreNames.contains(RECORDINGS_STORE)) {
-        db.createObjectStore(RECORDINGS_STORE, { keyPath: 'localId' })
+      if (!db.objectStoreNames.contains(RECORDING_SPOOL_RECORDINGS_STORE)) {
+        db.createObjectStore(RECORDING_SPOOL_RECORDINGS_STORE, { keyPath: 'localId' })
       }
-      if (!db.objectStoreNames.contains(CHUNKS_STORE)) {
-        const chunks = db.createObjectStore(CHUNKS_STORE, { keyPath: 'id' })
+      if (!db.objectStoreNames.contains(RECORDING_SPOOL_CHUNKS_STORE)) {
+        const chunks = db.createObjectStore(RECORDING_SPOOL_CHUNKS_STORE, { keyPath: 'id' })
         chunks.createIndex(LOCAL_ID_INDEX, 'localId', { unique: false })
         chunks.createIndex(ASSET_INDEX, 'localIdAsset', { unique: false })
       }
@@ -205,8 +205,8 @@ function emptyChunkStats(): RecordingSpoolChunkAssetStats {
 export async function createSpoolRecording(record: RecordingSpoolRecord): Promise<void> {
   await enqueueSpoolWrite(async () => {
     const db = await openSpoolDb()
-    const tx = db.transaction(RECORDINGS_STORE, 'readwrite')
-    tx.objectStore(RECORDINGS_STORE).put(record)
+    const tx = db.transaction(RECORDING_SPOOL_RECORDINGS_STORE, 'readwrite')
+    tx.objectStore(RECORDING_SPOOL_RECORDINGS_STORE).put(record)
     await transactionComplete(tx)
   })
 }
@@ -217,9 +217,9 @@ export async function updateSpoolRecording(record: RecordingSpoolRecord): Promis
 
 export async function getSpoolRecording(localId: string): Promise<RecordingSpoolRecord | null> {
   const db = await openSpoolDb()
-  const tx = db.transaction(RECORDINGS_STORE, 'readonly')
+  const tx = db.transaction(RECORDING_SPOOL_RECORDINGS_STORE, 'readonly')
   const result = await requestResult<RecordingSpoolRecord | undefined>(
-    tx.objectStore(RECORDINGS_STORE).get(localId)
+    tx.objectStore(RECORDING_SPOOL_RECORDINGS_STORE).get(localId)
   )
   return result || null
 }
@@ -233,7 +233,7 @@ export async function appendSpoolChunk(params: {
 }): Promise<number> {
   return enqueueSpoolWrite(async () => {
     const db = await openSpoolDb()
-    const tx = db.transaction(CHUNKS_STORE, 'readwrite')
+    const tx = db.transaction(RECORDING_SPOOL_CHUNKS_STORE, 'readwrite')
     const chunk: RecordingSpoolChunk = {
       id: `${params.localId}:${params.asset}:${params.sequence}`,
       localId: params.localId,
@@ -245,7 +245,7 @@ export async function appendSpoolChunk(params: {
       mimeType: params.mimeType,
       createdAt: new Date().toISOString()
     }
-    tx.objectStore(CHUNKS_STORE).put(chunk)
+    tx.objectStore(RECORDING_SPOOL_CHUNKS_STORE).put(chunk)
     await transactionComplete(tx)
     return chunk.sizeBytes
   })
@@ -253,9 +253,9 @@ export async function appendSpoolChunk(params: {
 
 export async function listSpoolRecordings(): Promise<RecordingSpoolRecord[]> {
   const db = await openSpoolDb()
-  const tx = db.transaction(RECORDINGS_STORE, 'readonly')
+  const tx = db.transaction(RECORDING_SPOOL_RECORDINGS_STORE, 'readonly')
   const result = await requestResult<RecordingSpoolRecord[]>(
-    tx.objectStore(RECORDINGS_STORE).getAll()
+    tx.objectStore(RECORDING_SPOOL_RECORDINGS_STORE).getAll()
   )
   return result.map(normalizeSpoolRecord)
 }
@@ -279,16 +279,16 @@ export async function listOrphanedSpoolChunkGroups(options: {
   const db = await openSpoolDb()
   const nowMs = options.nowMs ?? Date.now()
   const gracePeriodMs = Math.max(0, options.gracePeriodMs)
-  const recordsTx = db.transaction(RECORDINGS_STORE, 'readonly')
+  const recordsTx = db.transaction(RECORDING_SPOOL_RECORDINGS_STORE, 'readonly')
   const records = await requestResult<RecordingSpoolRecord[]>(
-    recordsTx.objectStore(RECORDINGS_STORE).getAll()
+    recordsTx.objectStore(RECORDING_SPOOL_RECORDINGS_STORE).getAll()
   )
   await transactionComplete(recordsTx)
 
   const knownLocalIds = new Set(records.map(record => record.localId))
   const groups: Record<string, OrphanedSpoolChunkGroup> = {}
-  const chunksTx = db.transaction(CHUNKS_STORE, 'readonly')
-  const store = chunksTx.objectStore(CHUNKS_STORE)
+  const chunksTx = db.transaction(RECORDING_SPOOL_CHUNKS_STORE, 'readonly')
+  const store = chunksTx.objectStore(RECORDING_SPOOL_CHUNKS_STORE)
   await new Promise<void>((resolve, reject) => {
     const request = store.openCursor()
     request.onerror = () => reject(request.error || new Error('Recording spool cursor failed.'))
@@ -346,18 +346,18 @@ export async function listOrphanedSpoolChunkGroups(options: {
 
 export async function assertSpoolAvailable(): Promise<void> {
   const db = await openSpoolDb()
-  const tx = db.transaction(RECORDINGS_STORE, 'readonly')
+  const tx = db.transaction(RECORDING_SPOOL_RECORDINGS_STORE, 'readonly')
   const complete = transactionComplete(tx)
   await Promise.all([
-    requestResult<number>(tx.objectStore(RECORDINGS_STORE).count()),
+    requestResult<number>(tx.objectStore(RECORDING_SPOOL_RECORDINGS_STORE).count()),
     complete
   ])
 }
 
 async function getChunksByIndex(localId: string, asset: RecordingUploadAsset): Promise<RecordingSpoolChunk[]> {
   const db = await openSpoolDb()
-  const tx = db.transaction(CHUNKS_STORE, 'readonly')
-  const index = tx.objectStore(CHUNKS_STORE).index(ASSET_INDEX)
+  const tx = db.transaction(RECORDING_SPOOL_CHUNKS_STORE, 'readonly')
+  const index = tx.objectStore(RECORDING_SPOOL_CHUNKS_STORE).index(ASSET_INDEX)
   const chunks = await requestResult<RecordingSpoolChunk[]>(
     index.getAll(localIdAsset(localId, asset))
   )
@@ -366,8 +366,8 @@ async function getChunksByIndex(localId: string, asset: RecordingUploadAsset): P
 
 async function countChunksByIndex(localId: string, asset: RecordingUploadAsset): Promise<number> {
   const db = await openSpoolDb()
-  const tx = db.transaction(CHUNKS_STORE, 'readonly')
-  const index = tx.objectStore(CHUNKS_STORE).index(ASSET_INDEX)
+  const tx = db.transaction(RECORDING_SPOOL_CHUNKS_STORE, 'readonly')
+  const index = tx.objectStore(RECORDING_SPOOL_CHUNKS_STORE).index(ASSET_INDEX)
   return requestResult<number>(index.count(localIdAsset(localId, asset)))
 }
 
@@ -396,8 +396,8 @@ export async function getSpoolChunkCounts(localId: string): Promise<Record<Recor
 export async function deleteSpoolChunks(localId: string): Promise<void> {
   await enqueueSpoolWrite(async () => {
     const db = await openSpoolDb()
-    const tx = db.transaction(CHUNKS_STORE, 'readwrite')
-    const store = tx.objectStore(CHUNKS_STORE)
+    const tx = db.transaction(RECORDING_SPOOL_CHUNKS_STORE, 'readwrite')
+    const store = tx.objectStore(RECORDING_SPOOL_CHUNKS_STORE)
     const index = store.index(LOCAL_ID_INDEX)
     const keys = await requestResult<IDBValidKey[]>(index.getAllKeys(localId))
     for (const key of keys) store.delete(key)
@@ -408,16 +408,16 @@ export async function deleteSpoolChunks(localId: string): Promise<void> {
 export async function deleteSpoolRecording(localId: string): Promise<void> {
   await enqueueSpoolWrite(async () => {
     const db = await openSpoolDb()
-    const tx = db.transaction(RECORDINGS_STORE, 'readwrite')
-    tx.objectStore(RECORDINGS_STORE).delete(localId)
+    const tx = db.transaction(RECORDING_SPOOL_RECORDINGS_STORE, 'readwrite')
+    tx.objectStore(RECORDING_SPOOL_RECORDINGS_STORE).delete(localId)
     await transactionComplete(tx)
   })
 }
 
 async function sumChunkSizes(): Promise<number> {
   const db = await openSpoolDb()
-  const tx = db.transaction(CHUNKS_STORE, 'readonly')
-  const store = tx.objectStore(CHUNKS_STORE)
+  const tx = db.transaction(RECORDING_SPOOL_CHUNKS_STORE, 'readonly')
+  const store = tx.objectStore(RECORDING_SPOOL_CHUNKS_STORE)
   const complete = transactionComplete(tx)
   let totalBytes = 0
 
@@ -443,7 +443,9 @@ export async function getSpoolUsage(): Promise<{ recordings: number; bytes: numb
   const db = await openSpoolDb()
   const [records, bytes] = await Promise.all([
     requestResult<RecordingSpoolRecord[]>(
-      db.transaction(RECORDINGS_STORE, 'readonly').objectStore(RECORDINGS_STORE).getAll()
+      db.transaction(RECORDING_SPOOL_RECORDINGS_STORE, 'readonly')
+        .objectStore(RECORDING_SPOOL_RECORDINGS_STORE)
+        .getAll()
     ),
     sumChunkSizes()
   ])

--- a/src/recordingStateSync.ts
+++ b/src/recordingStateSync.ts
@@ -1,4 +1,5 @@
 import { makeAuthorizationHeader, Meet2NoteAuthError } from './extensionAuth'
+import { fetchWithTimeout, normalizeErrorBody } from './httpClientUtils'
 import { makeMeet2NoteUrl } from './meet2noteConfig'
 import type { RecordingFailureReason, RecordingHistoryItem, RecordingUploadStatus } from './recordingHistory'
 
@@ -45,42 +46,6 @@ export function resolveExtensionRecordingId(item: RecordingHistoryItem): string 
   if (item.backendRecordingId && UUID_PATTERN.test(item.backendRecordingId)) return item.backendRecordingId
   if (UUID_PATTERN.test(item.localId)) return item.localId
   return null
-}
-
-function normalizeErrorBody(body: string | null): string | null {
-  if (!body) return null
-  const trimmed = body.trim()
-  if (!trimmed) return null
-  try {
-    const parsed = JSON.parse(trimmed) as unknown
-    if (parsed && typeof parsed === 'object') {
-      const record = parsed as Record<string, unknown>
-      const message = record.message
-      const error = record.error
-      if (Array.isArray(message)) return message.map(String).join('; ').slice(0, 500)
-      if (typeof message === 'string' && message.trim()) return message.trim().slice(0, 500)
-      if (typeof error === 'string' && error.trim()) return error.trim().slice(0, 500)
-    }
-  } catch {}
-  return trimmed.slice(0, 500)
-}
-
-async function fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), SYNC_EXTENSION_STATE_TIMEOUT_MS)
-  try {
-    return await fetch(url, {
-      ...init,
-      signal: controller.signal
-    })
-  } catch (error) {
-    if (controller.signal.aborted) {
-      throw new Error('sync extension recording state timed out after 30 seconds')
-    }
-    throw error
-  } finally {
-    clearTimeout(timeoutId)
-  }
 }
 
 function titleForSync(title: string): string {
@@ -172,7 +137,9 @@ export async function syncExtensionRecordingState(
         Authorization: makeAuthorizationHeader(extensionToken)
       },
       body: JSON.stringify(body)
-    }
+    },
+    SYNC_EXTENSION_STATE_TIMEOUT_MS,
+    'sync extension recording state timed out after 30 seconds'
   )
 
   if (!response.ok) {

--- a/src/recordingStateSync.ts
+++ b/src/recordingStateSync.ts
@@ -1,6 +1,6 @@
 import { makeAuthorizationHeader, Meet2NoteAuthError } from './extensionAuth'
 import { makeMeet2NoteUrl } from './meet2noteConfig'
-import type { RecordingHistoryItem, RecordingUploadStatus } from './recordingHistory'
+import type { RecordingFailureReason, RecordingHistoryItem, RecordingUploadStatus } from './recordingHistory'
 
 export type ExtensionMutableRecordingStatus = Extract<
   RecordingUploadStatus,
@@ -18,6 +18,18 @@ const EXTENSION_MUTABLE_RECORDING_STATUSES = new Set<RecordingUploadStatus>([
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const SYNC_EXTENSION_STATE_TIMEOUT_MS = 30_000
+const FAILURE_STAGE_BY_REASON: Record<RecordingFailureReason, string> = {
+  auth_required: 'authorization',
+  local_error: 'local_recording',
+  unrecoverable: 'local_recording',
+  upload_error: 'uploading'
+}
+const FAILURE_REASON_BY_REASON: Record<RecordingFailureReason, string> = {
+  auth_required: 'Meet2Note connection is required before this recording can upload.',
+  local_error: 'Recording failed locally in the browser.',
+  unrecoverable: 'Recording could not be finalized in the browser.',
+  upload_error: 'Recording upload failed in the extension.'
+}
 
 export interface SyncExtensionRecordingStateResult {
   recordingId: string
@@ -76,9 +88,48 @@ function titleForSync(title: string): string {
   return normalizedTitle.slice(0, 255)
 }
 
+function textForSync(value: string | null | undefined, fallback: string, maxLength: number): string {
+  const normalized = (value || fallback).trim() || fallback
+  return normalized.slice(0, maxLength)
+}
+
 function isIsoDateString(value: string): boolean {
   const timestamp = Date.parse(value)
   return Number.isFinite(timestamp)
+}
+
+function timestampForSync(value: number | null | undefined): string | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) return null
+  return date.toISOString()
+}
+
+function applyFailureDetails(body: Record<string, unknown>, item: RecordingHistoryItem): void {
+  const fallbackFailureReason = item.failureReason
+    ? FAILURE_REASON_BY_REASON[item.failureReason]
+    : 'Recording failed in the extension.'
+
+  body.failureStage = item.failureReason
+    ? FAILURE_STAGE_BY_REASON[item.failureReason]
+    : 'local_recording'
+  body.failureReason = textForSync(item.error, fallbackFailureReason, 255)
+  body.failureMessage = textForSync(
+    [
+      item.error ? `Extension error: ${item.error}` : null,
+      item.failureReason ? `Local failure reason: ${item.failureReason}` : null,
+      `Local recording id: ${item.localId}`
+    ].filter(Boolean).join('\n'),
+    fallbackFailureReason,
+    1000
+  )
+
+  if (typeof item.attempt === 'number' && Number.isFinite(item.attempt) && item.attempt >= 0) {
+    body.retryCount = Math.floor(item.attempt)
+  }
+
+  const nextRetryAt = timestampForSync(item.nextRetryAt)
+  if (nextRetryAt) body.nextRetryAt = nextRetryAt
 }
 
 export async function syncExtensionRecordingState(
@@ -109,7 +160,8 @@ export async function syncExtensionRecordingState(
     body.uploadProgressPercent = Math.max(0, Math.min(100, Math.floor(item.uploadProgressPercent)))
   }
   if (item.meetingId) body.meetingId = item.meetingId
-  if (item.tabUrl && /^https?:\/\//i.test(item.tabUrl)) body.meetingUrl = item.tabUrl
+  if (item.tabUrl && /^https:\/\//i.test(item.tabUrl)) body.meetingUrl = item.tabUrl
+  if (item.status === 'failed') applyFailureDetails(body, item)
 
   const response = await fetchWithTimeout(
     makeMeet2NoteUrl(`/api/recordings/${encodeURIComponent(recordingId)}/extension-state`),

--- a/src/recordingsClient.ts
+++ b/src/recordingsClient.ts
@@ -2,6 +2,7 @@ import {
   makeAuthorizationHeader,
   Meet2NoteAuthError
 } from './extensionAuth'
+import { fetchWithTimeout } from './httpClientUtils'
 import { makeMeet2NoteUrl } from './meet2noteConfig'
 
 export type BackendRecordingStatus = 'processing_queued' | 'processing' | 'ready' | 'failed' | 'expired'
@@ -18,23 +19,6 @@ export interface BackendRecordingListItem {
 }
 
 const LIST_RECORDINGS_TIMEOUT_MS = 30_000
-
-function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
-
-  return fetch(url, {
-    ...init,
-    signal: controller.signal
-  }).catch((error) => {
-    if (controller.signal.aborted) {
-      throw new Error(`recordings list timed out after ${Math.round(timeoutMs / 1000)} seconds`)
-    }
-    throw error
-  }).finally(() => {
-    clearTimeout(timeoutId)
-  })
-}
 
 function normalizeBackendRecordingStatus(value: unknown): BackendRecordingStatus | null {
   if (value === 'pending') return 'processing_queued'
@@ -86,7 +70,8 @@ export async function listMeet2NoteRecordings(extensionToken: string): Promise<B
         Authorization: makeAuthorizationHeader(token)
       }
     },
-    LIST_RECORDINGS_TIMEOUT_MS
+    LIST_RECORDINGS_TIMEOUT_MS,
+    `recordings list timed out after ${Math.round(LIST_RECORDINGS_TIMEOUT_MS / 1000)} seconds`
   )
 
   if (response.status === 401 || response.status === 403) {

--- a/src/uploadClient.ts
+++ b/src/uploadClient.ts
@@ -2,6 +2,7 @@ import {
   makeAuthorizationHeader,
   Meet2NoteAuthError
 } from './extensionAuth'
+import { fetchWithTimeout, normalizeErrorBody } from './httpClientUtils'
 import { makeMeet2NoteUrl } from './meet2noteConfig'
 
 export type UploadAsset = 'video_audio' | 'microphone'
@@ -86,24 +87,6 @@ class Meet2NoteUploadHttpError extends Error {
   }
 }
 
-function normalizeErrorBody(body: string | null): string | null {
-  if (!body) return null
-  const trimmed = body.trim()
-  if (!trimmed) return null
-  try {
-    const parsed = JSON.parse(trimmed) as unknown
-    if (parsed && typeof parsed === 'object') {
-      const record = parsed as Record<string, unknown>
-      const message = record.message
-      const error = record.error
-      if (Array.isArray(message)) return message.map(String).join('; ').slice(0, 500)
-      if (typeof message === 'string' && message.trim()) return message.trim().slice(0, 500)
-      if (typeof error === 'string' && error.trim()) return error.trim().slice(0, 500)
-    }
-  } catch {}
-  return trimmed.slice(0, 500)
-}
-
 function httpErrorFromStatus(operation: string, status: number, rawResponseBody: string | null = null): Error {
   if (status === 401 || status === 403) {
     return new Meet2NoteAuthError(`Meet2Note connection required for ${operation}.`, status)
@@ -131,28 +114,18 @@ function isStaleUploadSessionError(error: unknown): boolean {
   return error instanceof Meet2NoteUploadHttpError && error.status === 404
 }
 
-async function fetchWithTimeout(
+async function fetchUploadWithTimeout(
   operation: string,
   url: string,
   init: RequestInit,
   timeoutMs: number
 ): Promise<Response> {
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
-
-  try {
-    return await fetch(url, {
-      ...init,
-      signal: controller.signal
-    })
-  } catch (error) {
-    if (controller.signal.aborted) {
-      throw new Error(`${operation} timed out after ${Math.round(timeoutMs / 1000)} seconds`)
-    }
-    throw error
-  } finally {
-    clearTimeout(timeoutId)
-  }
+  return fetchWithTimeout(
+    url,
+    init,
+    timeoutMs,
+    `${operation} timed out after ${Math.round(timeoutMs / 1000)} seconds`
+  )
 }
 
 function numberOrUndefined(value: unknown): number | undefined {
@@ -311,7 +284,7 @@ async function initUpload(
   if (input.startedAt) body.startedAt = input.startedAt
   if (typeof input.durationMs === 'number' && input.durationMs > 0) body.durationMs = Math.floor(input.durationMs)
 
-  const response = await fetchWithTimeout(
+  const response = await fetchUploadWithTimeout(
     'init upload',
     makeMeet2NoteUrl('/api/upload/init'),
     {
@@ -386,7 +359,7 @@ async function initAsset(
 ): Promise<UploadAssetState> {
   const operation = `init ${asset} asset`
   const totalChunks = Math.ceil(blob.size / chunkSizeBytes)
-  const response = await fetchWithTimeout(
+  const response = await fetchUploadWithTimeout(
     operation,
     makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(session.recordingId)}/assets/${asset}`),
     {
@@ -416,7 +389,7 @@ async function getAssetState(
   authHeaders: { Authorization: string }
 ): Promise<UploadAssetState> {
   const operation = `get ${asset} asset state`
-  const response = await fetchWithTimeout(
+  const response = await fetchUploadWithTimeout(
     operation,
     makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(session.recordingId)}/assets/${asset}`),
     {
@@ -503,7 +476,7 @@ async function completeAsset(
   authHeaders: { Authorization: string }
 ): Promise<UploadAssetState> {
   const operation = `complete ${asset} asset`
-  const response = await fetchWithTimeout(
+  const response = await fetchUploadWithTimeout(
     operation,
     makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(session.recordingId)}/assets/${asset}/complete`),
     {
@@ -527,7 +500,7 @@ async function completeUpload(
   assets: UploadAsset[],
   authHeaders: { Authorization: string }
 ): Promise<void> {
-  const response = await fetchWithTimeout(
+  const response = await fetchUploadWithTimeout(
     'complete upload',
     makeMeet2NoteUrl(`/api/upload/${encodeURIComponent(session.recordingId)}/complete`),
     {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
   devtool: false,
   entry: {
     popup: './src/popup.tsx',
+    debug: './src/debug.tsx',
     background: './src/background.ts',
     connectCallback: './src/connectCallback.ts',
     offscreen: './src/offscreen.ts',
@@ -42,6 +43,7 @@ module.exports = {
         { from: 'manifest.json',  to: 'manifest.json' },
         { from: 'connect-callback.html', to: 'connect-callback.html' },
         { from: 'popup.html',     to: 'popup.html' },
+        { from: 'debug.html',     to: 'debug.html' },
         { from: 'offscreen.html', to: 'offscreen.html', noErrorOnMissing: true },
         { from: 'micsetup.html', to: 'micsetup.html' },
         { from: 'assets/icons', to: 'icons' },


### PR DESCRIPTION
## Zakres

- synchronizuje lokalne wpisy `failed` do backendu z wymaganym uzasadnieniem błędu (`failureStage`, `failureReason`, `failureMessage`, retry metadata), także gdy wpis wcześniej nie miał `backendRecordingId`
- dodaje stronę debug rozszerzenia z pełnym snapshotem `chrome.storage.local` i IndexedDB spoolu bez dużych blobów oraz z datami `firstChunkCreatedAt`/`lastChunkCreatedAt`
- dodaje backendowy kanał diagnostyczny wtyczki `POST /api/extension/diagnostics` dla osieroconych chunków spoolu
- wykrywa orphan chunk groups, raportuje je do backendu i usuwa lokalne chunki dopiero po odpowiedzi 2xx
- podbija wersję rozszerzenia do `1.9.31`

## Kontekst

Domyka część wtyczki dla:

- https://github.com/pawel-walaszek/chrome-recording-transcription-extension/issues/21
- backendowy follow-up: https://github.com/pawel-walaszek/recording-backend/issues/41

Root cause dla lokalnego `failed`: wtyczka wysyłała do `extension-state` sam status `failed`, ale backend wymaga uzasadnienia błędu. Root cause dla orphan chunków: w IndexedDB mogą zostać binarne chunki bez manifestu spoolu; nie da się ich wysłać normalną ścieżką uploadu, ale informacja o nich nie powinna ginąć.

## Weryfikacja

- `npm run typecheck`
- `make check`
- `npm run smoke`

Webpack nadal zgłasza istniejące warningi o rozmiarze bundli (`popup.js`, `debug.js`, `micsetup.js`).

## Uprawnienia Chrome

Bez zmian w uprawnieniach Chrome.
