### PR TITLE
Fix extension recording state sync

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Google Meet Recorder",
-    "version": "1.9.31",
+    "version": "1.9.44",
     "icons": {
       "16": "icons/icon-16.png",
       "32": "icons/icon-32.png",

--- a/src/background.ts
+++ b/src/background.ts
@@ -401,11 +401,11 @@ async function hasPendingLocalUploadInHistory(): Promise<boolean> {
   }
 }
 
-async function runOffscreenLocalMaintenance(): Promise<unknown> {
+async function runOffscreenLocalMaintenance(forceOrphanedChunkDiagnostics = false): Promise<unknown> {
   await ensureOffscreen()
   if (offscreenPort) {
     const response = await postToOffscreen(
-      { type: 'OFFSCREEN_RUN_LOCAL_MAINTENANCE' },
+      { type: 'OFFSCREEN_RUN_LOCAL_MAINTENANCE', forceOrphanedChunkDiagnostics },
       LOCAL_MAINTENANCE_OFFSCREEN_RESPONSE_TIMEOUT_MS
     ).catch((e) => ({ ok: false, error: e instanceof Error ? e.message : String(e) }))
     return response
@@ -1002,7 +1002,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
     if (msg?.type === 'DEBUG_RUN_LOCAL_MAINTENANCE') {
       try {
-        const result = await runOffscreenLocalMaintenance()
+        const result = await runOffscreenLocalMaintenance(true)
         sendResponse(result)
       } catch (e: any) {
         captureException(e, { operation: 'DEBUG_RUN_LOCAL_MAINTENANCE' })

--- a/src/background.ts
+++ b/src/background.ts
@@ -318,15 +318,20 @@ function mergedRecordingTitle(existing: RecordingHistoryItem, backendItem: Recor
 }
 
 function recordingDisplayTimestamp(item: RecordingHistoryItem): number {
-  const primary = Date.parse(item.startedAt || item.createdAt)
-  if (Number.isFinite(primary)) return primary
-  const fallback = Date.parse(item.createdAt || item.updatedAt)
-  return Number.isFinite(fallback) ? fallback : 0
+  return parseRecordingTimestamp(item.startedAt) ??
+    parseRecordingTimestamp(item.createdAt) ??
+    parseRecordingTimestamp(item.updatedAt) ??
+    0
 }
 
 function recordingCreatedTimestamp(item: RecordingHistoryItem): number {
-  const createdAt = Date.parse(item.createdAt)
-  return Number.isFinite(createdAt) ? createdAt : 0
+  return parseRecordingTimestamp(item.createdAt) ?? 0
+}
+
+function parseRecordingTimestamp(value?: string | null): number | null {
+  if (!value) return null
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) ? timestamp : null
 }
 
 function recordingStableSortId(item: RecordingHistoryItem): string {

--- a/src/background.ts
+++ b/src/background.ts
@@ -37,11 +37,14 @@ let recentRecordings: RecordingHistoryItem[] = []
 let backendRecordings: RecordingHistoryItem[] = []
 let backendRecordingsRefreshPromise: Promise<void> | null = null
 let backendRecordingsLastRefreshedAt = 0
+let localMaintenanceWakePromise: Promise<unknown> | null = null
+let localMaintenanceLastWokeAt = 0
 const BACKEND_RECORDINGS_REFRESH_THROTTLE_MS = 15_000
 
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
 const DEFAULT_OFFSCREEN_RESPONSE_TIMEOUT_MS = 15_000
 const LOCAL_MAINTENANCE_OFFSCREEN_RESPONSE_TIMEOUT_MS = 60_000
+const LOCAL_MAINTENANCE_WAKE_INTERVAL_MS = 60_000
 const STOP_OFFSCREEN_RESPONSE_TIMEOUT_MS = 3_000
 const EXTENSION_LOCAL_RECORDING_FAILURE_STAGE = 'local_recording'
 const EXTENSION_ORPHANED_CHUNKS_FAILURE_STAGE = 'local_spool_orphaned_chunks'
@@ -169,34 +172,33 @@ async function hydrateRecentRecordings(): Promise<RecordingHistoryItem[]> {
 
 async function refreshRecentRecordingsFromBackend(): Promise<RecordingHistoryItem[]> {
   backendRecordings = await readBackendRecordingHistory()
-  const localHistory = await pruneBackendOwnedLocalHistory(await readRecordingHistory(), backendRecordings)
+  const localHistory = await pruneBackendOwnedLocalHistory(backendRecordings)
   recentRecordings = mergeRecordingHistory(localHistory, backendRecordings).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
   return recentRecordings
 }
 
 async function pruneBackendOwnedLocalHistory(
-  localHistory: RecordingHistoryItem[],
   backendHistory: RecordingHistoryItem[]
 ): Promise<RecordingHistoryItem[]> {
-  if (!backendHistory.length) return localHistory
+  if (!backendHistory.length) return readRecordingHistory()
 
   const backendIds = new Set(
     backendHistory
       .map(item => item.backendRecordingId)
       .filter((backendId): backendId is string => typeof backendId === 'string' && backendId.length > 0)
   )
-  if (!backendIds.size) return localHistory
+  if (!backendIds.size) return readRecordingHistory()
 
-  let changed = false
-  const pruned = localHistory.filter((item) => {
-    if (!item.backendRecordingId || !backendIds.has(item.backendRecordingId)) return true
-    if (isLocalOnlyPopupHistoryItem(item)) return true
-    changed = true
-    return false
+  return updateRecordingHistory((currentHistory) => {
+    let changed = false
+    const pruned = currentHistory.filter((item) => {
+      if (!item.backendRecordingId || !backendIds.has(item.backendRecordingId)) return true
+      if (isLocalOnlyPopupHistoryItem(item)) return true
+      changed = true
+      return false
+    })
+    return changed ? pruned : currentHistory
   })
-  if (!changed) return localHistory
-
-  return updateRecordingHistory(() => pruned)
 }
 
 function backendRecordingToHistoryItem(recording: BackendRecordingListItem): RecordingHistoryItem {
@@ -428,7 +430,16 @@ function wakeOffscreenForLocalMaintenance(): void {
   ])
     .then(async ([hasPendingUploads, token]) => {
       if (!hasPendingUploads && !token) return undefined
-      await runOffscreenLocalMaintenance()
+      if (!hasPendingUploads && Date.now() - localMaintenanceLastWokeAt < LOCAL_MAINTENANCE_WAKE_INTERVAL_MS) {
+        return undefined
+      }
+      if (localMaintenanceWakePromise) return localMaintenanceWakePromise
+      localMaintenanceLastWokeAt = Date.now()
+      localMaintenanceWakePromise = runOffscreenLocalMaintenance()
+        .finally(() => {
+          localMaintenanceWakePromise = null
+        })
+      await localMaintenanceWakePromise
       return undefined
     })
     .catch((e) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -1061,11 +1061,15 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       }
 
       try {
-        const localHistory = await updateRecordingHistory((history) =>
-          history.filter(item => item.localId !== localId)
-        )
+        let removed = false
+        const localHistory = await updateRecordingHistory((history) => {
+          const next = history.filter(item => item.localId !== localId)
+          if (next.length === history.length) return history
+          removed = true
+          return next
+        })
         recentRecordings = mergeRecordingHistory(localHistory, backendRecordings).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
-        broadcastUploadQueueState()
+        if (removed) broadcastUploadQueueState()
         sendResponse({ ok: true, items: recentRecordings })
       } catch (e: any) {
         captureException(e, { operation: 'DELETE_RECORDING_HISTORY_ITEM', localId })

--- a/src/background.ts
+++ b/src/background.ts
@@ -357,7 +357,11 @@ function isLocalOnlyPopupHistoryItem(item: RecordingHistoryItem): boolean {
 
 function isLocalFailureVisibleWithoutBackendRecord(item: RecordingHistoryItem): boolean {
   return isLocalOnlyFailureWithoutRecording(item) ||
-    (item.status === 'failed' && !!item.backendRecordingId && item.failureReason !== 'auth_required')
+    (
+      item.status === 'failed' &&
+      !!item.backendRecordingId &&
+      (item.failureReason === 'local_error' || item.failureReason === 'unrecoverable')
+    )
 }
 
 function scheduleBackendRecordingsRefresh(force = false): Promise<void> | null {

--- a/src/background.ts
+++ b/src/background.ts
@@ -246,6 +246,9 @@ async function readBackendRecordingHistory(): Promise<RecordingHistoryItem[]> {
       .filter(shouldShowBackendRecordingInExtension)
       .map(backendRecordingToHistoryItem)
   } catch (e) {
+    if (isMeet2NoteAuthError(e)) {
+      await markMeet2NoteReconnectRequired(e.message).catch(() => {})
+    }
     bglog('Backend recordings list failed', e)
     captureException(e, { operation: 'readBackendRecordingHistory' })
     return []

--- a/src/background.ts
+++ b/src/background.ts
@@ -407,11 +407,14 @@ async function hasPendingLocalUploadInHistory(): Promise<boolean> {
   }
 }
 
-async function runOffscreenLocalMaintenance(forceOrphanedChunkDiagnostics = false): Promise<unknown> {
+async function runOffscreenLocalMaintenance(
+  forceOrphanedChunkDiagnostics = false,
+  includeDetails = false
+): Promise<unknown> {
   await ensureOffscreen()
   if (offscreenPort) {
     const response = await postToOffscreen(
-      { type: 'OFFSCREEN_RUN_LOCAL_MAINTENANCE', forceOrphanedChunkDiagnostics },
+      { type: 'OFFSCREEN_RUN_LOCAL_MAINTENANCE', forceOrphanedChunkDiagnostics, includeDetails },
       LOCAL_MAINTENANCE_OFFSCREEN_RESPONSE_TIMEOUT_MS
     ).catch((e) => ({ ok: false, error: e instanceof Error ? e.message : String(e) }))
     return response
@@ -1008,7 +1011,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 
     if (msg?.type === 'DEBUG_RUN_LOCAL_MAINTENANCE') {
       try {
-        const result = await runOffscreenLocalMaintenance(true)
+        const result = await runOffscreenLocalMaintenance(true, true)
         sendResponse(result)
       } catch (e: any) {
         captureException(e, { operation: 'DEBUG_RUN_LOCAL_MAINTENANCE' })

--- a/src/background.ts
+++ b/src/background.ts
@@ -43,6 +43,7 @@ const BACKEND_RECORDINGS_REFRESH_THROTTLE_MS = 15_000
 
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
 const DEFAULT_OFFSCREEN_RESPONSE_TIMEOUT_MS = 15_000
+const OFFSCREEN_STATUS_RESPONSE_TIMEOUT_MS = 1_500
 const LOCAL_MAINTENANCE_OFFSCREEN_RESPONSE_TIMEOUT_MS = 60_000
 const LOCAL_MAINTENANCE_WAKE_INTERVAL_MS = 60_000
 const STOP_OFFSCREEN_RESPONSE_TIMEOUT_MS = 3_000
@@ -419,7 +420,7 @@ async function readOffscreenRecordingStatus(): Promise<Record<string, unknown> |
   if (!offscreenPort) return null
   const response = await postToOffscreen(
     { type: 'OFFSCREEN_STATUS' },
-    DEFAULT_OFFSCREEN_RESPONSE_TIMEOUT_MS
+    OFFSCREEN_STATUS_RESPONSE_TIMEOUT_MS
   ).catch(() => null)
   return response && typeof response === 'object'
     ? response as Record<string, unknown>

--- a/src/background.ts
+++ b/src/background.ts
@@ -13,6 +13,7 @@ import {
   normalizeRecordingHistory,
   POPUP_RECORDING_HISTORY_LIMIT,
   readRecordingHistory,
+  updateRecordingHistory,
   upsertRecordingHistoryItem,
   type RecordingHistoryItem
 } from './recordingHistory'
@@ -40,7 +41,10 @@ const BACKEND_RECORDINGS_REFRESH_THROTTLE_MS = 15_000
 
 const wait = (ms: number) => new Promise(r => setTimeout(r, ms))
 const DEFAULT_OFFSCREEN_RESPONSE_TIMEOUT_MS = 15_000
+const LOCAL_MAINTENANCE_OFFSCREEN_RESPONSE_TIMEOUT_MS = 60_000
 const STOP_OFFSCREEN_RESPONSE_TIMEOUT_MS = 3_000
+const EXTENSION_LOCAL_RECORDING_FAILURE_STAGE = 'local_recording'
+const EXTENSION_ORPHANED_CHUNKS_FAILURE_STAGE = 'local_spool_orphaned_chunks'
 type CaptureSource = 'tab' | 'desktop'
 
 interface CaptureStreamRequest {
@@ -164,10 +168,35 @@ async function hydrateRecentRecordings(): Promise<RecordingHistoryItem[]> {
 }
 
 async function refreshRecentRecordingsFromBackend(): Promise<RecordingHistoryItem[]> {
-  const localHistory = await readRecordingHistory()
   backendRecordings = await readBackendRecordingHistory()
+  const localHistory = await pruneBackendOwnedLocalHistory(await readRecordingHistory(), backendRecordings)
   recentRecordings = mergeRecordingHistory(localHistory, backendRecordings).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
   return recentRecordings
+}
+
+async function pruneBackendOwnedLocalHistory(
+  localHistory: RecordingHistoryItem[],
+  backendHistory: RecordingHistoryItem[]
+): Promise<RecordingHistoryItem[]> {
+  if (!backendHistory.length) return localHistory
+
+  const backendIds = new Set(
+    backendHistory
+      .map(item => item.backendRecordingId)
+      .filter((backendId): backendId is string => typeof backendId === 'string' && backendId.length > 0)
+  )
+  if (!backendIds.size) return localHistory
+
+  let changed = false
+  const pruned = localHistory.filter((item) => {
+    if (!item.backendRecordingId || !backendIds.has(item.backendRecordingId)) return true
+    if (isLocalOnlyPopupHistoryItem(item)) return true
+    changed = true
+    return false
+  })
+  if (!changed) return localHistory
+
+  return updateRecordingHistory(() => pruned)
 }
 
 function backendRecordingToHistoryItem(recording: BackendRecordingListItem): RecordingHistoryItem {
@@ -193,17 +222,28 @@ function backendRecordingToHistoryItem(recording: BackendRecordingListItem): Rec
   }
 }
 
+function shouldShowBackendRecordingInExtension(recording: BackendRecordingListItem): boolean {
+  if (recording.status !== 'failed') return true
+  if (recording.failureStage === EXTENSION_ORPHANED_CHUNKS_FAILURE_STAGE) return false
+  if (
+    recording.failureStage === EXTENSION_LOCAL_RECORDING_FAILURE_STAGE &&
+    recording.failureMessage?.includes('Local recording id:')
+  ) {
+    return false
+  }
+  return true
+}
+
 async function readBackendRecordingHistory(): Promise<RecordingHistoryItem[]> {
   const token = await getMeet2NoteExtensionToken().catch(() => null)
   if (!token) return []
 
   try {
     const recordings = await listMeet2NoteRecordings(token)
-    return recordings.map(backendRecordingToHistoryItem)
+    return recordings
+      .filter(shouldShowBackendRecordingInExtension)
+      .map(backendRecordingToHistoryItem)
   } catch (e) {
-    if (isMeet2NoteAuthError(e)) {
-      await markMeet2NoteReconnectRequired(e.message).catch(() => {})
-    }
     bglog('Backend recordings list failed', e)
     captureException(e, { operation: 'readBackendRecordingHistory' })
     return []
@@ -258,10 +298,10 @@ function mergeRecordingHistory(
     (!item.backendRecordingId || !backendIds.has(item.backendRecordingId))
   ))
 
-  return [
+  return sortRecordingHistoryForDisplay([
     ...localOnlyActionableHistory,
     ...backendMergedHistory
-  ]
+  ])
 }
 
 function mergedRecordingTitle(existing: RecordingHistoryItem, backendItem: RecordingHistoryItem): string {
@@ -269,6 +309,30 @@ function mergedRecordingTitle(existing: RecordingHistoryItem, backendItem: Recor
     return backendItem.title
   }
   return existing.title || backendItem.title
+}
+
+function recordingDisplayTimestamp(item: RecordingHistoryItem): number {
+  const primary = Date.parse(item.startedAt || item.createdAt)
+  if (Number.isFinite(primary)) return primary
+  const fallback = Date.parse(item.createdAt || item.updatedAt)
+  return Number.isFinite(fallback) ? fallback : 0
+}
+
+function recordingCreatedTimestamp(item: RecordingHistoryItem): number {
+  const createdAt = Date.parse(item.createdAt)
+  return Number.isFinite(createdAt) ? createdAt : 0
+}
+
+function recordingStableSortId(item: RecordingHistoryItem): string {
+  return item.backendRecordingId || item.localId
+}
+
+function sortRecordingHistoryForDisplay(items: RecordingHistoryItem[]): RecordingHistoryItem[] {
+  return [...items].sort((a, b) =>
+    recordingDisplayTimestamp(b) - recordingDisplayTimestamp(a) ||
+    recordingCreatedTimestamp(b) - recordingCreatedTimestamp(a) ||
+    recordingStableSortId(b).localeCompare(recordingStableSortId(a))
+  )
 }
 
 function isLocalOnlyPopupHistoryItem(item: RecordingHistoryItem): boolean {
@@ -332,19 +396,44 @@ async function hasPendingLocalUploadInHistory(): Promise<boolean> {
   }
 }
 
-function wakeOffscreenForPendingUploads(): void {
-  void hasPendingLocalUploadInHistory()
-    .then(async (hasPendingUploads) => {
-      if (!hasPendingUploads) return undefined
-      await ensureOffscreen()
-      if (offscreenPort) {
-        return postToOffscreen({ type: 'OFFSCREEN_RESTORE_UPLOAD_QUEUE' }).catch(() => undefined)
-      }
+async function runOffscreenLocalMaintenance(): Promise<unknown> {
+  await ensureOffscreen()
+  if (offscreenPort) {
+    const response = await postToOffscreen(
+      { type: 'OFFSCREEN_RUN_LOCAL_MAINTENANCE' },
+      LOCAL_MAINTENANCE_OFFSCREEN_RESPONSE_TIMEOUT_MS
+    ).catch((e) => ({ ok: false, error: e instanceof Error ? e.message : String(e) }))
+    return response
+  }
+  return { ok: false, error: 'Offscreen port not connected' }
+}
+
+async function readOffscreenRecordingStatus(): Promise<Record<string, unknown> | null> {
+  if (!offscreenPort && !await hasOffscreenContext().catch(() => false)) return null
+  await ensureOffscreen()
+  if (!offscreenPort) return null
+  const response = await postToOffscreen(
+    { type: 'OFFSCREEN_STATUS' },
+    DEFAULT_OFFSCREEN_RESPONSE_TIMEOUT_MS
+  ).catch(() => null)
+  return response && typeof response === 'object'
+    ? response as Record<string, unknown>
+    : null
+}
+
+function wakeOffscreenForLocalMaintenance(): void {
+  void Promise.all([
+    hasPendingLocalUploadInHistory(),
+    getMeet2NoteExtensionToken().catch(() => null)
+  ])
+    .then(async ([hasPendingUploads, token]) => {
+      if (!hasPendingUploads && !token) return undefined
+      await runOffscreenLocalMaintenance()
       return undefined
     })
     .catch((e) => {
-      bglog('Failed to wake offscreen for active uploads', e)
-      captureException(e, { operation: 'wakeOffscreenForPendingUploads' })
+      bglog('Failed to wake offscreen for local maintenance', e)
+      captureException(e, { operation: 'wakeOffscreenForLocalMaintenance' })
     })
 }
 
@@ -825,12 +914,39 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         lastRecordingError = typeof sessionState?.lastRecordingError === 'string'
           ? sessionState.lastRecordingError
           : null
+
+        const offscreenStatus = await readOffscreenRecordingStatus()
+        if (offscreenStatus) {
+          const offscreenRecording = !!offscreenStatus.recording
+          const offscreenStartedAt = typeof offscreenStatus.recordingStartedAt === 'number'
+            ? offscreenStatus.recordingStartedAt
+            : null
+          if (offscreenRecording) {
+            lastKnownRecording = true
+            recordingStarting = false
+            recordingStopping = false
+            if (offscreenStartedAt) recordingStartedAt = offscreenStartedAt
+            if (!recordingStartedAt) recordingStartedAt = Date.now()
+            persistRecordingState(true, recordingStartedAt)
+            setBadge(true, currentRecordingTabId)
+          } else if (!recordingStarting && !recordingStopping) {
+            lastKnownRecording = false
+            recordingStartedAt = null
+            persistRecordingState(false, null)
+          }
+        }
+
         if (!lastKnownRecording && !recordingStarting && !recordingStopping) {
           clearRecordingBadges(currentRecordingTabId)
         }
         await refreshRecentRecordingsForPopup()
+        if (msg.forceBackendRefresh === true) {
+          await scheduleBackendRecordingsRefresh(true)
+        }
       } catch {}
-      wakeOffscreenForPendingUploads()
+      if (!lastKnownRecording && !recordingStarting && !recordingStopping) {
+        wakeOffscreenForLocalMaintenance()
+      }
       sendResponse({
         recording: lastKnownRecording,
         recordingStartedAt,
@@ -870,6 +986,17 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       return
     }
 
+    if (msg?.type === 'DEBUG_RUN_LOCAL_MAINTENANCE') {
+      try {
+        const result = await runOffscreenLocalMaintenance()
+        sendResponse(result)
+      } catch (e: any) {
+        captureException(e, { operation: 'DEBUG_RUN_LOCAL_MAINTENANCE' })
+        sendResponse({ ok: false, error: e?.message || String(e) })
+      }
+      return
+    }
+
     if (msg?.type === 'UPSERT_RECORDING_HISTORY_ITEM') {
       const [item] = normalizeRecordingHistory([msg.item])
       if (!item) {
@@ -897,11 +1024,43 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
       try {
         await hydrateRecentRecordings()
         scheduleBackendRecordingsRefresh()
-        wakeOffscreenForPendingUploads()
+        wakeOffscreenForLocalMaintenance()
         sendResponse({ ok: true, items: recentRecordings })
       } catch (e: any) {
         captureException(e, { operation: 'READ_RECORDING_HISTORY' })
         sendResponse({ ok: false, error: e?.message || String(e), items: recentRecordings })
+      }
+      return
+    }
+
+    if (msg?.type === 'DELETE_RECORDING_HISTORY_ITEM') {
+      const localId = typeof msg.localId === 'string' ? msg.localId.trim() : ''
+      if (!localId) {
+        sendResponse({ ok: false, error: 'Invalid recording localId' })
+        return
+      }
+
+      try {
+        const localHistory = await updateRecordingHistory((history) =>
+          history.filter(item => item.localId !== localId)
+        )
+        recentRecordings = mergeRecordingHistory(localHistory, backendRecordings).slice(0, POPUP_RECORDING_HISTORY_LIMIT)
+        broadcastUploadQueueState()
+        sendResponse({ ok: true, items: recentRecordings })
+      } catch (e: any) {
+        captureException(e, { operation: 'DELETE_RECORDING_HISTORY_ITEM', localId })
+        sendResponse({ ok: false, error: e?.message || String(e) })
+      }
+      return
+    }
+
+    if (msg?.type === 'READ_LOCAL_RECORDING_HISTORY') {
+      try {
+        const items = await readRecordingHistory()
+        sendResponse({ ok: true, items })
+      } catch (e: any) {
+        captureException(e, { operation: 'READ_LOCAL_RECORDING_HISTORY' })
+        sendResponse({ ok: false, error: e?.message || String(e), items: [] })
       }
       return
     }
@@ -933,7 +1092,7 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
   const tokenChange = changes[MEET2NOTE_EXTENSION_TOKEN_KEY]
   if (!tokenChange || typeof tokenChange.newValue !== 'string' || !tokenChange.newValue.trim()) return
   if (!offscreenPort) {
-    wakeOffscreenForPendingUploads()
+    wakeOffscreenForLocalMaintenance()
     return
   }
 
@@ -943,9 +1102,8 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
   })
 })
 
-chrome.runtime.onSuspend?.addListener(async () => {
-  try { if (offscreenPort) await postToOffscreen({ type: 'OFFSCREEN_STOP' }) } catch {}
-  clearRecordingBadges(currentRecordingTabId)
+chrome.runtime.onSuspend?.addListener(() => {
+  persistRecordingState(lastKnownRecording, recordingStartedAt)
 })
 
 async function hydrateRecordingRuntimeState(): Promise<void> {
@@ -992,7 +1150,7 @@ async function initializeRecentRecordings(): Promise<void> {
   await hydrateRecordingRuntimeState()
   await hydrateRecentRecordings()
   scheduleBackendRecordingsRefresh()
-  wakeOffscreenForPendingUploads()
+  wakeOffscreenForLocalMaintenance()
 }
 
 void initializeRecentRecordings().catch((e) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -956,7 +956,7 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
         }
         await refreshRecentRecordingsForPopup()
         if (msg.forceBackendRefresh === true) {
-          await scheduleBackendRecordingsRefresh(true)
+          scheduleBackendRecordingsRefresh(true)
         }
       } catch {}
       if (!lastKnownRecording && !recordingStarting && !recordingStopping) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -352,7 +352,12 @@ function isLocalOnlyPopupHistoryItem(item: RecordingHistoryItem): boolean {
     item.status === 'upload_queued' ||
     item.status === 'uploading' ||
     (item.status === 'failed' && item.failureReason === 'auth_required') ||
-    isLocalOnlyFailureWithoutRecording(item)
+    isLocalFailureVisibleWithoutBackendRecord(item)
+}
+
+function isLocalFailureVisibleWithoutBackendRecord(item: RecordingHistoryItem): boolean {
+  return isLocalOnlyFailureWithoutRecording(item) ||
+    (item.status === 'failed' && !!item.backendRecordingId && item.failureReason !== 'auth_required')
 }
 
 function scheduleBackendRecordingsRefresh(force = false): Promise<void> | null {

--- a/src/debug.tsx
+++ b/src/debug.tsx
@@ -28,6 +28,7 @@ function App(): React.ReactElement {
   const [snapshot, setSnapshot] = useState<DebugSnapshot | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [maintenanceError, setMaintenanceError] = useState<string | null>(null)
 
   const snapshotJson = useMemo(
     () => snapshot ? JSON.stringify(snapshot, null, 2) : '',
@@ -37,8 +38,20 @@ function App(): React.ReactElement {
   const refresh = useCallback(async () => {
     setLoading(true)
     setError(null)
+    setMaintenanceError(null)
     try {
-      setSnapshot(await readDebugSnapshot())
+      const response = await chrome.runtime.sendMessage({ type: 'DEBUG_RUN_LOCAL_MAINTENANCE' }).catch((err) => ({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err)
+      }))
+      if (response?.ok === false) {
+        setMaintenanceError(response.error || 'Local maintenance could not be started.')
+      }
+      setSnapshot(await readDebugSnapshot(
+        response && typeof response === 'object'
+          ? response as Record<string, unknown>
+          : { ok: false, error: 'Local maintenance returned invalid response.' }
+      ))
     } catch (err) {
       console.error('[debug] snapshot error', err)
       captureException(err, { operation: 'readDebugSnapshot.debugPage' })
@@ -95,6 +108,9 @@ function App(): React.ReactElement {
 
         {error ? (
           <Alert message={error} showIcon type="error" />
+        ) : null}
+        {maintenanceError ? (
+          <Alert message={maintenanceError} showIcon type="warning" />
         ) : null}
 
         {snapshot ? (

--- a/src/debug.tsx
+++ b/src/debug.tsx
@@ -44,14 +44,15 @@ function App(): React.ReactElement {
         ok: false,
         error: err instanceof Error ? err.message : String(err)
       }))
-      if (response?.ok === false) {
-        setMaintenanceError(response.error || 'Local maintenance could not be started.')
+      const maintenanceResult = response && typeof response === 'object'
+        ? response as Record<string, unknown>
+        : { ok: false, error: 'Local maintenance returned invalid response.' }
+      if (maintenanceResult.ok !== true) {
+        setMaintenanceError(typeof maintenanceResult.error === 'string'
+          ? maintenanceResult.error
+          : 'Local maintenance could not be started.')
       }
-      setSnapshot(await readDebugSnapshot(
-        response && typeof response === 'object'
-          ? response as Record<string, unknown>
-          : { ok: false, error: 'Local maintenance returned invalid response.' }
-      ))
+      setSnapshot(await readDebugSnapshot(maintenanceResult))
     } catch (err) {
       console.error('[debug] snapshot error', err)
       captureException(err, { operation: 'readDebugSnapshot.debugPage' })

--- a/src/debugSnapshot.ts
+++ b/src/debugSnapshot.ts
@@ -58,6 +58,7 @@ export interface DebugSnapshot {
     pageUrl: string
     userAgent: string
   }
+  maintenance: Record<string, unknown> | null
   summary: {
     spoolRecordCount: number
     spoolBlockingCount: number
@@ -360,7 +361,9 @@ function countByStatus(items: Array<{ status?: unknown }>): Record<string, numbe
   return counts
 }
 
-export async function readDebugSnapshot(): Promise<DebugSnapshot> {
+export async function readDebugSnapshot(
+  maintenance: Record<string, unknown> | null = null
+): Promise<DebugSnapshot> {
   const [spool, storageLocal] = await Promise.all([
     readDebugSpool(),
     readChromeStorageLocal()
@@ -384,6 +387,7 @@ export async function readDebugSnapshot(): Promise<DebugSnapshot> {
       pageUrl: window.location.href,
       userAgent: navigator.userAgent
     },
+    maintenance,
     summary: {
       spoolRecordCount: spool.records.length,
       spoolBlockingCount: spool.records.filter(record => record.countsAgainstSpoolCapacity).length,

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -59,6 +59,7 @@ const DEBUG_MAINTENANCE_SYNC_WAIT_TIMEOUT_MS = 10_000
 const STOP_FINALIZE_TIMEOUT_MS = 10_000
 const MICROPHONE_STOP_TIMEOUT_MS = 2_000
 const MEDIA_RECORDER_TIMESLICE_MS = 5_000
+const CLOSED_SPOOL_LOCAL_IDS_LIMIT = 100
 const INTERRUPTED_RECORDING_MESSAGE = 'Recording was interrupted before it could be finalized.'
 const STORAGE_ALMOST_FULL_MESSAGE = 'Browser storage is almost full. Free space before starting another recording.'
 const ORPHANED_PENDING_UPLOAD_STATUSES: RecordingUploadStatus[] = [
@@ -599,6 +600,15 @@ let currentRecordingId = 0
 const abandonedRecordingIds = new Set<number>()
 const closedSpoolLocalIds = new Set<string>()
 
+function rememberClosedSpoolLocalId(localId: string): void {
+  closedSpoolLocalIds.add(localId)
+  while (closedSpoolLocalIds.size > CLOSED_SPOOL_LOCAL_IDS_LIMIT) {
+    const oldestLocalId = closedSpoolLocalIds.values().next().value
+    if (typeof oldestLocalId !== 'string') break
+    closedSpoolLocalIds.delete(oldestLocalId)
+  }
+}
+
 function buildOffscreenRuntimeStatus(): OffscreenRuntimeStatus {
   return {
     recording: capturing,
@@ -923,7 +933,7 @@ async function deleteLocalRecordingHistoryItem(localId: string): Promise<void> {
 }
 
 async function deleteLocalSpoolArtifacts(localId: string): Promise<void> {
-  closedSpoolLocalIds.add(localId)
+  rememberClosedSpoolLocalId(localId)
   await Promise.all([
     deleteSpoolChunks(localId),
     deleteSpoolRecording(localId)

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -913,8 +913,7 @@ async function queueRecordingStateSync(item: RecordingHistoryItem): Promise<Reco
 
 function shouldRemoveSyncedTerminalLocalHistoryItem(item: RecordingHistoryItem): boolean {
   if (!item.backendRecordingId) return false
-  if (item.status === 'canceled') return true
-  return item.status === 'failed' && item.failureReason !== 'auth_required'
+  return item.status === 'canceled'
 }
 
 async function deleteLocalRecordingHistoryItem(localId: string): Promise<void> {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -917,16 +917,16 @@ function shouldRemoveSyncedTerminalLocalHistoryItem(item: RecordingHistoryItem):
 }
 
 async function deleteLocalRecordingHistoryItem(localId: string): Promise<void> {
-  const response = await chrome.runtime.sendMessage({
+  const response: unknown = await chrome.runtime.sendMessage({
     type: 'DELETE_RECORDING_HISTORY_ITEM',
     localId
   }).catch((e) => ({ ok: false, error: e instanceof Error ? e.message : String(e) }))
 
-  if (response?.ok === false) {
+  if (!isRuntimeOkResponse(response)) {
     captureMessage('Recording history item could not be deleted after backend archival.', 'warning', {
       operation: 'deleteLocalRecordingHistoryItem',
       localId,
-      error: typeof response.error === 'string' ? response.error : null
+      error: runtimeResponseError(response, 'Invalid DELETE_RECORDING_HISTORY_ITEM response.')
     })
   }
 }
@@ -1454,11 +1454,30 @@ async function markInterruptedSpoolRecordings(): Promise<void> {
 }
 
 async function readLocalRecordingHistory(): Promise<RecordingHistoryItem[]> {
-  const response = await chrome.runtime.sendMessage({ type: 'READ_LOCAL_RECORDING_HISTORY' })
-  if (response?.ok === false) {
-    throw new Error(response.error || 'Could not read local recording history.')
+  const response: unknown = await chrome.runtime.sendMessage({ type: 'READ_LOCAL_RECORDING_HISTORY' })
+  if (!isRuntimeOkResponse(response)) {
+    throw new Error(runtimeResponseError(response, 'Invalid READ_LOCAL_RECORDING_HISTORY response.'))
   }
-  return normalizeRecordingHistory(response?.items)
+  const items = isObjectRecord(response) ? response.items : undefined
+  if (!Array.isArray(items)) {
+    throw new Error('READ_LOCAL_RECORDING_HISTORY response did not include an items array.')
+  }
+  return normalizeRecordingHistory(items)
+}
+
+function isRuntimeOkResponse(response: unknown): response is Record<string, unknown> & { ok: true } {
+  return isObjectRecord(response) && response.ok === true
+}
+
+function runtimeResponseError(response: unknown, fallback: string): string {
+  if (isObjectRecord(response) && typeof response.error === 'string' && response.error.length > 0) {
+    return response.error
+  }
+  return fallback
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
 }
 
 async function markOrphanedPendingHistoryItems(uploadableSpoolLocalIds: Set<string>): Promise<void> {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -2355,11 +2355,7 @@ async function handleOffscreenPortMessage(msg: any): Promise<void> {
     }
 
     if (msg?.type === 'OFFSCREEN_STATUS') {
-      const historyResponse = await chrome.runtime.sendMessage({ type: 'READ_RECORDING_HISTORY' }).catch(() => null)
-      return respond(msg, {
-        ...buildOffscreenRuntimeStatus(),
-        items: Array.isArray(historyResponse?.items) ? historyResponse.items : uploadQueue.map(toHistoryItem)
-      })
+      return respond(msg, buildOffscreenRuntimeStatus())
     }
 
     if (msg?.type === 'OFFSCREEN_REQUEUE_AUTH_REQUIRED_UPLOADS') {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -911,7 +911,7 @@ async function queueRecordingStateSync(item: RecordingHistoryItem): Promise<Reco
   return syncItem
 }
 
-function shouldRemoveSyncedTerminalLocalHistoryItem(item: RecordingHistoryItem): boolean {
+function shouldDeleteSyncedTerminalSpoolArtifacts(item: RecordingHistoryItem): boolean {
   if (!item.backendRecordingId) return false
   return item.status === 'canceled'
 }
@@ -974,14 +974,12 @@ async function markRecordingStateSynced(
     })
   }
 
-  if (shouldRemoveSyncedTerminalLocalHistoryItem(updatedItem)) {
+  if (shouldDeleteSyncedTerminalSpoolArtifacts(updatedItem)) {
     if (currentSpoolRecord?.localId === updatedItem.localId || uploadQueue.some(entry => entry.localId === updatedItem.localId)) {
       await persistHistoryItem(updatedItem, { syncState: false })
       return
     }
     await deleteLocalSpoolArtifacts(updatedItem.localId)
-    await deleteLocalRecordingHistoryItem(updatedItem.localId)
-    return
   }
 
   await persistHistoryItem(updatedItem, { syncState: false })

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -916,21 +916,6 @@ function shouldDeleteSyncedTerminalSpoolArtifacts(item: RecordingHistoryItem): b
   return item.status === 'canceled'
 }
 
-async function deleteLocalRecordingHistoryItem(localId: string): Promise<void> {
-  const response: unknown = await chrome.runtime.sendMessage({
-    type: 'DELETE_RECORDING_HISTORY_ITEM',
-    localId
-  }).catch((e) => ({ ok: false, error: e instanceof Error ? e.message : String(e) }))
-
-  if (!isRuntimeOkResponse(response)) {
-    captureMessage('Recording history item could not be deleted after backend archival.', 'warning', {
-      operation: 'deleteLocalRecordingHistoryItem',
-      localId,
-      error: runtimeResponseError(response, 'Invalid DELETE_RECORDING_HISTORY_ITEM response.')
-    })
-  }
-}
-
 async function deleteLocalSpoolArtifacts(localId: string): Promise<void> {
   rememberClosedSpoolLocalId(localId)
   await Promise.all([

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1308,7 +1308,6 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
         uploadProgressPercent: null
       })
       await deleteLocalSpoolArtifacts(entry.localId)
-      await deleteLocalRecordingHistoryItem(entry.localId)
       removeQueueEntry(entry.localId)
       log('Upload completed', { localId: entry.localId, recordingId: result.recordingId, assets: result.assets, attempt })
       return 'done'
@@ -1824,7 +1823,9 @@ async function restoreUploadQueueFromSpoolOnce(): Promise<void> {
   }
 }
 
-async function runLocalMaintenanceNow(): Promise<LocalMaintenanceResult> {
+async function runLocalMaintenanceNow(
+  options: { forceOrphanedChunkDiagnostics?: boolean } = {}
+): Promise<LocalMaintenanceResult> {
   if (capturing || currentSpoolRecord) {
     return {
       ranAt: new Date().toISOString(),
@@ -1860,7 +1861,9 @@ async function runLocalMaintenanceNow(): Promise<LocalMaintenanceResult> {
       ? historyAfterSync.get(item.localId)?.backendRecordingId ?? null
       : null
   }
-  const orphanedChunkDiagnostics = await reportAndDeleteOrphanedSpoolChunks({ force: true })
+  const orphanedChunkDiagnostics = await reportAndDeleteOrphanedSpoolChunks({
+    force: options.forceOrphanedChunkDiagnostics === true
+  })
 
   return {
     ranAt: new Date().toISOString(),
@@ -2386,7 +2389,9 @@ async function handleOffscreenPortMessage(msg: any): Promise<void> {
     }
 
     if (msg?.type === 'OFFSCREEN_RUN_LOCAL_MAINTENANCE') {
-      const result = await runLocalMaintenanceNow()
+      const result = await runLocalMaintenanceNow({
+        forceOrphanedChunkDiagnostics: msg.forceOrphanedChunkDiagnostics === true
+      })
       return respond(msg, { ok: true, result })
     }
 

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -2389,7 +2389,7 @@ async function handleOffscreenPortMessage(msg: any): Promise<void> {
       const result = await runLocalMaintenanceNow({
         forceOrphanedChunkDiagnostics: msg.forceOrphanedChunkDiagnostics === true
       })
-      return respond(msg, { ok: true, result })
+      return respond(msg, msg.includeDetails === true ? { ok: true, result } : { ok: true })
     }
 
     if (msg?.type === 'DIAG_ECHO') {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1040,21 +1040,6 @@ async function queueAllKnownRecordingStates(): Promise<RecordingStateMaintenance
       continue
     }
 
-    if (!resolvedRecordingId) {
-      summary.skipped += 1
-      summary.items.push({
-        localId: normalizedItem.localId,
-        status: normalizedItem.status,
-        backendRecordingIdBefore: normalizedItem.backendRecordingId,
-        backendRecordingIdAfter: normalizedItem.backendRecordingId,
-        resolvedRecordingId,
-        action: 'skipped',
-        reason: 'missing_backend_compatible_recording_id'
-      })
-      await queueRecordingStateSync(syncCandidate)
-      continue
-    }
-
     summary.queued += 1
     summary.items.push({
       localId: normalizedItem.localId,

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1051,7 +1051,7 @@ async function queueAllKnownRecordingStates(): Promise<RecordingStateMaintenance
         action: 'skipped',
         reason: 'missing_backend_compatible_recording_id'
       })
-      await queueRecordingStateSync(normalizedItem)
+      await queueRecordingStateSync(syncCandidate)
       continue
     }
 
@@ -1065,7 +1065,7 @@ async function queueAllKnownRecordingStates(): Promise<RecordingStateMaintenance
       action: 'queued',
       reason: null
     })
-    await queueRecordingStateSync(normalizedItem)
+    await queueRecordingStateSync(syncCandidate)
   }
 
   return summary
@@ -1619,7 +1619,7 @@ async function reportAndDeleteOrphanedSpoolChunks(
         stage: 'history',
         message: e instanceof Error ? e.message : String(e)
       }
-      captureException(e, { operation: 'reportAndDeleteOrphanedSpoolChunks.readRecordingHistory' })
+      captureException(e, { operation: 'reportAndDeleteOrphanedSpoolChunks.readLocalRecordingHistory' })
       return [] as RecordingHistoryItem[]
     })
     const historyByLocalId = new Map(historyItems.map(item => [item.localId, item]))

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -10,8 +10,8 @@ import { uploadRecordingOnce, type UploadRecordingInput, type UploadSessionState
 import { reportExtensionDiagnostic } from './extensionDiagnosticsClient'
 import {
   generateRecordingLocalId,
+  normalizeRecordingHistory,
   normalizeRecordingHistoryItem,
-  readRecordingHistory,
   type RecordingHistoryItem,
   type RecordingUploadStatus
 } from './recordingHistory'
@@ -24,7 +24,9 @@ import {
   appendSpoolChunk,
   assertSpoolAvailable,
   createSpoolRecording,
+  deleteSpoolChunks,
   deleteSpoolChunkKeys,
+  deleteSpoolRecording,
   getSpoolRecording,
   getSpoolChunkCounts,
   listInterruptedSpoolRecordings,
@@ -39,6 +41,8 @@ import {
   type RecordingSpoolRecord
 } from './recordingSpool'
 
+declare const __EXTENSION_VERSION__: string
+
 initDiagnostics('offscreen')
 
 // Włączone oznacza przygotowanie osobnego assetu mikrofonu do uploadu.
@@ -51,6 +55,7 @@ const UPLOAD_RETRY_INTERVAL_MS = 15_000
 const RECORDING_STATE_SYNC_RETRY_INTERVAL_MS = 30_000
 const ORPHANED_CHUNK_REPORT_GRACE_PERIOD_MS = 15 * 60 * 1000
 const ORPHANED_CHUNK_DIAGNOSTIC_INTERVAL_MS = 15 * 60 * 1000
+const DEBUG_MAINTENANCE_SYNC_WAIT_TIMEOUT_MS = 10_000
 const STOP_FINALIZE_TIMEOUT_MS = 10_000
 const MICROPHONE_STOP_TIMEOUT_MS = 2_000
 const MEDIA_RECORDER_TIMESLICE_MS = 5_000
@@ -168,6 +173,13 @@ function sleepUntilRecordingStateSyncWakeOrTimeout(ms: number): Promise<void> {
   })
 }
 
+async function waitForRecordingStateSyncIdle(timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while ((recordingStateSyncWorkerRunning || recordingStateSyncQueue.size > 0) && Date.now() < deadline) {
+    await sleep(100)
+  }
+}
+
 interface UploadQueueEntry extends RecordingHistoryItem {
   schemaVersion: number
   videoMimeType: string
@@ -187,6 +199,71 @@ let orphanedChunkDiagnosticsRunning = false
 let orphanedChunkDiagnosticsTimeoutId: number | null = null
 let lastOrphanedChunkDiagnosticsStartedAtMs = 0
 const recordingStateSyncQueue = new Map<string, RecordingHistoryItem>()
+let lastRecordingStateSyncError: Record<string, unknown> | null = null
+let lastOrphanedChunkDiagnosticsError: Record<string, unknown> | null = null
+
+interface OrphanedChunkDiagnosticsResult {
+  skipped: boolean
+  reason: string | null
+  groups: number
+  reported: number
+  deleted: number
+  errors: number
+  items: OrphanedChunkDiagnosticsItem[]
+}
+
+interface OrphanedChunkDiagnosticsItem {
+  localId: string
+  chunks: number
+  bytes: number
+  firstChunkCreatedAt: string | null
+  lastChunkCreatedAt: string | null
+  status:
+    | 'reported_deleted'
+    | 'reported_skipped_current_or_queued'
+    | 'reported_skipped_restored_spool_record'
+    | 'skipped_current_or_queued'
+    | 'skipped_restored_spool_record'
+    | 'error'
+  error?: string
+}
+
+interface RecordingStateMaintenanceItem {
+  localId: string
+  status: RecordingUploadStatus
+  backendRecordingIdBefore: string | null
+  backendRecordingIdAfter: string | null
+  resolvedRecordingId: string | null
+  action: 'queued' | 'skipped'
+  reason: string | null
+}
+
+interface RecordingStateMaintenanceResult {
+  candidates: number
+  queued: number
+  skipped: number
+  items: RecordingStateMaintenanceItem[]
+}
+
+interface OffscreenRuntimeStatus {
+  recording: boolean
+  recordingStartedAt: number | null
+  currentLocalId: string | null
+  currentStatus: RecordingUploadStatus | null
+  uploadWorkerRunning: boolean
+  queuedUploads: number
+}
+
+interface LocalMaintenanceResult {
+  ranAt: string
+  offscreenStatus: OffscreenRuntimeStatus
+  recordingStateQueueSize: number
+  recordingStateSyncRunning: boolean
+  recordingStateSync: RecordingStateMaintenanceResult
+  lastRecordingStateSyncError: Record<string, unknown> | null
+  orphanedChunkDiagnostics: OrphanedChunkDiagnosticsResult
+  lastOrphanedChunkDiagnosticsError: Record<string, unknown> | null
+}
 
 function generateBackendRecordingId(): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
@@ -520,6 +597,18 @@ let stopRequested = false
 let stopFinalizeTimeoutId: number | null = null
 let currentRecordingId = 0
 const abandonedRecordingIds = new Set<number>()
+const closedSpoolLocalIds = new Set<string>()
+
+function buildOffscreenRuntimeStatus(): OffscreenRuntimeStatus {
+  return {
+    recording: capturing,
+    recordingStartedAt: capturing ? currentRecordingStartedAtMs : null,
+    currentLocalId: currentSpoolRecord?.localId ?? null,
+    currentStatus: currentSpoolRecord?.status ?? null,
+    uploadWorkerRunning,
+    queuedUploads: uploadQueue.length
+  }
+}
 
 interface RecordingContext {
   tabUrl?: string | null
@@ -706,11 +795,13 @@ function enqueueCurrentSpoolWrite(operation: () => Promise<void>): void {
 function saveRecorderChunk(asset: 'video_audio' | 'microphone', blob: Blob, mimeType: string): void {
   const record = currentSpoolRecord
   if (!record || !blob.size) return
+  if (closedSpoolLocalIds.has(record.localId)) return
   const sequence = asset === 'video_audio'
     ? currentVideoChunkSequence++
     : currentMicrophoneChunkSequence++
 
   enqueueCurrentSpoolWrite(async () => {
+    if (closedSpoolLocalIds.has(record.localId)) return
     const sizeBytes = await appendSpoolChunk({
       localId: record.localId,
       asset,
@@ -724,7 +815,15 @@ function saveRecorderChunk(asset: 'video_audio' | 'microphone', blob: Blob, mime
 }
 
 function withBackendRecordingId(item: RecordingHistoryItem): RecordingHistoryItem {
-  if (resolveExtensionRecordingId(item)) return item
+  const recordingId = resolveExtensionRecordingId(item)
+  if (recordingId && item.backendRecordingId === recordingId) return item
+  if (recordingId) {
+    return {
+      ...item,
+      backendRecordingId: recordingId,
+      updatedAt: new Date().toISOString()
+    }
+  }
   return {
     ...item,
     backendRecordingId: generateBackendRecordingId(),
@@ -802,6 +901,37 @@ async function queueRecordingStateSync(item: RecordingHistoryItem): Promise<Reco
   return syncItem
 }
 
+function shouldRemoveSyncedTerminalLocalHistoryItem(item: RecordingHistoryItem): boolean {
+  if (!item.backendRecordingId) return false
+  if (item.status === 'canceled') return true
+  return item.status === 'failed' && item.failureReason !== 'auth_required'
+}
+
+async function deleteLocalRecordingHistoryItem(localId: string): Promise<void> {
+  const response = await chrome.runtime.sendMessage({
+    type: 'DELETE_RECORDING_HISTORY_ITEM',
+    localId
+  }).catch((e) => ({ ok: false, error: e instanceof Error ? e.message : String(e) }))
+
+  if (response?.ok === false) {
+    captureMessage('Recording history item could not be deleted after backend archival.', 'warning', {
+      operation: 'deleteLocalRecordingHistoryItem',
+      localId,
+      error: typeof response.error === 'string' ? response.error : null
+    })
+  }
+}
+
+async function deleteLocalSpoolArtifacts(localId: string): Promise<void> {
+  closedSpoolLocalIds.add(localId)
+  await Promise.all([
+    deleteSpoolChunks(localId),
+    deleteSpoolRecording(localId)
+  ]).catch((e) => {
+    captureException(e, { operation: 'deleteLocalSpoolArtifacts', localId })
+  })
+}
+
 async function markRecordingStateSynced(
   item: RecordingHistoryItem,
   recordingId: string
@@ -835,25 +965,101 @@ async function markRecordingStateSynced(
     })
   }
 
+  if (shouldRemoveSyncedTerminalLocalHistoryItem(updatedItem)) {
+    if (currentSpoolRecord?.localId === updatedItem.localId || uploadQueue.some(entry => entry.localId === updatedItem.localId)) {
+      await persistHistoryItem(updatedItem, { syncState: false })
+      return
+    }
+    await deleteLocalSpoolArtifacts(updatedItem.localId)
+    await deleteLocalRecordingHistoryItem(updatedItem.localId)
+    return
+  }
+
   await persistHistoryItem(updatedItem, { syncState: false })
 }
 
-async function queueAllKnownRecordingStates(): Promise<void> {
+async function queueAllKnownRecordingStates(): Promise<RecordingStateMaintenanceResult> {
   const [spoolRecords, historyItems] = await Promise.all([
     listSpoolRecordings().catch((e) => {
       captureException(e, { operation: 'queueAllKnownRecordingStates.listSpoolRecordings' })
       return [] as RecordingSpoolRecord[]
     }),
-    readRecordingHistory().catch((e) => {
-      captureException(e, { operation: 'queueAllKnownRecordingStates.readRecordingHistory' })
+    readLocalRecordingHistory().catch((e) => {
+      captureException(e, { operation: 'queueAllKnownRecordingStates.readLocalRecordingHistory' })
       return [] as RecordingHistoryItem[]
     })
   ])
 
   const byLocalId = new Map<string, RecordingHistoryItem>()
+  const spoolByLocalId = new Map<string, RecordingSpoolRecord>()
   for (const item of historyItems) byLocalId.set(item.localId, item)
-  for (const record of spoolRecords) byLocalId.set(record.localId, record)
-  for (const item of byLocalId.values()) await queueRecordingStateSync(item)
+  for (const record of spoolRecords) {
+    spoolByLocalId.set(record.localId, record)
+    byLocalId.set(record.localId, record)
+  }
+
+  const summary: RecordingStateMaintenanceResult = {
+    candidates: 0,
+    queued: 0,
+    skipped: 0,
+    items: []
+  }
+
+  for (const item of byLocalId.values()) {
+    const normalizedItem = normalizeRecordingHistoryItem(item)
+    if (!normalizedItem) continue
+    const mutable = isExtensionMutableRecordingStatus(normalizedItem.status)
+    const syncCandidate = mutable ? withBackendRecordingId(normalizedItem) : normalizedItem
+    const resolvedRecordingId = mutable ? resolveExtensionRecordingId(syncCandidate) : null
+    summary.candidates += 1
+
+    if (!mutable) {
+      const localSpoolRecord = spoolByLocalId.get(normalizedItem.localId)
+      if (localSpoolRecord?.backendRecordingId && !isCurrentOrQueuedLocalId(normalizedItem.localId)) {
+        await deleteLocalSpoolArtifacts(normalizedItem.localId)
+      }
+      summary.skipped += 1
+      summary.items.push({
+        localId: normalizedItem.localId,
+        status: normalizedItem.status,
+        backendRecordingIdBefore: normalizedItem.backendRecordingId,
+        backendRecordingIdAfter: normalizedItem.backendRecordingId,
+        resolvedRecordingId,
+        action: 'skipped',
+        reason: 'backend_owned_status'
+      })
+      continue
+    }
+
+    if (!resolvedRecordingId) {
+      summary.skipped += 1
+      summary.items.push({
+        localId: normalizedItem.localId,
+        status: normalizedItem.status,
+        backendRecordingIdBefore: normalizedItem.backendRecordingId,
+        backendRecordingIdAfter: normalizedItem.backendRecordingId,
+        resolvedRecordingId,
+        action: 'skipped',
+        reason: 'missing_backend_compatible_recording_id'
+      })
+      await queueRecordingStateSync(normalizedItem)
+      continue
+    }
+
+    summary.queued += 1
+    summary.items.push({
+      localId: normalizedItem.localId,
+      status: normalizedItem.status,
+      backendRecordingIdBefore: normalizedItem.backendRecordingId,
+      backendRecordingIdAfter: null,
+      resolvedRecordingId,
+      action: 'queued',
+      reason: null
+    })
+    await queueRecordingStateSync(normalizedItem)
+  }
+
+  return summary
 }
 
 async function runRecordingStateSyncWorker(): Promise<void> {
@@ -867,11 +1073,21 @@ async function runRecordingStateSyncWorker(): Promise<void> {
         extensionToken = await requestMeet2NoteExtensionToken()
       } catch (e) {
         if (isMeet2NoteAuthError(e)) {
+          lastRecordingStateSyncError = {
+            at: new Date().toISOString(),
+            stage: 'auth',
+            message: e.message
+          }
           await chrome.runtime.sendMessage({
             type: 'MARK_MEET2NOTE_RECONNECT_REQUIRED',
             message: e.message
           }).catch(() => {})
         } else {
+          lastRecordingStateSyncError = {
+            at: new Date().toISOString(),
+            stage: 'auth',
+            message: e instanceof Error ? e.message : String(e)
+          }
           captureException(e, { operation: 'runRecordingStateSyncWorker.auth' })
         }
         return
@@ -883,10 +1099,18 @@ async function runRecordingStateSyncWorker(): Promise<void> {
           const result = await syncExtensionRecordingState(item, extensionToken)
           if (recordingStateSyncQueue.get(recordingId) === item) {
             recordingStateSyncQueue.delete(recordingId)
+            lastRecordingStateSyncError = null
             await markRecordingStateSynced(item, result.recordingId)
           }
         } catch (e) {
           if (isMeet2NoteAuthError(e)) {
+            lastRecordingStateSyncError = {
+              at: new Date().toISOString(),
+              stage: 'sync_auth',
+              localId: item.localId,
+              status: item.status,
+              message: e.message
+            }
             await chrome.runtime.sendMessage({
               type: 'MARK_MEET2NOTE_RECONNECT_REQUIRED',
               message: e.message
@@ -895,6 +1119,12 @@ async function runRecordingStateSyncWorker(): Promise<void> {
           }
 
           hadRetryableFailure = true
+          lastRecordingStateSyncError = {
+            at: new Date().toISOString(),
+            localId: item.localId,
+            status: item.status,
+            message: e instanceof Error ? e.message : String(e)
+          }
           captureException(e, {
             operation: 'runRecordingStateSyncWorker.sync',
             localId: item.localId,
@@ -1067,7 +1297,8 @@ async function uploadQueueEntryUntilTerminal(entry: UploadQueueEntry): Promise<'
         error: null,
         uploadProgressPercent: null
       })
-      retainTerminalSpoolEntry(entry.localId, 'uploadQueueEntryUntilTerminal.retainUploaded')
+      await deleteLocalSpoolArtifacts(entry.localId)
+      await deleteLocalRecordingHistoryItem(entry.localId)
       removeQueueEntry(entry.localId)
       log('Upload completed', { localId: entry.localId, recordingId: result.recordingId, assets: result.assets, attempt })
       return 'done'
@@ -1215,7 +1446,8 @@ async function assertSpoolCapacityBeforeRecording(): Promise<void> {
 }
 
 async function markInterruptedSpoolRecordings(): Promise<void> {
-  const interrupted = await listInterruptedSpoolRecordings()
+  const interrupted = (await listInterruptedSpoolRecordings())
+    .filter(record => !isCurrentOrQueuedLocalId(record.localId))
   for (const record of interrupted) {
     const counts = await getSpoolChunkCounts(record.localId).catch(() => ({ video_audio: 0, microphone: 0 }))
     const message = counts.video_audio > 0
@@ -1229,7 +1461,11 @@ async function markInterruptedSpoolRecordings(): Promise<void> {
 }
 
 async function readLocalRecordingHistory(): Promise<RecordingHistoryItem[]> {
-  return readRecordingHistory()
+  const response = await chrome.runtime.sendMessage({ type: 'READ_LOCAL_RECORDING_HISTORY' })
+  if (response?.ok === false) {
+    throw new Error(response.error || 'Could not read local recording history.')
+  }
+  return normalizeRecordingHistory(response?.items)
 }
 
 async function markOrphanedPendingHistoryItems(uploadableSpoolLocalIds: Set<string>): Promise<void> {
@@ -1296,7 +1532,9 @@ function buildOrphanedChunkDiagnosticEvent(
       assets: group.assets,
       extension: {
         id: chrome.runtime.id,
-        version: chrome.runtime.getManifest().version
+        version: typeof __EXTENSION_VERSION__ === 'string' && __EXTENSION_VERSION__.trim()
+          ? __EXTENSION_VERSION__
+          : 'unknown'
       },
       historyItem: historyContextForDiagnostic(historyItem)
     }
@@ -1307,26 +1545,54 @@ function isCurrentOrQueuedLocalId(localId: string): boolean {
   return currentSpoolRecord?.localId === localId || uploadQueue.some(entry => entry.localId === localId)
 }
 
-async function reportAndDeleteOrphanedSpoolChunks(): Promise<void> {
-  if (orphanedChunkDiagnosticsRunning) return
+async function reportAndDeleteOrphanedSpoolChunks(
+  options: { force?: boolean } = {}
+): Promise<OrphanedChunkDiagnosticsResult> {
+  const result: OrphanedChunkDiagnosticsResult = {
+    skipped: false,
+    reason: null,
+    groups: 0,
+    reported: 0,
+    deleted: 0,
+    errors: 0,
+    items: []
+  }
+  if (orphanedChunkDiagnosticsRunning) {
+    return { ...result, skipped: true, reason: 'already_running' }
+  }
   const nowMs = Date.now()
-  if (nowMs - lastOrphanedChunkDiagnosticsStartedAtMs < ORPHANED_CHUNK_DIAGNOSTIC_INTERVAL_MS) return
+  if (!options.force && nowMs - lastOrphanedChunkDiagnosticsStartedAtMs < ORPHANED_CHUNK_DIAGNOSTIC_INTERVAL_MS) {
+    return { ...result, skipped: true, reason: 'throttled' }
+  }
   lastOrphanedChunkDiagnosticsStartedAtMs = nowMs
   orphanedChunkDiagnosticsRunning = true
 
   try {
     const groups = await listOrphanedSpoolChunkGroups({
-      gracePeriodMs: ORPHANED_CHUNK_REPORT_GRACE_PERIOD_MS
+      gracePeriodMs: options.force ? 0 : ORPHANED_CHUNK_REPORT_GRACE_PERIOD_MS
     }).catch((e) => {
+      result.errors += 1
+      lastOrphanedChunkDiagnosticsError = {
+        at: new Date().toISOString(),
+        stage: 'list',
+        message: e instanceof Error ? e.message : String(e)
+      }
       captureException(e, { operation: 'reportAndDeleteOrphanedSpoolChunks.listOrphanedSpoolChunkGroups' })
       return [] as OrphanedSpoolChunkGroup[]
     })
-    if (!groups.length) return
+    result.groups = groups.length
+    if (!groups.length) return result
 
     let extensionToken: string
     try {
       extensionToken = await requestMeet2NoteExtensionToken()
     } catch (e) {
+      result.errors += 1
+      lastOrphanedChunkDiagnosticsError = {
+        at: new Date().toISOString(),
+        stage: 'auth',
+        message: e instanceof Error ? e.message : String(e)
+      }
       if (isMeet2NoteAuthError(e)) {
         await chrome.runtime.sendMessage({
           type: 'MARK_MEET2NOTE_RECONNECT_REQUIRED',
@@ -1335,17 +1601,33 @@ async function reportAndDeleteOrphanedSpoolChunks(): Promise<void> {
       } else {
         captureException(e, { operation: 'reportAndDeleteOrphanedSpoolChunks.auth' })
       }
-      return
+      return result
     }
 
     const historyItems = await readLocalRecordingHistory().catch((e) => {
+      result.errors += 1
+      lastOrphanedChunkDiagnosticsError = {
+        at: new Date().toISOString(),
+        stage: 'history',
+        message: e instanceof Error ? e.message : String(e)
+      }
       captureException(e, { operation: 'reportAndDeleteOrphanedSpoolChunks.readRecordingHistory' })
       return [] as RecordingHistoryItem[]
     })
     const historyByLocalId = new Map(historyItems.map(item => [item.localId, item]))
 
     for (const group of groups) {
-      if (isCurrentOrQueuedLocalId(group.localId)) continue
+      if (isCurrentOrQueuedLocalId(group.localId)) {
+        result.items.push({
+          localId: group.localId,
+          chunks: group.chunks,
+          bytes: group.bytes,
+          firstChunkCreatedAt: group.firstChunkCreatedAt,
+          lastChunkCreatedAt: group.lastChunkCreatedAt,
+          status: 'skipped_current_or_queued'
+        })
+        continue
+      }
       const currentRecord = await getSpoolRecording(group.localId).catch((e) => {
         captureException(e, {
           operation: 'reportAndDeleteOrphanedSpoolChunks.getSpoolRecording',
@@ -1353,15 +1635,36 @@ async function reportAndDeleteOrphanedSpoolChunks(): Promise<void> {
         })
         return null
       })
-      if (currentRecord) continue
+      if (currentRecord) {
+        result.items.push({
+          localId: group.localId,
+          chunks: group.chunks,
+          bytes: group.bytes,
+          firstChunkCreatedAt: group.firstChunkCreatedAt,
+          lastChunkCreatedAt: group.lastChunkCreatedAt,
+          status: 'skipped_restored_spool_record'
+        })
+        continue
+      }
 
       try {
         await reportExtensionDiagnostic(
           buildOrphanedChunkDiagnosticEvent(group, historyByLocalId.get(group.localId)),
           extensionToken
         )
+        result.reported += 1
 
-        if (isCurrentOrQueuedLocalId(group.localId)) continue
+        if (isCurrentOrQueuedLocalId(group.localId)) {
+          result.items.push({
+            localId: group.localId,
+            chunks: group.chunks,
+            bytes: group.bytes,
+            firstChunkCreatedAt: group.firstChunkCreatedAt,
+            lastChunkCreatedAt: group.lastChunkCreatedAt,
+            status: 'reported_skipped_current_or_queued'
+          })
+          continue
+        }
         const recordAfterReport = await getSpoolRecording(group.localId).catch((e) => {
           captureException(e, {
             operation: 'reportAndDeleteOrphanedSpoolChunks.getSpoolRecordingAfterReport',
@@ -1369,9 +1672,29 @@ async function reportAndDeleteOrphanedSpoolChunks(): Promise<void> {
           })
           return null
         })
-        if (recordAfterReport) continue
+        if (recordAfterReport) {
+          result.items.push({
+            localId: group.localId,
+            chunks: group.chunks,
+            bytes: group.bytes,
+            firstChunkCreatedAt: group.firstChunkCreatedAt,
+            lastChunkCreatedAt: group.lastChunkCreatedAt,
+            status: 'reported_skipped_restored_spool_record'
+          })
+          continue
+        }
 
         await deleteSpoolChunkKeys(group.chunkKeys)
+        result.deleted += 1
+        lastOrphanedChunkDiagnosticsError = null
+        result.items.push({
+          localId: group.localId,
+          chunks: group.chunks,
+          bytes: group.bytes,
+          firstChunkCreatedAt: group.firstChunkCreatedAt,
+          lastChunkCreatedAt: group.lastChunkCreatedAt,
+          status: 'reported_deleted'
+        })
         captureMessage('Deleted orphaned local spool chunks after backend diagnostic acknowledgement.', 'info', {
           operation: 'reportAndDeleteOrphanedSpoolChunks',
           localId: group.localId,
@@ -1381,12 +1704,28 @@ async function reportAndDeleteOrphanedSpoolChunks(): Promise<void> {
           lastChunkCreatedAt: group.lastChunkCreatedAt
         })
       } catch (e) {
+        result.errors += 1
+        lastOrphanedChunkDiagnosticsError = {
+          at: new Date().toISOString(),
+          stage: 'report_or_delete',
+          localId: group.localId,
+          message: e instanceof Error ? e.message : String(e)
+        }
+        result.items.push({
+          localId: group.localId,
+          chunks: group.chunks,
+          bytes: group.bytes,
+          firstChunkCreatedAt: group.firstChunkCreatedAt,
+          lastChunkCreatedAt: group.lastChunkCreatedAt,
+          status: 'error',
+          error: e instanceof Error ? e.message : String(e)
+        })
         if (isMeet2NoteAuthError(e)) {
           await chrome.runtime.sendMessage({
             type: 'MARK_MEET2NOTE_RECONNECT_REQUIRED',
             message: e.message
           }).catch(() => {})
-          return
+          return result
         }
         captureException(e, {
           operation: 'reportAndDeleteOrphanedSpoolChunks.reportOrDelete',
@@ -1396,6 +1735,7 @@ async function reportAndDeleteOrphanedSpoolChunks(): Promise<void> {
         })
       }
     }
+    return result
   } finally {
     orphanedChunkDiagnosticsRunning = false
   }
@@ -1471,6 +1811,56 @@ async function restoreUploadQueueFromSpoolOnce(): Promise<void> {
       log('Unexpected restored upload queue worker failure', e)
       captureException(e, { operation: 'restoreUploadQueueFromSpool.runUploadQueueWorker' })
     })
+  }
+}
+
+async function runLocalMaintenanceNow(): Promise<LocalMaintenanceResult> {
+  if (capturing || currentSpoolRecord) {
+    return {
+      ranAt: new Date().toISOString(),
+      offscreenStatus: buildOffscreenRuntimeStatus(),
+      recordingStateQueueSize: recordingStateSyncQueue.size,
+      recordingStateSyncRunning: recordingStateSyncWorkerRunning,
+      recordingStateSync: {
+        candidates: 0,
+        queued: 0,
+        skipped: 0,
+        items: []
+      },
+      lastRecordingStateSyncError,
+      orphanedChunkDiagnostics: {
+        skipped: true,
+        reason: 'active_recording',
+        groups: 0,
+        reported: 0,
+        deleted: 0,
+        errors: 0,
+        items: []
+      },
+      lastOrphanedChunkDiagnosticsError
+    }
+  }
+
+  await markInterruptedSpoolRecordings()
+  const recordingStateSync = await queueAllKnownRecordingStates()
+  await waitForRecordingStateSyncIdle(DEBUG_MAINTENANCE_SYNC_WAIT_TIMEOUT_MS)
+  const historyAfterSync = new Map((await readLocalRecordingHistory()).map(item => [item.localId, item]))
+  for (const item of recordingStateSync.items) {
+    item.backendRecordingIdAfter = historyAfterSync.has(item.localId)
+      ? historyAfterSync.get(item.localId)?.backendRecordingId ?? null
+      : null
+  }
+  const orphanedChunkDiagnostics = await reportAndDeleteOrphanedSpoolChunks({ force: true })
+
+  return {
+    ranAt: new Date().toISOString(),
+    offscreenStatus: buildOffscreenRuntimeStatus(),
+    recordingStateQueueSize: recordingStateSyncQueue.size,
+    recordingStateSyncRunning: recordingStateSyncWorkerRunning,
+    recordingStateSync,
+    lastRecordingStateSyncError,
+    orphanedChunkDiagnostics,
+    lastOrphanedChunkDiagnosticsError
   }
 }
 
@@ -1695,6 +2085,7 @@ async function prepareAndRecord(
   const mime = chooseVideoMime()
   const microphoneMime = chooseMicrophoneMime()
   const localId = generateRecordingLocalId()
+  closedSpoolLocalIds.delete(localId)
   currentVideoChunkSequence = 0
   currentMicrophoneChunkSequence = 0
   currentVideoBytes = 0
@@ -1967,16 +2358,9 @@ async function handleOffscreenPortMessage(msg: any): Promise<void> {
     }
 
     if (msg?.type === 'OFFSCREEN_STATUS') {
-      let recording = false
-      try {
-        const res = await (chrome.storage as any)?.session?.get?.(['recording'])
-        recording = !!res?.recording
-      } catch {}
       const historyResponse = await chrome.runtime.sendMessage({ type: 'READ_RECORDING_HISTORY' }).catch(() => null)
       return respond(msg, {
-        recording,
-        uploadWorkerRunning,
-        queuedUploads: uploadQueue.length,
+        ...buildOffscreenRuntimeStatus(),
         items: Array.isArray(historyResponse?.items) ? historyResponse.items : uploadQueue.map(toHistoryItem)
       })
     }
@@ -1989,6 +2373,11 @@ async function handleOffscreenPortMessage(msg: any): Promise<void> {
     if (msg?.type === 'OFFSCREEN_RESTORE_UPLOAD_QUEUE') {
       await restoreUploadQueueFromSpool()
       return respond(msg, { ok: true })
+    }
+
+    if (msg?.type === 'OFFSCREEN_RUN_LOCAL_MAINTENANCE') {
+      const result = await runLocalMaintenanceNow()
+      return respond(msg, { ok: true, result })
     }
 
     if (msg?.type === 'DIAG_ECHO') {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -45,7 +45,7 @@ interface RecordingStatus {
 
 const { Text } = Typography
 const START_RECORDING_POPUP_DELAY_MS = 3_000
-const BACKEND_STATUS_REFRESH_INTERVAL_MS = 5_000
+const BACKEND_STATUS_REFRESH_INTERVAL_MS = 15_000
 const MEET2NOTE_BRAND_ICON_URL = chrome.runtime.getURL('icons/meet2note-favicon.svg')
 const POPUP_WIDTH = 252
 const HEADER_ACTION_ICON_STYLE: React.CSSProperties = {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -45,6 +45,7 @@ interface RecordingStatus {
 
 const { Text } = Typography
 const START_RECORDING_POPUP_DELAY_MS = 3_000
+const BACKEND_STATUS_REFRESH_INTERVAL_MS = 5_000
 const MEET2NOTE_BRAND_ICON_URL = chrome.runtime.getURL('icons/meet2note-favicon.svg')
 const POPUP_WIDTH = 252
 const HEADER_ACTION_ICON_STYLE: React.CSSProperties = {
@@ -169,6 +170,13 @@ function getHistoryTagText(item: RecordingHistoryItem): string {
   return item.status
 }
 
+function hasBackendProcessingStatus(items: RecordingHistoryItem[]): boolean {
+  return items.some(item =>
+    item.backendRecordingId &&
+    (item.status === 'processing_queued' || item.status === 'processing')
+  )
+}
+
 function readPopupUiCache(): PopupUiCache {
   try {
     const raw = window.localStorage.getItem(POPUP_UI_CACHE_KEY)
@@ -280,6 +288,22 @@ function App(): React.ReactElement {
     setMeet2NoteConnection(connection)
   }, [])
 
+  const refreshRecordingStatus = useCallback(async (forceBackendRefresh = false) => {
+    const status = await chrome.runtime.sendMessage({
+      type: 'GET_RECORDING_STATUS',
+      forceBackendRefresh
+    })
+    const startedAt = status?.recordingStartedAt ?? status?.startRequestedAt ?? null
+    setRecordingState({
+      recording: !!status?.recording,
+      starting: !!status?.starting,
+      stopping: !!status?.stopping,
+      recordingStartedAt: typeof startedAt === 'number' ? startedAt : null,
+      error: typeof status?.error === 'string' ? status.error : null
+    })
+    setRecentRecordings(sanitizeRecordingHistory(status?.recentRecordings))
+  }, [])
+
   useEffect(() => {
     writePopupUiCache({
       connection: meet2NoteConnection,
@@ -290,16 +314,7 @@ function App(): React.ReactElement {
   useEffect(() => {
     void (async () => {
       try {
-        const status = await chrome.runtime.sendMessage({ type: 'GET_RECORDING_STATUS' })
-        const startedAt = status?.recordingStartedAt ?? status?.startRequestedAt ?? null
-        setRecordingState({
-          recording: !!status?.recording,
-          starting: !!status?.starting,
-          stopping: !!status?.stopping,
-          recordingStartedAt: typeof startedAt === 'number' ? startedAt : null,
-          error: typeof status?.error === 'string' ? status.error : null
-        })
-        setRecentRecordings(sanitizeRecordingHistory(status?.recentRecordings))
+        await refreshRecordingStatus()
       } catch {
         setRecordingState({
           recording: false,
@@ -314,7 +329,19 @@ function App(): React.ReactElement {
         refreshMeet2NoteConnection().catch(() => {})
       ])
     })()
-  }, [refreshMic, refreshMeet2NoteConnection])
+  }, [refreshMic, refreshMeet2NoteConnection, refreshRecordingStatus])
+
+  useEffect(() => {
+    if (!hasBackendProcessingStatus(recentRecordings)) return undefined
+
+    const timerId = window.setInterval(() => {
+      refreshRecordingStatus(true).catch((error) => {
+        captureException(error, { operation: 'refreshRecordingStatus.backendProcessingPoll' })
+      })
+    }, BACKEND_STATUS_REFRESH_INTERVAL_MS)
+
+    return () => window.clearInterval(timerId)
+  }, [recentRecordings, refreshRecordingStatus])
 
   useEffect(() => {
     if (!('permissions' in navigator)) return undefined

--- a/src/recordingHistory.ts
+++ b/src/recordingHistory.ts
@@ -253,6 +253,7 @@ export async function updateRecordingHistory(
   return enqueueRecordingHistoryWrite(async () => {
     const history = await readRecordingHistory()
     const next = await updater(history)
+    if (next === history) return history
     return writeRecordingHistoryInternal(next)
   })
 }

--- a/src/recordingsClient.ts
+++ b/src/recordingsClient.ts
@@ -13,6 +13,9 @@ export interface BackendRecordingListItem {
   status: BackendRecordingStatus
   durationMs: number | null
   startedAt: string | null
+  failureStage: string | null
+  failureReason: string | null
+  failureMessage: string | null
   createdAt: string
   updatedAt: string
   displayTimeline?: string
@@ -40,6 +43,15 @@ function parseBackendRecording(value: unknown): BackendRecordingListItem | null 
   const createdAt = typeof record.createdAt === 'string' ? record.createdAt.trim() : ''
   const updatedAtRaw = typeof record.updatedAt === 'string' ? record.updatedAt.trim() : ''
   const updatedAt = updatedAtRaw || createdAt
+  const failureStage = typeof record.failureStage === 'string' && record.failureStage.trim()
+    ? record.failureStage.trim()
+    : null
+  const failureReason = typeof record.failureReason === 'string' && record.failureReason.trim()
+    ? record.failureReason.trim()
+    : null
+  const failureMessage = typeof record.failureMessage === 'string' && record.failureMessage.trim()
+    ? record.failureMessage.trim()
+    : null
   const displayTimeline = typeof record.displayTimeline === 'string' ? record.displayTimeline.trim() : ''
 
   if (!id || !status || !createdAt) return null
@@ -52,6 +64,9 @@ function parseBackendRecording(value: unknown): BackendRecordingListItem | null 
       ? record.durationMs
       : null,
     startedAt: startedAtRaw || null,
+    failureStage,
+    failureReason,
+    failureMessage,
     createdAt,
     updatedAt,
     ...(displayTimeline ? { displayTimeline } : {})


### PR DESCRIPTION
## Scope
- make offscreen capture state the source of truth for popup recording status
- prevent debug/local maintenance from mutating active recordings
- clean local spool/history after backend-owned recordings are synced
- refresh open popup backend statuses until processing recordings become terminal
- bump extension version to 1.9.44

## Verification
- npm run typecheck
- make check
- npm run smoke
- confirmed dist/manifest.json reports 1.9.44

## Risks
- Local maintenance behavior changed around active recordings and backend-owned local cache cleanup.
- No Chrome permission changes.